### PR TITLE
No need for a 2nd destructuring and `delete`

### DIFF
--- a/src/reduxForm.js
+++ b/src/reduxForm.js
@@ -21,10 +21,7 @@ export default function reduxForm(sliceName, validate) {
     }
 
     render() {
-      const {slice, dispatch} = this.props;
-      const passableProps = { ...this.props };
-      delete passableProps.slice;
-      delete passableProps.dispatch;
+      const {slice, dispatch ...passableProps} = this.props;
       const handleChange = (name) => (event) => dispatch(change(sliceName, name, event.target.value));
       return (<DecoratedComponent
         handleChange={handleChange}


### PR DESCRIPTION
Since we're already using destructuring here, we can skip the 2nd destructuring step and the `delete` (in order to avoid possible deoptimization of the function)