### PR TITLE
Fix README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# [erikras.github.io/redux-form](erikras.github.io/redux-form)
+# [erikras.github.io/redux-form](http://erikras.github.io/redux-form)


### PR DESCRIPTION
This commit fixes the README link to the redux-form Github pages docs; this wasn't linking correctly as it seemed to be a relative rather than absolute link.