### PR TITLE
Update handleChange to dispatch immediately when passed a value (#108)

### DIFF
--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -129,9 +129,11 @@ export default function createReduxForm(isReactNative, React) {
             },
             handleChange: {
               params: ['actions', 'dispatch'],
-              fn: (actions, dispatch) => (name, value) => (event) => {
+              fn: (actions, dispatch) => (name, value) => {
                 const doChange = bindActionData(actions.change, {touch: touchOnChange});
-                dispatch(doChange(name, getValue(value, event)));
+
+                return value ? dispatch(doChange(name, getValue(value)))
+                : (event) => dispatch(doChange(name, getValue(value, event)));
               }
             },
             fieldActions: {


### PR DESCRIPTION
This patch:

• Updates a form's `handleChange()` prop to dispatch if passed both a field and value as stated in documentation. Related issue [#108](https://github.com/erikras/redux-form/issues/108)