### PR TITLE
isPristine should return false when the number of keys is different

### DIFF
--- a/src/isPristine.js
+++ b/src/isPristine.js
@@ -6,7 +6,11 @@ export default function isPristine(initial, data) {
     if (!data || typeof data !== 'object') {
       return false;
     }
+    const initialKeys = Object.keys(initial);
     const dataKeys = Object.keys(data);
+    if (initialKeys.length !== dataKeys.length) {
+      return false;
+    }
     for (let index = 0; index < dataKeys.length; index++) {
       const key = dataKeys[index];
       if (!isPristine(initial[key], data[key])) {

--- a/test/isPristine.spec.js
+++ b/test/isPristine.spec.js
@@ -40,6 +40,11 @@ describe('isPristine', () => {
     tryBothWays({foo: 7, bar: 8}, {foo: 7, bar: 9}, false);
   });
 
+  it('should return false when the number of keys is different', () => {
+    tryBothWays({foo: 'bar'}, {}, false);
+    tryBothWays([1], [1, 2], false);
+  });
+
   it('should return true when matching key values are null, undefined, or empty string', () => {
     tryBothWays({foo: ''}, {foo: null}, true);
     tryBothWays({foo: ''}, {foo: undefined}, true);


### PR DESCRIPTION
Hey guys! I have a case when initial value of a form's field is an empty array.

After updating the field via `this.props.fields['someField'].handleChange([1, 2, 3])`, `this.props.pristine` remain equal to `true`.

This pull request should fix the problem.