### PR TITLE
Remove spread operators

### DIFF
--- a/src/getValues.js
+++ b/src/getValues.js
@@ -1,6 +1,6 @@
-const getValues = (fields, form) => fields.reduce((accumulator, field) => ({
-  ...accumulator,
-  [field]: form[field] ? form[field].value : undefined
-}), {});
+const getValues = (fields, form) => fields.reduce((accumulator, field) => {
+  accumulator[field] = form[field] ? form[field].value : undefined;
+  return accumulator;
+}, {});
 
 export default getValues;

--- a/src/readFields.js
+++ b/src/readFields.js
@@ -95,10 +95,8 @@ const readFields = (props, myFields, asyncValidate, isReactNative) => {
     if (result.dirty) {
       allPristine = false;
     }
-    return {
-      ...accumulator,
-      [name]: result
-    };
+    accumulator[name] = result;
+    return accumulator;
   }, {});
   Object.defineProperty(fieldObjects, '_meta', {
     value: {

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -10,12 +10,15 @@ export const initialState = {
   _submitFailed: false
 };
 
-const getValues = (state) =>
-  Object.keys(state).reduce((accumulator, name) =>
-    name[0] === '_' ? accumulator : {
-      ...accumulator,
-      [name]: state[name].value
-    }, {});
+const getValues = (state) => {
+  Object.keys(state).reduce((accumulator, name) => {
+    if (name[0] === '_') {
+      return accumulator;
+    }
+    accumulator[name] = state[name].value;
+    return accumulator;
+  }, {});
+};
 
 const reducer = (state = initialState, action = {}) => {
   switch (action.type) {
@@ -118,24 +121,24 @@ const reducer = (state = initialState, action = {}) => {
     case TOUCH:
       return {
         ...state,
-        ...action.fields.reduce((accumulator, field) => ({
-          ...accumulator,
-          [field]: {
+        ...action.fields.reduce((accumulator, field) => {
+          accumulator[field] = {
             ...state[field],
             touched: true
-          }
-        }), {})
+          };
+          return accumulator;
+        }, {})
       };
     case UNTOUCH:
       return {
         ...state,
-        ...action.fields.reduce((accumulator, field) => ({
-          ...accumulator,
-          [field]: {
+        ...action.fields.reduce((accumulator, field) => {
+          accumulator[field] = {
             ...state[field],
             touched: false
-          }
-        }), {})
+          };
+          return accumulator;
+        }, {})
       };
     default:
       return state;


### PR DESCRIPTION
Spread operators is very slow when there are many fields (I have a 200+ fields huge form).

Compare using spread operators and not: http://jsbin.com/tibiji/edit?js,console