### PR TITLE
allow initialValues to be in the `mapPropsToValues` form

### DIFF
--- a/src/createHigherOrderComponent.js
+++ b/src/createHigherOrderComponent.js
@@ -68,7 +68,7 @@ const createHigherOrderComponent = (config, isReactNative, React, WrappedCompone
       componentWillMount() {
         const {initialize, initialValues} = this.props;
         if (initialValues) {
-          initialize(initialValues);
+          initialize(typeof initialValues === 'function' ? initialValues(this.props) : initialValues);
         }
       }
 


### PR DESCRIPTION
This allows for the `initialValues` property to be in the `mapPropsToValues` form, matching an idiom already familiar to the redux world. This also provides an entry-point in taking advantage of react props in conjuction with a reduxForm.

```
const Form = reduxForm({
  initialValues: (props) => ({query: props.query})
});

const RenderedForm => (
  <Form field={location.query.query} />
)
```