### PR TITLE
return undefined if an object is not passed to getValuesFromState before Object.keys is executed

### DIFF
--- a/src/getValuesFromState.js
+++ b/src/getValuesFromState.js
@@ -5,6 +5,10 @@ const getValuesFromState = state => {
   if (!state) {
     return state;
   }
+   if (typeof state != "object"){
+    return undefined;
+  }
+  
   const keys = Object.keys(state);
   if (!keys.length) {
     return undefined;

--- a/src/getValuesFromState.js
+++ b/src/getValuesFromState.js
@@ -5,10 +5,9 @@ const getValuesFromState = state => {
   if (!state) {
     return state;
   }
-   if (typeof state != "object"){
+  if (typeof state !== 'object') {
     return undefined;
   }
-  
   const keys = Object.keys(state);
   if (!keys.length) {
     return undefined;


### PR DESCRIPTION
In some cases, the boolean "true" gets passed to getValuesFromState. While this returns an empty array in Chrome and Edge, it returns an error in IE11. This added check with prevent the error(and thusly, the form exploding) in IE11.