### PR TITLE
Normalization of keyed forms.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,7 +12,7 @@
     "comma-dangle": 0,  // not sure why airbnb turned this on. gross!
     "indent": [2, 2, {"SwitchCase": 1}],
     "spaced-comment": 0,
-
+    "no-redeclare": 0,
     //Temporarirly disabled due to a possible bug in babel-eslint (todomvc example)
     "block-scoped-var": 0,
     // Temporarily disabled for test/* until babel/babel-eslint#33 is resolved

--- a/src/__tests__/reducer.spec.js
+++ b/src/__tests__/reducer.spec.js
@@ -976,6 +976,63 @@ describe('reducer.normalize', () => {
         }
       });
   });
+  it('should normalize keyed forms depending on action form key', () => {
+    const defaultFields = {
+      _active: undefined,
+      _asyncValidating: false,
+      _error: undefined,
+      _submitting: false,
+      _submitFailed: false,
+    };
+    const normalize = reducer.normalize({
+      foo: {
+        myField: () => 'normalized'
+      }
+    });
+    const state = normalize({
+      foo: {
+        firstSubform: {}
+      }
+    }, {
+      form: 'foo',
+      key: 'firstSubform'
+    });
+    const nextState = normalize(state, {
+      form: 'foo',
+      key: 'secondSubForm'
+    });
+    expect(state)
+      .toExist()
+      .toBeA('object');
+    expect(Object.keys(state).length).toBe(1);
+    expect(state.foo)
+      .toExist()
+      .toBeA('object')
+      .toEqual({
+        firstSubform: {
+          ...defaultFields,
+          myField: {
+            value: 'normalized'
+          }
+        }
+      });
+    expect(nextState.foo)
+      .toEqual({
+        firstSubform: {
+          ...defaultFields,
+          myField: {
+            value: 'normalized'
+          }
+        },
+        secondSubForm: {
+          ...defaultFields,
+          myField: {
+            value: 'normalized'
+          }
+        }
+      });
+
+  });
 });
 
 describe('reducer.getValues', () => {

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -204,9 +204,10 @@ function decorate(target) {
         ...mapValues(normalizers, (formNormalizers, form) => {
           const previousValues = getValues({...initialState, ...(state[form] && action.key ? state[form][action.key] : state[form])
           });
+          const useKey = action.key && action.form && form === action.form;
           const formResult = {
             ...initialState,
-            ...(result[form] && action.key ? result[form][action.key] : result[form])
+            ...(result[form] && useKey ? result[form][action.key] : result[form])
           };
           if (action.form && form !== action.form) {
             return formResult;


### PR DESCRIPTION
Reducer's getValues now returns values. I assume this was a bug.

Normalization can now occur on formKeyed forms, if the action.key is defined.

Also, every version of eslint I tried gave me an error for redeclaration in on master.

I didn't add any tests for this, so please let me know if you want some, assuming that is was the right approach to take.