### PR TITLE
Global dirty

### DIFF
--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -1,6 +1,5 @@
 import * as formActions from './actions';
 import getDisplayName from './getDisplayName';
-import isPristine from './isPristine';
 import isValid from './isValid';
 import bindActionData from './bindActionData';
 import {initialState} from './reducer';
@@ -233,7 +232,6 @@ export default function createReduxForm(isReactNative, React) {
 
           // Calculate calculable state
           let allValid = true;
-          let allPristine = true;
 
           const handleSubmit = submitOrEvent => {
             const createEventHandler = submit => event => {
@@ -283,15 +281,11 @@ export default function createReduxForm(isReactNative, React) {
           const syncErrors = this.runSyncValidation(values);
           const allFields = fields.reduce((accumulator, name) => {
             const field = subForm[name] || {};
-            const pristine = isPristine(field.value, field.initial);
             const error = syncErrors[name] || field.asyncError || field.submitError;
             const valid = isValid(error);
             const initialValue = passableProps.initialValues && passableProps.initialValues[name];
             if (!valid) {
               allValid = false;
-            }
-            if (!pristine) {
-              allPristine = false;
             }
             return {
               ...accumulator,
@@ -300,13 +294,13 @@ export default function createReduxForm(isReactNative, React) {
                 checked: typeof field.value === 'boolean' ? field.value : undefined,
                 defaultChecked: initialValue,
                 defaultValue: initialValue,
-                dirty: !pristine,
+                dirty: field.dirty,
                 error,
                 ...fieldActions[name],
                 invalid: !valid,
                 name,
                 onDrag: event => event.dataTransfer.setData('value', field.value),
-                pristine,
+                pristine: !field.dirty,
                 touched: field.touched,
                 valid: valid,
                 value: field.value,
@@ -324,12 +318,12 @@ export default function createReduxForm(isReactNative, React) {
             // State:
             active: subForm._active,
             asyncValidating: subForm._asyncValidating,
-            dirty: !allPristine,
+            dirty: subForm._dirty,
             error: formError,
             fields: allFields,
             formKey,
             invalid: !allValid,
-            pristine: allPristine,
+            pristine: !subForm._dirty,
             submitting: subForm._submitting,
             valid: allValid,
             values,

--- a/test/reducer.spec.js
+++ b/test/reducer.spec.js
@@ -31,7 +31,8 @@ describe('reducer', () => {
         _active: undefined,
         _asyncValidating: false,
         _error: undefined,
-        _submitting: false
+        _submitting: false,
+        _dirty: false
       });
   });
 
@@ -49,7 +50,8 @@ describe('reducer', () => {
         _active: undefined,
         _asyncValidating: false,
         _error: undefined,
-        _submitting: false
+        _submitting: false,
+        _dirty: false
       });
   });
 
@@ -68,7 +70,8 @@ describe('reducer', () => {
         _active: undefined,
         _asyncValidating: false,
         _error: undefined,
-        _submitting: false
+        _submitting: false,
+        _dirty: false
       });
   });
 
@@ -83,7 +86,8 @@ describe('reducer', () => {
         _active: 'myField',
         _asyncValidating: false,
         _error: undefined,
-        _submitting: false
+        _submitting: false,
+        _dirty: false
       }
     }, {
       ...blur('myField', 'myValue'),
@@ -100,7 +104,8 @@ describe('reducer', () => {
         _active: undefined,
         _asyncValidating: false,
         _error: undefined,
-        _submitting: false
+        _submitting: false,
+        _dirty: false
       });
   });
 
@@ -115,7 +120,8 @@ describe('reducer', () => {
         _active: 'myField',
         _asyncValidating: false,
         _error: undefined,
-        _submitting: false
+        _submitting: false,
+        _dirty: false
       }
     }, {
       ...blur('myField'),
@@ -132,7 +138,8 @@ describe('reducer', () => {
         _active: undefined,
         _asyncValidating: false,
         _error: undefined,
-        _submitting: false
+        _submitting: false,
+        _dirty: false
       });
   });
 
@@ -145,7 +152,8 @@ describe('reducer', () => {
         _active: 'myField',
         _asyncValidating: false,
         _error: undefined,
-        _submitting: false
+        _submitting: false,
+        _dirty: false
       }
     }, {
       ...blur('myField'),
@@ -161,7 +169,8 @@ describe('reducer', () => {
         _active: undefined,
         _asyncValidating: false,
         _error: undefined,
-        _submitting: false
+        _submitting: false,
+        _dirty: false
       });
   });
 
@@ -176,12 +185,14 @@ describe('reducer', () => {
           value: 'myValue',
           touched: false,
           asyncError: null,
-          submitError: null
+          submitError: null,
+          dirty: true
         },
         _active: undefined, // CHANGE doesn't touch _active
         _asyncValidating: false,
         _error: undefined,
-        _submitting: false
+        _submitting: false,
+        _dirty: true
       });
   });
 
@@ -197,12 +208,14 @@ describe('reducer', () => {
           value: 'myValue',
           touched: true,
           asyncError: null,
-          submitError: null
+          submitError: null,
+          dirty: true
         },
         _active: undefined, // CHANGE doesn't touch _active
         _asyncValidating: false,
         _error: undefined,
-        _submitting: false
+        _submitting: false,
+        _dirty: true
       });
   });
 
@@ -212,12 +225,14 @@ describe('reducer', () => {
         myField: {
           initial: 'initialValue',
           value: 'initialValue',
-          touched: false
+          touched: false,
+          dirty: false
         },
         _active: 'myField',
         _asyncValidating: false,
         _error: 'Some global error',
-        _submitting: false
+        _submitting: false,
+        _dirty: false
       }
     }, {
       ...change('myField', 'myValue'),
@@ -231,12 +246,60 @@ describe('reducer', () => {
           value: 'myValue',
           touched: true,
           asyncError: null,
-          submitError: null
+          submitError: null,
+          dirty: true
         },
         _active: 'myField',
         _asyncValidating: false,
         _error: undefined,
-        _submitting: false
+        _submitting: false,
+        _dirty: true
+      });
+  });
+
+  it('should set value on change and set dirty as needed', () => {
+    const state = reducer({
+      foo: {
+        someField: {
+          initial: 'initialValue',
+          value: 'otherValue',
+          dirty: true
+        },
+        otherField: {
+          initial: 'initialValue',
+          value: 'otherValue',
+          dirty: true
+        },
+        _active: 'myField',
+        _asyncValidating: false,
+        _error: undefined,
+        _submitting: false,
+        _dirty: true
+      }
+    }, {
+      ...change('someField', 'initialValue'),
+      form: 'foo'
+    });
+    expect(state.foo)
+      .toEqual({
+        someField: {
+          initial: 'initialValue',
+          value: 'initialValue',
+          dirty: false,
+          touched: false,
+          asyncError: undefined,
+          submitError: undefined
+        },
+        otherField: {
+          initial: 'initialValue',
+          value: 'otherValue',
+          dirty: true
+        },
+        _active: 'myField',
+        _asyncValidating: false,
+        _error: undefined,
+        _submitting: false,
+        _dirty: true
       });
   });
 
@@ -253,7 +316,8 @@ describe('reducer', () => {
         _active: 'myField',
         _asyncValidating: false,
         _error: undefined,
-        _submitting: false
+        _submitting: false,
+        _dirty: false
       });
   });
 
@@ -268,7 +332,8 @@ describe('reducer', () => {
         _active: 'otherField',
         _asyncValidating: false,
         _error: undefined,
-        _submitting: false
+        _submitting: false,
+        _dirty: false
       }
     }, {
       ...focus('myField'),
@@ -284,7 +349,8 @@ describe('reducer', () => {
         _active: 'myField',
         _asyncValidating: false,
         _error: undefined,
-        _submitting: false
+        _submitting: false,
+        _dirty: false
       });
   });
 
@@ -297,12 +363,14 @@ describe('reducer', () => {
       .toEqual({
         myField: {
           initial: 'initialValue',
-          value: 'initialValue'
+          value: 'initialValue',
+          dirty: false
         },
         _active: undefined,
         _asyncValidating: false,
         _error: undefined,
-        _submitting: false
+        _submitting: false,
+        _dirty: false
       });
   });
 
@@ -311,12 +379,14 @@ describe('reducer', () => {
       foo: {
         myField: {
           value: 'dirtyValue',
-          touched: true
+          touched: true,
+          dirty: true
         },
         _active: 'myField',
         _asyncValidating: false,
         _error: undefined,
-        _submitting: false
+        _submitting: false,
+        _dirty: true
       }
     }, {
       ...initialize({myField: 'initialValue'}),
@@ -327,12 +397,14 @@ describe('reducer', () => {
       .toEqual({
         myField: {
           initial: 'initialValue',
-          value: 'initialValue'
+          value: 'initialValue',
+          dirty: false
         },
         _active: undefined,
         _asyncValidating: false,
         _error: undefined,
-        _submitting: false
+        _submitting: false,
+        _dirty: false
       });
   });
 
@@ -342,17 +414,20 @@ describe('reducer', () => {
         myField: {
           initial: 'initialValue',
           value: 'dirtyValue',
-          touched: true
+          touched: true,
+          dirty: true
         },
         myOtherField: {
           initial: 'otherInitialValue',
           value: 'otherDirtyValue',
-          touched: true
+          touched: true,
+          dirty: true
         },
         _active: 'myField',
         _asyncValidating: false,
         _error: undefined,
-        _submitting: false
+        _submitting: false,
+        _dirty: true
       }
     }, {
       ...reset(),
@@ -362,16 +437,19 @@ describe('reducer', () => {
       .toEqual({
         myField: {
           initial: 'initialValue',
-          value: 'initialValue'
+          value: 'initialValue',
+          dirty: false
         },
         myOtherField: {
           initial: 'otherInitialValue',
-          value: 'otherInitialValue'
+          value: 'otherInitialValue',
+          dirty: false
         },
         _active: undefined,
         _asyncValidating: false,
         _error: undefined,
-        _submitting: false
+        _submitting: false,
+        _dirty: false
       });
   });
 
@@ -383,7 +461,8 @@ describe('reducer', () => {
         _active: undefined,
         _asyncValidating: false,
         _error: undefined,
-        _submitting: false
+        _submitting: false,
+        _dirty: false
       }
     }, {
       ...startAsyncValidation(),
@@ -396,7 +475,8 @@ describe('reducer', () => {
         _active: undefined,
         _asyncValidating: true,
         _error: undefined,
-        _submitting: false
+        _submitting: false,
+        _dirty: false
       });
   });
 
@@ -408,7 +488,8 @@ describe('reducer', () => {
         _active: undefined,
         _asyncValidating: false,
         _error: undefined,
-        _submitting: false
+        _submitting: false,
+        _dirty: false
       }
     }, {
       ...startSubmit(),
@@ -421,7 +502,8 @@ describe('reducer', () => {
         _active: undefined,
         _asyncValidating: false,
         _error: undefined,
-        _submitting: true
+        _submitting: true,
+        _dirty: false
       });
   });
 
@@ -442,7 +524,8 @@ describe('reducer', () => {
         _active: undefined,
         _asyncValidating: true,
         _error: undefined,
-        _submitting: false
+        _submitting: false,
+        _dirty: false
       }
     }, {
       ...stopAsyncValidation({
@@ -468,7 +551,8 @@ describe('reducer', () => {
         _active: undefined,
         _asyncValidating: false,
         _error: undefined,
-        _submitting: false
+        _submitting: false,
+        _dirty: false
       });
   });
 
@@ -488,7 +572,8 @@ describe('reducer', () => {
         _active: undefined,
         _asyncValidating: true,
         _error: undefined,
-        _submitting: false
+        _submitting: false,
+        _dirty: false
       }
     }, {
       ...stopAsyncValidation({
@@ -511,7 +596,8 @@ describe('reducer', () => {
         _active: undefined,
         _asyncValidating: false,
         _error: 'This is a global error',
-        _submitting: false
+        _submitting: false,
+        _dirty: false
       });
   });
 
@@ -523,7 +609,8 @@ describe('reducer', () => {
         _active: undefined,
         _asyncValidating: false,
         _error: undefined,
-        _submitting: true
+        _submitting: true,
+        _dirty: false
       }
     }, {
       ...stopSubmit(),
@@ -536,7 +623,8 @@ describe('reducer', () => {
         _active: undefined,
         _asyncValidating: false,
         _error: undefined,
-        _submitting: false
+        _submitting: false,
+        _dirty: false
       });
   });
 
@@ -556,7 +644,8 @@ describe('reducer', () => {
         _active: undefined,
         _asyncValidating: false,
         _error: undefined,
-        _submitting: true
+        _submitting: true,
+        _dirty: false
       }
     }, {
       ...stopSubmit({
@@ -582,7 +671,8 @@ describe('reducer', () => {
         _active: undefined,
         _asyncValidating: false,
         _error: undefined,
-        _submitting: false
+        _submitting: false,
+        _dirty: false
       });
   });
 
@@ -602,7 +692,8 @@ describe('reducer', () => {
         _active: undefined,
         _asyncValidating: false,
         _error: undefined,
-        _submitting: true
+        _submitting: true,
+        _dirty: false
       }
     }, {
       ...stopSubmit({
@@ -625,7 +716,8 @@ describe('reducer', () => {
         _active: undefined,
         _asyncValidating: false,
         _error: 'This is a global error',
-        _submitting: false
+        _submitting: false,
+        _dirty: false
       });
   });
 
@@ -643,7 +735,8 @@ describe('reducer', () => {
         _active: undefined,
         _asyncValidating: false,
         _error: undefined,
-        _submitting: false
+        _submitting: false,
+        _dirty: false
       }
     }, {
       ...touch('myField', 'myOtherField'),
@@ -662,7 +755,8 @@ describe('reducer', () => {
         _active: undefined,
         _asyncValidating: false,
         _error: undefined,
-        _submitting: false
+        _submitting: false,
+        _dirty: false
       });
   });
 
@@ -680,7 +774,8 @@ describe('reducer', () => {
         _active: undefined,
         _asyncValidating: false,
         _error: undefined,
-        _submitting: false
+        _submitting: false,
+        _dirty: false
       }
     }, {
       ...untouch('myField', 'myOtherField'),
@@ -699,7 +794,8 @@ describe('reducer', () => {
         _active: undefined,
         _asyncValidating: false,
         _error: undefined,
-        _submitting: false
+        _submitting: false,
+        _dirty: false
       });
   });
 
@@ -709,13 +805,15 @@ describe('reducer', () => {
         _active: undefined,
         _asyncValidating: false,
         _error: undefined,
-        _submitting: false
+        _submitting: false,
+        _dirty: false
       },
       bar: {
         _active: undefined,
         _asyncValidating: false,
         _error: undefined,
-        _submitting: false
+        _submitting: false,
+        _dirty: false
       }
     }, {
       ...destroy(),
@@ -798,7 +896,8 @@ describe('reducer.plugin', () => {
         _active: undefined,
         _asyncValidating: false,
         _error: undefined,
-        _submitting: false
+        _submitting: false,
+        _dirty: false
       });
   });
 });
@@ -822,6 +921,7 @@ describe('reducer.normalize', () => {
         _asyncValidating: false,
         _error: undefined,
         _submitting: false,
+        _dirty: false,
         myField: {
           value: 'normalized'
         }

--- a/test/reducer.spec.js
+++ b/test/reducer.spec.js
@@ -303,52 +303,6 @@ describe('reducer', () => {
       });
   });
 
-  it('should set value on change and set dirty as needed', () => {
-    const state = reducer({
-      foo: {
-        someField: {
-          initial: 'initialValue',
-          value: 'otherValue',
-          dirty: true
-        },
-        otherField: {
-          initial: 'initialValue',
-          value: 'otherValue',
-          dirty: true
-        },
-        _active: 'myField',
-        _asyncValidating: false,
-        _error: undefined,
-        _submitting: false,
-        _dirty: true
-      }
-    }, {
-      ...change('someField', 'initialValue'),
-      form: 'foo'
-    });
-    expect(state.foo)
-      .toEqual({
-        someField: {
-          initial: 'initialValue',
-          value: 'initialValue',
-          dirty: false,
-          touched: false,
-          asyncError: undefined,
-          submitError: undefined
-        },
-        otherField: {
-          initial: 'initialValue',
-          value: 'otherValue',
-          dirty: true
-        },
-        _active: 'myField',
-        _asyncValidating: false,
-        _error: undefined,
-        _submitting: false,
-        _dirty: true
-      });
-  });
-
   it('should set visited on focus and update current with no previous state', () => {
     const state = reducer({}, {
       ...focus('myField'),

--- a/test/reducer.spec.js
+++ b/test/reducer.spec.js
@@ -825,7 +825,8 @@ describe('reducer', () => {
           _active: undefined,
           _asyncValidating: false,
           _error: undefined,
-          _submitting: false
+          _submitting: false,
+          _dirty: false
         }
       });
   });


### PR DESCRIPTION
Push dirty and pristine handling in the reducer instead of the component.

I know it sounds like duplication of state (since originals and current values are already in the store), but I think it really belongs there. It makes it really easier to read the status of a form from the outside, which can be a blessing with dynamic forms.

Is it open to discussion?