### PR TITLE
fixed not submitting if there are no async errors

### DIFF
--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -195,7 +195,7 @@ export default function createReduxForm(isReactNative, React) {
           }
           const handleErrors = asyncErrors => {
             dispatch(actions.stopAsyncValidation(asyncErrors));
-            return hasErrors(asyncErrors);
+            return asyncErrors;
           };
           return promise.then(handleErrors, handleErrors);
         }
@@ -271,8 +271,8 @@ export default function createReduxForm(isReactNative, React) {
                 dispatch(actions.touch(...fields));
                 if (allValid) {
                   if (asyncValidate) {
-                    return this.runAsyncValidation(actions, values).then(asyncValid => {
-                      if (allValid && asyncValid) {
+                    return this.runAsyncValidation(actions, values).then(asyncErrors => {
+                      if (allValid && !hasErrors(asyncErrors)) {
                         return submitWithPromiseCheck(values);
                       }
                     });


### PR DESCRIPTION
Currently `handleSubmit` routine checks whether if there are async errors by doing this:
```js
return this.runAsyncValidation(actions, values).then(asyncValid => {
  if (allValid && asyncValid) {
    ...
  }
}
```

But `runAsyncValidation` function returns true **if there are errors**:
```js
return hasErrors(asyncErrors);
```

Since this function returns true if there are errors, form can be only submitted if there are async errors in the form.

This pull request fixes this issue by changing `runAsyncValidation` to return an object of errors (thus acting same as `runSyncValidation` to give consistency).

```js
return this.runAsyncValidation(actions, values).then(asyncErrors => {
  if (allValid && !hasErrors(asyncErrors)) {
    ...
  }
}
```