### PR TITLE
include original props on when rendering decorated component

### DIFF
--- a/src/reduxForm.js
+++ b/src/reduxForm.js
@@ -24,6 +24,7 @@ export default function reduxForm(sliceName, validate) {
       const {slice, dispatch} = this.props;
       const handleChange = (name) => (event) => dispatch(change(sliceName, name, event.target.value));
       return (<DecoratedComponent
+        {...this.props}
         handleChange={handleChange}
         showAll={() => dispatch(showAll(sliceName))}
         reset={() => dispatch(reset(sliceName))}


### PR DESCRIPTION
I'm not sure if the removal of the original props was an intentional design decision, but in case it wasn't: This small change "fixed" #6 for me so that I can now access actions passed as props from a container component.