### PR TITLE
Add ability to pass in arguments to resolve method

### DIFF
--- a/src/__tests__/asyncValidation.spec.js
+++ b/src/__tests__/asyncValidation.spec.js
@@ -19,8 +19,22 @@ describe('asyncValidation', () => {
     expect(isPromise(asyncValidation(fn, start, stop))).toBe(true);
   });
 
-  it('should call start, fn, and stop on promise resolve', () => {
+  it('should call start, fn, and stop on promise resolve with no arguments', () => {
     const fn = createSpy().andReturn(Promise.resolve());
+    const start = createSpy();
+    const stop = createSpy();
+    const promise = asyncValidation(fn, start, stop);
+    expect(fn).toHaveBeenCalled();
+    expect(start).toHaveBeenCalled();
+    return promise.then(() => {
+      expect(stop).toHaveBeenCalled();
+    }, () => {
+      expect(false).toBe(true); // should not get into reject branch
+    });
+  });
+
+  it('should call start, fn, and stop on promise resolve with arguments', () => {
+    const fn = createSpy().andReturn(Promise.resolve({foo: 'success'}));
     const start = createSpy();
     const stop = createSpy();
     const promise = asyncValidation(fn, start, stop);

--- a/src/asyncValidation.js
+++ b/src/asyncValidation.js
@@ -8,7 +8,7 @@ const asyncValidation = (fn, start, stop) => {
     throw new Error('asyncValidate function passed to reduxForm must return a promise');
   }
   const handleErrors = rejected => errors => {
-    if (!isValid(errors)) {
+    if (!isValid(errors) && rejected) {
       stop(errors);
       return Promise.reject();
     } else if (rejected) {


### PR DESCRIPTION
If user passes in an argument to the resolve method the library shouldn't treat this as an error. This may not be the best practice but just in case someone needs to wait till that promise has been resolved
to fire an action from there, this update will handle it appropriately.