### PR TITLE
Allow removal of the whole form object from the reducer

### DIFF
--- a/README.md
+++ b/README.md
@@ -995,6 +995,10 @@ for most of your needs.**
 
 > Resets the 'touched' flag for all the fields passed in.
 
+#### -`destroy(form:String)`
+
+> Destroys the form, removing all its state.
+
 ---
   
 ## Working Demo

--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -9,3 +9,4 @@ export const STOP_ASYNC_VALIDATION = 'redux-form/STOP_ASYNC_VALIDATION';
 export const STOP_SUBMIT = 'redux-form/STOP_SUBMIT';
 export const TOUCH = 'redux-form/TOUCH';
 export const UNTOUCH = 'redux-form/UNTOUCH';
+export const DESTROY = 'redux-form/DESTROY';

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,5 +1,5 @@
 import { BLUR, CHANGE, FOCUS, INITIALIZE, RESET, START_ASYNC_VALIDATION, START_SUBMIT, STOP_ASYNC_VALIDATION,
-  STOP_SUBMIT, TOUCH, UNTOUCH } from './actionTypes';
+  STOP_SUBMIT, TOUCH, UNTOUCH, DESTROY } from './actionTypes';
 
 export function blur(field, value) {
   return {type: BLUR, field, value};
@@ -43,4 +43,8 @@ export function touch(...fields) {
 
 export function untouch(...fields) {
   return {type: UNTOUCH, fields};
+}
+
+export function destroy() {
+  return {type: DESTROY};
 }

--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -346,7 +346,7 @@ export default function createReduxForm(isReactNative, React) {
             touchAll: silenceEvents(() => dispatch(actions.touch(...fields))),
             untouch: silenceEvents((...untouchFields) => dispatch(actions.untouch(...untouchFields))),
             untouchAll: silenceEvents(() => dispatch(actions.untouch(...fields))),
-
+            destroyForm: silenceEvents(() => dispatch(actions.destroy())),
             // Other:
             dispatch,
             ...passableProps

--- a/src/index.js
+++ b/src/index.js
@@ -17,5 +17,6 @@ export const {
   stopAsyncValidation,
   stopSubmit,
   touch,
-  untouch
+  untouch,
+  destroy
 } = createAll(false, React, connect);

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,5 +1,5 @@
 import { BLUR, CHANGE, FOCUS, INITIALIZE, RESET, START_ASYNC_VALIDATION, START_SUBMIT, STOP_ASYNC_VALIDATION,
-  STOP_SUBMIT, TOUCH, UNTOUCH } from './actionTypes';
+  STOP_SUBMIT, TOUCH, UNTOUCH, DESTROY } from './actionTypes';
 import mapValues from './mapValues';
 
 export const initialState = {
@@ -125,6 +125,8 @@ const reducer = (state = initialState, action = {}) => {
           }
         }), {})
       };
+    case DESTROY:
+      return undefined;
     default:
       return state;
   }

--- a/test/actions.spec.js
+++ b/test/actions.spec.js
@@ -1,8 +1,8 @@
 import expect from 'expect';
 import { BLUR, CHANGE, FOCUS, INITIALIZE, RESET, START_ASYNC_VALIDATION, START_SUBMIT, STOP_ASYNC_VALIDATION,
-  STOP_SUBMIT, TOUCH, UNTOUCH } from '../src/actionTypes';
+  STOP_SUBMIT, TOUCH, UNTOUCH, DESTROY } from '../src/actionTypes';
 import {blur, change, focus, initialize, reset, startAsyncValidation, startSubmit,
-  stopAsyncValidation, stopSubmit, touch, untouch} from '../src/actions';
+  stopAsyncValidation, stopSubmit, touch, untouch, destroy} from '../src/actions';
 
 describe('actions', () => {
   it('should create blur action', () => {
@@ -48,6 +48,10 @@ describe('actions', () => {
 
   it('should create reset action', () => {
     expect(reset()).toEqual({type: RESET});
+  });
+
+  it('should create destroy action', () => {
+    expect(destroy()).toEqual({type: DESTROY});
   });
 
   it('should create startAsyncValidation action', () => {

--- a/test/reducer.spec.js
+++ b/test/reducer.spec.js
@@ -1,7 +1,7 @@
 import expect from 'expect';
 import reducer from '../src/reducer';
 import {blur, change, focus, initialize, reset, startAsyncValidation, startSubmit,
-  stopAsyncValidation, stopSubmit, touch, untouch} from '../src/actions';
+  stopAsyncValidation, stopSubmit, touch, untouch, destroy} from '../src/actions';
 
 describe('reducer', () => {
   it('should initialize state to {}', () => {
@@ -700,6 +700,22 @@ describe('reducer', () => {
         _error: undefined,
         _submitting: false
       });
+  });
+
+  it('should destroy forms on destroy', () => {
+    const state = reducer({
+      foo: {
+        _active: undefined,
+        _asyncValidating: false,
+        _error: undefined,
+        _submitting: false
+      }
+    }, {
+      ...destroy(),
+      form: 'foo'
+    });
+    expect(state.foo)
+      .toEqual(undefined);
   });
 });
 


### PR DESCRIPTION
 for proper memory management with apps that generate a significant amount of dynamic forms.