### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,7 @@ test
 .babelrc
 .eslint*
 .idea
+.editorconfig
 .npmignore
 .travis.yml
 webpack.*


### PR DESCRIPTION
IntelliJ defaults to 4 space indentation, but respects an editorconfig