### PR TITLE
add a jsnext:main so we can distribute ES2015 modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.5",
   "description": "A higher order component decorator for forms using Redux and React",
   "main": "./lib/index.js",
+  "jsnext:main": "./src/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/erikras/redux-form"


### PR DESCRIPTION
See https://github.com/rollup/rollup#can-i-distribute-my-package-as-an-es6-module