### PR TITLE
Adds check for null state within setErrors

### DIFF
--- a/src/__tests__/setErrors.spec.js
+++ b/src/__tests__/setErrors.spec.js
@@ -7,7 +7,7 @@ describe('setErrors', () => {
       .toEqual({foo: 42, bar: true});
   });
 
-  it('should set errors even when no state', () => {
+  it('should set errors even when state is empty', () => {
     expect(setErrors({}, {
       foo: 'fooError',
       bar: 'barError'
@@ -19,6 +19,17 @@ describe('setErrors', () => {
         bar: {
           __err: 'barError'
         }
+      });
+  });
+
+  it('should set errors even when state is null', () => {
+    expect(setErrors(null, {
+      foo: 'fooError',
+    }, '__err'))
+      .toEqual({
+        foo: {
+          __err: 'fooError'
+        },
       });
   });
 

--- a/src/setErrors.js
+++ b/src/setErrors.js
@@ -8,7 +8,7 @@ const setErrors = (state, errors, destKey) => {
     if (Array.isArray(state)) {
       return state.map((stateItem, index) => setErrors(stateItem, errors && errors[index], destKey));
     }
-    if (typeof state === 'object') {
+    if (state && typeof state === 'object') {
       return Object.keys(state)
         .reduce((accumulator, key) =>
             isMetaKey(key) ? accumulator : {


### PR DESCRIPTION
Previously was throwing error "TypeError: Cannot convert undefined or null to object"

This was being encountered in relation to async form submission [as seen in the submit-validation demo](http://erikras.github.io/redux-form/#/examples/submit-validation?_k=5igft0)

Credit: Implemented fix suggested by @box-turtle here https://github.com/erikras/redux-form/issues/446#issuecomment-166014354