### PR TITLE
Add onSubmit prop to WrappedComponent

### DIFF
--- a/src/createHigherOrderComponent.js
+++ b/src/createHigherOrderComponent.js
@@ -122,6 +122,7 @@ const createHigherOrderComponent = (config,
           // ^ doesn't just pass this.asyncValidate to disallow values passing
           destroyForm: silenceEvents(destroy),
           handleSubmit: this.handleSubmit,
+          onSubmit,
           initializeForm: silenceEvents(initialize),
           resetForm: silenceEvents(reset),
           touch: silenceEvents((...touchFields) => touch(...touchFields)),


### PR DESCRIPTION
The `WrappedComponent` current loses its reference to `onSubmit` because it is pulled out of `this.props` and not passed back to`WrappedComponent`.

This restores that reference and seems to solve #294.