### PR TITLE
Allow for a field's errors to be an array.

### DIFF
--- a/src/isValid.js
+++ b/src/isValid.js
@@ -1,3 +1,6 @@
 export default function isValid(error) {
-
+  if ( !Array.isArray(error) ) {
+    return !error;
+  }
+  return error.reduce(( valid, errorValue ) => valid && !errorValue, true);
 }

--- a/src/isValid.js
+++ b/src/isValid.js
@@ -1,0 +1,3 @@
+export default function isValid(error) {
+
+}

--- a/src/reduxForm.js
+++ b/src/reduxForm.js
@@ -43,7 +43,7 @@ function silenceEvents(fn) {
   };
 }
 
-function isValid(errors) {
+function isAsyncValid(errors) {
   if (!errors) {
     return true;
   }
@@ -124,7 +124,7 @@ export default function reduxForm(config) {
           }
           return promise.then(asyncErrors => {
             dispatch(stopAsyncValidation(asyncErrors));
-            return isValid(asyncErrors);
+            return isAsyncValid(asyncErrors);
           }, (err) => {
             dispatch(stopAsyncValidation({}));
             throw new Error('redux-form: Asynchronous validation failed: ' + err);

--- a/src/reduxForm.js
+++ b/src/reduxForm.js
@@ -2,6 +2,7 @@ import React, {Component, PropTypes} from 'react';
 import * as formActions from './actions';
 import getDisplayName from './getDisplayName';
 import isPristine from './isPristine';
+import isValid from './isValid';
 import bindActionData from './bindActionData';
 import {initialState} from './reducer';
 
@@ -196,7 +197,8 @@ export default function reduxForm(config) {
           const field = subForm[name] || {};
           const pristine = isPristine(field.value, field.initial);
           const error = syncErrors[name] || field.asyncError;
-          if (error) {
+          const valid = isValid(error);
+          if (!valid) {
             allValid = false;
           }
           if (!pristine) {
@@ -210,13 +212,13 @@ export default function reduxForm(config) {
               error,
               handleBlur: handleBlur(name),
               handleChange: handleChange(name),
-              invalid: !!error,
+              invalid: !valid,
               name,
               onBlur: handleBlur(name),
               onChange: handleChange(name),
               pristine,
               touched: field.touched,
-              valid: !error,
+              valid: valid,
               value: field.value
             }
           };

--- a/test/isValid.spec.js
+++ b/test/isValid.spec.js
@@ -1,0 +1,29 @@
+import expect from 'expect';
+import isValid from '../src/isValid';
+
+describe('isValid', () => {
+
+  it('should return true if the value is falsey', () => {
+    const a = undefined;
+    const b = false;
+    expect(isValid(a)).toBe(true);
+    expect(isValid(b)).toBe(true);
+  });
+
+  it('should return true if the value is an array of falsey values', () => {
+    const a = undefined;
+    const b = false;
+    expect(isValid([a, b])).toBe(true);
+  });
+
+  it('should return true if the value is an empty array', () => {
+    expect(isValid([])).toBe(true);
+  });
+
+  it('should return false if the value is an array with one truthy value', () => {
+    const a = undefined;
+    const b = 'Error';
+    expect(isValid([a, b, a])).toBe(false);
+  });
+
+});


### PR DESCRIPTION
As discussed on Slack, when a field's error property was an array of falsey values the form was deemed invalid.