### PR TITLE
Normalization of keyed forms.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,7 +12,7 @@
     "comma-dangle": 0,  // not sure why airbnb turned this on. gross!
     "indent": [2, 2, {"SwitchCase": 1}],
     "spaced-comment": 0,
-
+    "no-redeclare": 0,
     //Temporarirly disabled due to a possible bug in babel-eslint (todomvc example)
     "block-scoped-var": 0,
     // Temporarily disabled for test/* until babel/babel-eslint#33 is resolved

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -204,9 +204,10 @@ function decorate(target) {
         ...mapValues(normalizers, (formNormalizers, form) => {
           const previousValues = getValues({...initialState, ...(state[form] && action.key ? state[form][action.key] : state[form])
           });
+          const useKey = action.key && action.form && form === action.form;
           const formResult = {
             ...initialState,
-            ...(result[form] && action.key ? result[form][action.key] : result[form])
+            ...(result[form] && useKey ? result[form][action.key] : result[form])
           };
           if (action.form && form !== action.form) {
             return formResult;


### PR DESCRIPTION
Reducer's getValues now returns values.   I assume this was a bug.

Normalization can now occur on formKeyed forms, if the action.key is defined.  Running normalization only when action.form matches form to normalize, or is undefined.  I think that last part is probably contentious.

Also, every version of eslint I tried gave me an error for redeclaration in on master.

I didn't add any tests for this,  so please let me know if you want some, assuming that is was the right approach to take.