### PR TITLE
Added documentation & example for swapFields() to deep forms

### DIFF
--- a/src/examples/DeepForm.js
+++ b/src/examples/DeepForm.js
@@ -66,14 +66,24 @@ class DeepForm extends Component {
             <div className="col-xs-2">
               <input type="text" className="form-control" placeholder="Child Age" {...child.age}/>
             </div>
-            <div className="col-xs-2">
+            <div className="col-xs-4 btn-toolbar">
               <button className="btn btn-success" onClick={event => {
                 event.preventDefault();   // prevent form submission
                 child.awards.addField();  // pushes empty award field onto the end of the array
               }}><i className="fa fa-trophy"/> Add Award
               </button>
-            </div>
-            <div className="col-xs-2">
+              <div className="btn-group">
+                <button className="btn btn-success" disabled={index === 0} onClick={event => {
+                  event.preventDefault();                 // prevent form submission
+                  children.swapFields(index, index - 1);  // swap field with it's predecessor
+                }}><i className="fa fa-caret-up"/>
+                </button>
+                <button className="btn btn-success" disabled={index === children.length - 1} onClick={event => {
+                  event.preventDefault();                 // prevent form submission
+                  children.swapFields(index, index + 1);  // swap field with it's successor
+                }}><i className="fa fa-caret-down"/>
+                </button>
+              </div>
               <button className="btn btn-danger" onClick={event => {
                 event.preventDefault();       // prevent form submission
                 children.removeField(index);  // remove from index

--- a/src/pages/examples/Deep.md
+++ b/src/pages/examples/Deep.md
@@ -5,9 +5,10 @@ turned into arrays in the `fields` prop given to the decorated form.
 
 Also demonstrated here is how a common component, `<Address/>`, can be used to render a group of fields.
 
-The array fields can be modified by calling `addField(value?, index?)` and `removeField(index?)` _on the array_ 
-inside the `fields` prop. If you do not specify an `index`, they will act like `push()` and `pop()`, modifying the 
-end of the array.
+The array fields can be modified by calling `addField(value?, index?)`, `removeField(index?)` and `swapFields(indexA?, indexB?)` _on the array_
+inside the `fields` prop. If you do not specify an `index` in `addField(value?, index?)` or `removeField(index?)`,
+they will act like `push()` and `pop()`, modifying the end of the array. Calling `swapFields(indexA?, indexB?)` with invalid indexes does not
+modify the array.
 
 Your synchronous validation function will be given the deep data structure and should return a deep data structure of
 errors.


### PR DESCRIPTION
The title speaks for itself. You can now reorder the children by clicking up/down.