### PR TITLE
FIX the implementation guide, tell the user he *have to* use the key 'form' in his state

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ import { createStore, combineReducers } from 'redux';
 import { reducer as formReducer } from 'redux-form';
 const reducers = {
   // ... your other reducers here ...
-  form: formReducer   // it is recommended that you use the key 'form'
+  form: formReducer   // you have to use the key 'form'
 }
 const reducer = combineReducers(reducers);
 const store = createStore(reducer);


### PR DESCRIPTION
In the documentation it's stated that it's "recommended" to use "form" as key in the state.

I think this is not a recommendation but an obligation, otherwise connectReduxForm will fail
https://github.com/erikras/redux-form/blob/master/src/connectReduxForm.js#L5