### PR TITLE
Populate `initialValues` on first render

### DIFF
--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -286,6 +286,7 @@ export default function createReduxForm(isReactNative, React) {
             const pristine = isPristine(field.value, field.initial);
             const error = syncErrors[name] || field.asyncError || field.submitError;
             const valid = isValid(error);
+            const initialValue = passableProps.initialValues && passableProps.initialValues[name];
             if (!valid) {
               allValid = false;
             }
@@ -297,6 +298,8 @@ export default function createReduxForm(isReactNative, React) {
               [name]: filterProps({
                 active: subForm._active === name,
                 checked: typeof field.value === 'boolean' ? field.value : undefined,
+                defaultChecked: initialValue,
+                defaultValue: initialValue,
                 dirty: !pristine,
                 error,
                 ...fieldActions[name],


### PR DESCRIPTION
To support server-side rendering, populate `initialValues` using `defaultValue` and `defaultChecked`

I was not ambitious enough to add component tests to add a regression test for this issue.  Hopefully that is okay for now :grin:.

Closes #97

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/erikras/redux-form/132)
<!-- Reviewable:end -->
