### PR TITLE
Set dirty when array field changes

### DIFF
--- a/src/__tests__/createReduxForm.spec.js
+++ b/src/__tests__/createReduxForm.spec.js
@@ -394,6 +394,69 @@ describe('createReduxForm', () => {
     });
   });
 
+  it('should set dirty when and array field changes', () => {
+    const store = makeStore();
+    const form = 'testForm';
+    const Decorated = reduxForm({
+      form,
+      fields: ['children[].name'],
+    })(Form);
+    const dom = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <Decorated initialValues={{children: [{name: 'Tom'}, {name: 'Jerry'}]}}/>
+      </Provider>
+    );
+    const stub = TestUtils.findRenderedComponentWithType(dom, Form);
+
+    expectField({
+      field: stub.props.fields.children[0].name,
+      name: 'children[0].name',
+      value: 'Tom',
+      valid: true,
+      dirty: false,
+      error: undefined,
+      touched: false,
+      visited: false,
+      readonly: false
+    });
+    expectField({
+      field: stub.props.fields.children[1].name,
+      name: 'children[1].name',
+      value: 'Jerry',
+      valid: true,
+      dirty: false,
+      error: undefined,
+      touched: false,
+      visited: false,
+      readonly: false
+    });
+
+    stub.props.fields.children[0].name.onChange('Tim');
+
+    expectField({
+      field: stub.props.fields.children[0].name,
+      name: 'children[0].name',
+      value: 'Tim',
+      valid: true,
+      dirty: true,
+      error: undefined,
+      touched: false,
+      visited: false,
+      readonly: false
+    });
+    expectField({
+      field: stub.props.fields.children[1].name,
+      name: 'children[1].name',
+      value: 'Jerry',
+      valid: true,
+      dirty: false,
+      error: undefined,
+      touched: false,
+      visited: false,
+      readonly: false
+    });
+  });
+
   it('should trigger sync error on change that invalidates value', () => {
     const store = makeStore();
     const form = 'testForm';

--- a/src/readFields.js
+++ b/src/readFields.js
@@ -16,14 +16,20 @@ const readFields = (props, myFields, asyncValidate, isReactNative) => {
   const fieldObjects = {...myFields};
   fields.forEach(name => {
     const result = readField(form, name, undefined, fieldObjects, syncErrors, asyncValidate, isReactNative, props);
-    if (result.invalid) {
-      allValid = false;
-    }
-    if (result.dirty) {
-      allPristine = false;
-    }
-    if (result.error) {
-      errors = write(name, result.error, errors);
+    if (Array.isArray(result)) {
+      allValid = result.every(res => !res.invalid);
+      allPristine = result.every(res => !res.dirty);
+      errors = result.every(res => write(name, res.error, errors));
+    } else {
+      if (result.invalid) {
+        allValid = false;
+      }
+      if (result.dirty) {
+        allPristine = false;
+      }
+      if (result.error) {
+        errors = write(name, result.error, errors);
+      }
     }
   });
   Object.defineProperty(fieldObjects, '_meta', {


### PR DESCRIPTION
`readField`'s return value can be an array so in order to determine if a form is dirty, I handle this case by iterating through all the elements.