### PR TITLE
Add asyncValidating prop in case of async validation

### DIFF
--- a/src/__tests__/actions.spec.js
+++ b/src/__tests__/actions.spec.js
@@ -93,7 +93,10 @@ describe('actions', () => {
   });
 
   it('should create startAsyncValidation action', () => {
-    expect(startAsyncValidation()).toEqual({type: START_ASYNC_VALIDATION});
+    expect(startAsyncValidation('myField')).toEqual({
+      type: START_ASYNC_VALIDATION,
+      field: 'myField'
+    });
   });
 
   it('should create startSubmit action', () => {
@@ -105,8 +108,9 @@ describe('actions', () => {
       foo: 'Foo error',
       bar: 'Error for bar'
     };
-    expect(stopAsyncValidation(errors)).toEqual({
+    expect(stopAsyncValidation('myField', errors)).toEqual({
       type: STOP_ASYNC_VALIDATION,
+      field: 'myField',
       errors
     });
   });

--- a/src/__tests__/asyncValidation.spec.js
+++ b/src/__tests__/asyncValidation.spec.js
@@ -3,6 +3,7 @@ import isPromise from 'is-promise';
 import asyncValidation from '../asyncValidation';
 
 describe('asyncValidation', () => {
+  const field = 'myField';
 
   it('should throw an error if fn does not return a promise', () => {
     const fn = () => null;
@@ -23,11 +24,13 @@ describe('asyncValidation', () => {
     const fn = createSpy().andReturn(Promise.resolve());
     const start = createSpy();
     const stop = createSpy();
-    const promise = asyncValidation(fn, start, stop);
+    const promise = asyncValidation(fn, start, stop, field);
     expect(fn).toHaveBeenCalled();
     expect(start).toHaveBeenCalled();
     return promise.then(() => {
-      expect(stop).toHaveBeenCalled();
+      expect(stop)
+        .toHaveBeenCalled()
+        .toHaveBeenCalledWith(field);
     }, () => {
       expect(false).toBe(true); // should not get into reject branch
     });
@@ -37,13 +40,17 @@ describe('asyncValidation', () => {
     const fn = createSpy().andReturn(Promise.reject());
     const start = createSpy();
     const stop = createSpy();
-    const promise = asyncValidation(fn, start, stop);
+    const promise = asyncValidation(fn, start, stop, field);
     expect(fn).toHaveBeenCalled();
-    expect(start).toHaveBeenCalled();
+    expect(start)
+      .toHaveBeenCalled()
+      .toHaveBeenCalledWith(field);
     return promise.then(() => {
       expect(false).toBe(true); // should not get into resolve branch
     }, () => {
-      expect(stop).toHaveBeenCalled();
+      expect(stop)
+        .toHaveBeenCalled()
+        .toHaveBeenCalledWith(field);
     });
   });
 
@@ -52,15 +59,17 @@ describe('asyncValidation', () => {
     const fn = createSpy().andReturn(Promise.reject(errors));
     const start = createSpy();
     const stop = createSpy();
-    const promise = asyncValidation(fn, start, stop);
+    const promise = asyncValidation(fn, start, stop, field);
     expect(fn).toHaveBeenCalled();
-    expect(start).toHaveBeenCalled();
+    expect(start)
+      .toHaveBeenCalled()
+      .toHaveBeenCalledWith(field);
     return promise.then(() => {
       expect(false).toBe(true); // should not get into resolve branch
     }, () => {
       expect(stop)
         .toHaveBeenCalled()
-        .toHaveBeenCalledWith(errors);
+        .toHaveBeenCalledWith(field, errors);
     });
   });
 });

--- a/src/__tests__/reducer.spec.js
+++ b/src/__tests__/reducer.spec.js
@@ -973,6 +973,10 @@ describe('reducer', () => {
   it('should set asyncValidating on startAsyncValidation', () => {
     const state = reducer({
       foo: {
+        myField: {
+          initial: 'initialValue',
+          value: 'initialValue',
+        },
         doesnt: 'matter',
         should: 'notchange',
         _active: undefined,
@@ -982,11 +986,16 @@ describe('reducer', () => {
         _submitFailed: false
       }
     }, {
-      ...startAsyncValidation(),
+      ...startAsyncValidation('myField'),
       form: 'foo'
     });
     expect(state.foo)
       .toEqual({
+        myField: {
+          initial: 'initialValue',
+          value: 'initialValue',
+          asyncValidating: true,
+        },
         doesnt: 'matter',
         should: 'notchange',
         _active: undefined,
@@ -1073,12 +1082,15 @@ describe('reducer', () => {
         _submitFailed: false
       }
     }, {
-      ...stopAsyncValidation({
-        bar: {
-          myField: 'Error about myField',
-          myOtherField: 'Error about myOtherField'
+      ...stopAsyncValidation(
+        'myField',
+        {
+          bar: {
+            myField: 'Error about myField',
+            myOtherField: 'Error about myOtherField'
+          }
         }
-      }),
+      ),
       form: 'foo'
     });
     expect(state.foo)
@@ -1088,7 +1100,8 @@ describe('reducer', () => {
             initial: 'initialValue',
             value: 'dirtyValue',
             touched: true,
-            asyncError: 'Error about myField'
+            asyncError: 'Error about myField',
+            asyncValidating: false
           },
           myOtherField: {
             initial: 'otherInitialValue',
@@ -1127,12 +1140,15 @@ describe('reducer', () => {
         _submitFailed: false
       }
     }, {
-      ...stopAsyncValidation({
-        bar: [
-          'Error about myField',
-          'Error about myOtherField'
-        ]
-      }),
+      ...stopAsyncValidation(
+        'bar',
+        {
+          bar: [
+            'Error about myField',
+            'Error about myOtherField'
+          ]
+        }
+      ),
       form: 'foo'
     });
     expect(state.foo)
@@ -1179,10 +1195,13 @@ describe('reducer', () => {
         _submitFailed: false
       }
     }, {
-      ...stopAsyncValidation({
-        myField: 'Error about myField',
-        myOtherField: 'Error about myOtherField'
-      }),
+      ...stopAsyncValidation(
+        'myField',
+        {
+          myField: 'Error about myField',
+          myOtherField: 'Error about myOtherField'
+        }
+      ),
       form: 'foo'
     });
     expect(state.foo)
@@ -1191,7 +1210,8 @@ describe('reducer', () => {
           initial: 'initialValue',
           value: 'dirtyValue',
           touched: true,
-          asyncError: 'Error about myField'
+          asyncError: 'Error about myField',
+          asyncValidating: false
         },
         myOtherField: {
           initial: 'otherInitialValue',
@@ -1229,7 +1249,7 @@ describe('reducer', () => {
         _submitFailed: false
       }
     }, {
-      ...stopAsyncValidation(),
+      ...stopAsyncValidation('myField'),
       form: 'foo'
     });
     expect(state.foo)
@@ -1237,7 +1257,8 @@ describe('reducer', () => {
         myField: {
           initial: 'initialValue',
           value: 'dirtyValue',
-          touched: true
+          touched: true,
+          asyncValidating: false
         },
         myOtherField: {
           initial: 'otherInitialValue',
@@ -1272,9 +1293,10 @@ describe('reducer', () => {
         _submitFailed: false
       }
     }, {
-      ...stopAsyncValidation({
-        [globalErrorKey]: 'This is a global error'
-      }),
+      ...stopAsyncValidation(
+        'myField',
+        {[globalErrorKey]: 'This is a global error'}
+      ),
       form: 'foo'
     });
     expect(state.foo)
@@ -1282,7 +1304,8 @@ describe('reducer', () => {
         myField: {
           initial: 'initialValue',
           value: 'dirtyValue',
-          touched: true
+          touched: true,
+          asyncValidating: false
         },
         myOtherField: {
           initial: 'otherInitialValue',

--- a/src/__tests__/setErrors.spec.js
+++ b/src/__tests__/setErrors.spec.js
@@ -7,6 +7,11 @@ describe('setErrors', () => {
       .toEqual({foo: 42, bar: true});
   });
 
+  it('should add { asyncValidating: false } for the passed field', () => {
+    expect(setErrors({foo: {value: 42}, bar: true}, {}, '__err', 'foo'))
+      .toEqual({foo: {value: 42, asyncValidating: false}, bar: true});
+  });
+
   it('should set errors even when no state', () => {
     expect(setErrors({}, {
       foo: 'fooError',
@@ -78,11 +83,12 @@ describe('setErrors', () => {
     }, {
       foo: 'fooError',
       cat: 'meow'
-    }, '__err'))
+    }, '__err', 'foo'))
       .toEqual({
         foo: {
           value: 'bar',
-          __err: 'fooError'
+          __err: 'fooError',
+          asyncValidating: false
         },
         cat: {
           value: 'rat',
@@ -101,10 +107,11 @@ describe('setErrors', () => {
         value: 'rat',
         __err: 'meow'
       }
-    }, {}, '__err'))
+    }, {}, '__err', 'foo'))
       .toEqual({
         foo: {
-          value: 'bar'
+          value: 'bar',
+          asyncValidating: false
         },
         cat: {
           value: 'rat'
@@ -139,12 +146,13 @@ describe('setErrors', () => {
       dog: {
         foo: 'fooError'
       }
-    }, '__err'))
+    }, '__err', 'foo'))
       .toEqual({
         dog: {
           foo: {
             value: 'bar',
-            __err: 'fooError'
+            __err: 'fooError',
+            asyncValidating: false
           }
         }
       });
@@ -158,11 +166,12 @@ describe('setErrors', () => {
           __err: 'fooError'
         }
       }
-    }, {}, '__err'))
+    }, {}, '__err', 'foo'))
       .toEqual({
         dog: {
           foo: {
-            value: 'bar'
+            value: 'bar',
+            asyncValidating: false
           }
         }
       });

--- a/src/__tests__/updateField.spec.js
+++ b/src/__tests__/updateField.spec.js
@@ -116,4 +116,15 @@ describe('updateField', () => {
     expect(updateField({visited: true}, {visited: false}, false, undefined).visited).toBe(false);
     expect(updateField({visited: true}, {}, false, undefined).visited).toBe(false);
   });
+
+  it('should set asyncValidating', () => {
+    // init
+    expect(updateField({}, {asyncValidating: true}, false, undefined).asyncValidating).toBe(true);
+    expect(updateField({}, {asyncValidating: false}, false, undefined).asyncValidating).toBe(false);
+    expect(updateField({}, {}, false, undefined).asyncValidating).toBe(false);
+    // update
+    expect(updateField({asyncValidating: false}, {asyncValidating: true}, false, undefined).asyncValidating).toBe(true);
+    expect(updateField({asyncValidating: true}, {asyncValidating: false}, false, undefined).asyncValidating).toBe(false);
+    expect(updateField({asyncValidating: true}, {}, false, undefined).asyncValidating).toBe(false);
+  });
 });

--- a/src/actions.js
+++ b/src/actions.js
@@ -29,14 +29,14 @@ export const removeArrayValue = (path, index) =>
 export const reset = () =>
   ({type: RESET});
 
-export const startAsyncValidation = () =>
-  ({type: START_ASYNC_VALIDATION});
+export const startAsyncValidation = field =>
+  ({type: START_ASYNC_VALIDATION, field});
 
 export const startSubmit = () =>
   ({type: START_SUBMIT});
 
-export const stopAsyncValidation = errors =>
-  ({type: STOP_ASYNC_VALIDATION, errors});
+export const stopAsyncValidation = (field, errors) =>
+  ({type: STOP_ASYNC_VALIDATION, field, errors});
 
 export const stopSubmit = errors =>
   ({type: STOP_SUBMIT, errors});

--- a/src/asyncValidation.js
+++ b/src/asyncValidation.js
@@ -1,21 +1,21 @@
 import isPromise from 'is-promise';
 import isValid from './isValid';
 
-const asyncValidation = (fn, start, stop) => {
-  start();
+const asyncValidation = (fn, start, stop, field) => {
+  start(field);
   const promise = fn();
   if (!isPromise(promise)) {
     throw new Error('asyncValidate function passed to reduxForm must return a promise');
   }
   const handleErrors = rejected => errors => {
     if (!isValid(errors)) {
-      stop(errors);
+      stop(field, errors);
       return Promise.reject();
     } else if (rejected) {
-      stop();
+      stop(field);
       throw new Error('Asynchronous validation promise was rejected without errors.');
     }
-    stop();
+    stop(field);
     return Promise.resolve();
   };
   return promise.then(handleErrors(false), handleErrors(true));

--- a/src/createHigherOrderComponent.js
+++ b/src/createHigherOrderComponent.js
@@ -68,7 +68,7 @@ const createHigherOrderComponent = (config,
           // if blur validating, only run async validate if sync validation passes
           if (!name || isValid(syncErrors[name])) {
             return asyncValidation(() =>
-              asyncValidate(values, dispatch, this.props), startAsyncValidation, stopAsyncValidation);
+              asyncValidate(values, dispatch, this.props), startAsyncValidation, stopAsyncValidation, name);
           }
         }
       }

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -95,11 +95,10 @@ const behaviors = {
       _submitFailed: false
     };
   },
-  [START_ASYNC_VALIDATION](state) {
-    return {
-      ...state,
-      _asyncValidating: true
-    };
+  [START_ASYNC_VALIDATION](state, {field}) {
+    const stateCopy = write(field + '.asyncValidating', true, state);
+    stateCopy._asyncValidating = true;
+    return stateCopy;
   },
   [START_SUBMIT](state) {
     return {
@@ -107,9 +106,9 @@ const behaviors = {
       _submitting: true
     };
   },
-  [STOP_ASYNC_VALIDATION](state, {errors}) {
+  [STOP_ASYNC_VALIDATION](state, {field, errors}) {
     return {
-      ...setErrors(state, errors, 'asyncError'),
+      ...setErrors(state, errors, 'asyncError', field),
       _asyncValidating: false,
       [globalErrorKey]: errors && errors[globalErrorKey]
     };

--- a/src/setErrors.js
+++ b/src/setErrors.js
@@ -3,17 +3,20 @@ const isMetaKey = key => key[0] === '_';
 /**
  * Sets an error on a field deep in the tree, returning a new copy of the state
  */
-const setErrors = (state, errors, destKey) => {
+const setErrors = (state, errors, destKey, asyncField) => {
+  if (asyncField && state[asyncField]) state[asyncField].asyncValidating = false;
   const clear = () => {
     if (Array.isArray(state)) {
-      return state.map((stateItem, index) => setErrors(stateItem, errors && errors[index], destKey));
+      return state.map(
+        (stateItem, index) => setErrors(stateItem, errors && errors[index], destKey, asyncField)
+      );
     }
     if (typeof state === 'object') {
       return Object.keys(state)
         .reduce((accumulator, key) =>
             isMetaKey(key) ? accumulator : {
               ...accumulator,
-              [key]: setErrors(state[key], errors && errors[key], destKey)
+              [key]: setErrors(state[key], errors && errors[key], destKey, asyncField)
             },
           state);
     }
@@ -35,8 +38,12 @@ const setErrors = (state, errors, destKey) => {
   }
   if (Array.isArray(errors)) {
     if (!state || Array.isArray(state)) {
-      const copy = (state || []).map((stateItem, index) => setErrors(stateItem, errors[index], destKey));
-      errors.forEach((errorItem, index) => copy[index] = setErrors(copy[index], errorItem, destKey));
+      const copy = (state || []).map(
+        (stateItem, index) => setErrors(stateItem, errors[index], destKey, asyncField)
+      );
+      errors.forEach(
+        (errorItem, index) => copy[index] = setErrors(copy[index], errorItem, destKey, asyncField)
+      );
       return copy;
     }
     return setErrors(state, errors[0], destKey);
@@ -44,7 +51,7 @@ const setErrors = (state, errors, destKey) => {
   return Object.keys(errors).reduce((accumulator, key) =>
       isMetaKey(key) ? accumulator : {
         ...accumulator,
-        [key]: setErrors(state && state[key], errors[key], destKey)
+        [key]: setErrors(state && state[key], errors[key], destKey, asyncField)
       },
     clear() || {});
 };

--- a/src/updateField.js
+++ b/src/updateField.js
@@ -42,6 +42,10 @@ const updateField = (field, formField, active, syncError) => {
   if (visited !== field.visited) {
     diff.visited = visited;
   }
+  const asyncValidating = !!formField.asyncValidating;
+  if (asyncValidating !== field.asyncValidating) {
+    diff.asyncValidating = asyncValidating;
+  }
 
   return Object.keys(diff).length ? {
     ...field,


### PR DESCRIPTION
I would like to offer asyncValidation prop for all fields, that are processed ajax validation. So it allows to do the following:
```
if (field.asyncValidating) {
    return <i className="fa fa-spinner fa-spin fa-2x"></i>;
  }
```
Please have a look. One note. It doesn't work when state is array w/o field name.
The main reason of this propose that form _asyncValidating prop hardly helps when you have several fields width async validation. It makes you invent some tricks.
Please let me know your thoughts. Thanks in advance!