### PR TITLE
Correct imported actions

### DIFF
--- a/src/pages/faq/WebsocketSubmit.md
+++ b/src/pages/faq/WebsocketSubmit.md
@@ -11,9 +11,7 @@ replicate its behavior using any other asynchronous paradigm. All you need do is
 `STOP_SUBMIT` actions yourself using the exported [Action Creators](#/api/action-creators).
 
 ```javascript
-import {actionCreators} from 'redux-form';
-
-const {startSubmit, stopSubmit} = actionCreators;
+import {startSubmit, stopSubmit} from 'redux-form';
 
 function submitForm(data, dispatch) {
   // tell redux-form that the submission has started


### PR DESCRIPTION
I noticed that the startSubmit and stopSubmit action creators are actually [ exported](https://github.com/erikras/redux-form/blob/master/src/index.js#L20) from the top level redux-form object. This just corrects the documentation.