### PR TITLE
Add field name to field object

### DIFF
--- a/src/reduxForm.js
+++ b/src/reduxForm.js
@@ -170,6 +170,7 @@ function createReduxFormDecorator(formName, fields, syncValidate, touchOnBlur, t
               handleBlur: handleBlur(name),
               handleChange: handleChange(name),
               invalid: !!error,
+              name: name,
               onBlur: handleBlur(name),
               onChange: handleChange(name),
               pristine: pristine,


### PR DESCRIPTION
This adds the name of the field to the field object.

I thought it might be good to have the name of the field at hand as well. Especially for custom and more complex input fields that need to implement their own change/blur handlers. Otherwise you would need to pass the field name from the redux form decorated component all the way down to ther pertaining component.

Feel free to close if you think this is not necessary of you want to add it yourself.