### PR TITLE
Fix for missing initialState in reducer.normalize

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -173,7 +173,7 @@ function decorate(target) {
           const formResult = {
             ...initialState,
             ...result[form]
-          }
+          };
           return {
             ...formResult,
             ...mapValues(formNormalizers, (fieldNormalizer, field) => ({

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -169,16 +169,22 @@ function decorate(target) {
       const result = this(state, action);
       return {
         ...result,
-        ...mapValues(normalizers, (formNormalizers, form) => ({
-          ...result[form],
-          ...mapValues(formNormalizers, (fieldNormalizer, field) => ({
-            ...result[form][field],
-            value: fieldNormalizer(
-              result[form][field] ? result[form][field].value : undefined,                // value
-              state[form] && state[form][field] ? state[form][field].value : undefined,   // previous value
-              getValues(result[form]))                                                    // all field values
-          }))
-        }))
+        ...mapValues(normalizers, (formNormalizers, form) => {
+          const formResult = {
+            ...initialState,
+            ...result[form]
+          }
+          return {
+            ...formResult,
+            ...mapValues(formNormalizers, (fieldNormalizer, field) => ({
+              ...formResult[field],
+              value: fieldNormalizer(
+                formResult[field] ? formResult[field].value : undefined,                // value
+                state[form] && state[form][field] ? state[form][field].value : undefined,   // previous value
+                getValues(formResult))                                                    // all field values
+            }))
+          };
+        })
       };
     });
   };

--- a/test/reducer.spec.js
+++ b/test/reducer.spec.js
@@ -702,3 +702,52 @@ describe('reducer', () => {
       });
   });
 });
+
+describe('reducer.plugin', () => {
+  it('should initialize form state when there is a reducer plugin', () => {
+    const state = reducer.plugin({
+      foo: (state, action) => {
+        return state;
+      }
+    })();
+    expect(state)
+      .toExist()
+      .toBeA('object');
+    expect(Object.keys(state).length).toBe(1);
+    expect(state.foo)
+      .toExist()
+      .toBeA('object')
+      .toEqual({
+        _active: undefined,
+        _asyncValidating: false,
+        _error: undefined,
+        _submitting: false
+      });
+  });
+});
+
+describe('reducer.normalize', () => {
+  it('should initialize form state when there is a normalizer', () => {
+    const state = reducer.normalize({
+      foo: {
+        myField: (value, previousValue, allValues) => 'normalized'
+      }
+    })();
+    expect(state)
+      .toExist()
+      .toBeA('object');
+    expect(Object.keys(state).length).toBe(1);
+    expect(state.foo)
+      .toExist()
+      .toBeA('object')
+      .toEqual({
+        _active: undefined,
+        _asyncValidating: false,
+        _error: undefined,
+        _submitting: false,
+        myField: {
+          value: 'normalized'
+        }
+      });
+  });
+});


### PR DESCRIPTION
Attempts to use reducer.normalize as documented would result in the following error:
    
    Uncaught TypeError: Cannot read property 'myField' of undefined
    
I've some unit tests and a fix that sets initialState in reducer.normalize