### PR TITLE
null handling in isPristine

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -7,7 +7,7 @@ export function isPristine(initial, data) {
     return true;
   }
   if (typeof initial === 'object') {
-    if (typeof data !== 'object') {
+    if (!data || typeof data !== 'object') {
       return false;
     }
     const dataKeys = Object.keys(data);


### PR DESCRIPTION
`isPristine` is throwing when value is changing from `null` to object. This is a fix.