### PR TITLE
allow mapDispatchToProps to override dispatch property

### DIFF
--- a/src/wrapMapDispatchToProps.js
+++ b/src/wrapMapDispatchToProps.js
@@ -5,26 +5,26 @@ const wrapMapDispatchToProps = (mapDispatchToProps, actionCreators) => {
     if (typeof mapDispatchToProps === 'function') {
       if (mapDispatchToProps.length > 1) {
         return (dispatch, ownProps) => ({
+          dispatch,
           ...mapDispatchToProps(dispatch, ownProps),
-          ...bindActionCreators(actionCreators, dispatch),
-          dispatch
+          ...bindActionCreators(actionCreators, dispatch)
         });
       }
       return dispatch => ({
+        dispatch,
         ...mapDispatchToProps(dispatch),
-        ...bindActionCreators(actionCreators, dispatch),
-        dispatch
+        ...bindActionCreators(actionCreators, dispatch)
       });
     }
     return dispatch => ({
+      dispatch,
       ...bindActionCreators(mapDispatchToProps, dispatch),
-      ...bindActionCreators(actionCreators, dispatch),
-      dispatch
+      ...bindActionCreators(actionCreators, dispatch)
     });
   }
   return dispatch => ({
-    ...bindActionCreators(actionCreators, dispatch),
-    dispatch
+    dispatch,
+    ...bindActionCreators(actionCreators, dispatch)
   });
 };
 


### PR DESCRIPTION
In my project, I create a wrapper around dispatch to catch promise rejections. Passing in that overridden dispatch function as follows would be nice:

```js
const WrappedForm = reduxForm(
  { form: 'login' },
  state => ({}),
  dispatch => ({ dispatch: bindSafeDispatch(dispatch) }),
)(LoginForm);
```

All tests pass =)