### PR TITLE
Properly detect async validation result

### DIFF
--- a/src/reduxForm.js
+++ b/src/reduxForm.js
@@ -24,7 +24,8 @@ export default function reduxForm(sliceName, ...args) {
   function runValidation(form) {
     const syncErrors = validate(form.data);
     const asyncErrors = {...form.asyncErrors};
-    const valid = !!(syncErrors.valid && asyncErrors.valid);  // !! to convert falsy to boolean
+    const { valid: asyncValid } = asyncErrors;
+    const valid = !!(syncErrors.valid && (asyncValid !== void 0 || asyncValid));  // !! to convert falsy to boolean
     return {
       ...syncErrors,
       ...asyncErrors,


### PR DESCRIPTION
In case we don't have an async validation function `asyncErrors.valid` will be `undefined`, and `valid` will never be `true`. This fixes that by checking if we actually have a value for `asyncErrors.valid`.