### PR TITLE
Update react-lazy-cache to not use getters

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "deep-equal": "^1.0.1",
     "hoist-non-react-statics": "^1.0.3",
     "is-promise": "^2.1.0",
-    "react-lazy-cache": "^3.0.0"
+    "react-lazy-cache": "^3.0.1"
   },
   "devDependencies": {
     "babel": "^5.8.23",

--- a/src/createReduxFormConnector.js
+++ b/src/createReduxFormConnector.js
@@ -1,4 +1,4 @@
-import lazyCache from 'react-lazy-cache';
+import LazyCache from 'react-lazy-cache/noGetters';
 import getDisplayName from './getDisplayName';
 import createHigherOrderComponent from './createHigherOrderComponent';
 
@@ -13,7 +13,7 @@ const createReduxFormConnector =
       class ReduxFormConnector extends Component {
         constructor(props) {
           super(props);
-          this.cache = lazyCache(this, {
+          this.cache = new LazyCache(this, {
             ReduxForm: {
               params: [
                 // props that effect how redux-form connects to the redux store
@@ -33,7 +33,7 @@ const createReduxFormConnector =
         }
 
         render() {
-          const {ReduxForm} = this.cache;
+          const ReduxForm = this.cache.get('ReduxForm');
           // remove some redux-form config-only props
           const {reduxMountPoint, destroyOnUnmount, form, getFormState, touchOnBlur, touchOnChange,
             ...passableProps } = this.props; // eslint-disable-line no-redeclare


### PR DESCRIPTION
IE8: 
![image](https://cloud.githubusercontent.com/assets/1404810/12372074/9a89ae8a-bc4a-11e5-8130-97999d5ef16b.png)

![image](https://cloud.githubusercontent.com/assets/1404810/12372075/a65f3130-bc4a-11e5-8888-8b1dff7f9a2d.png)

You mentioned tests in #517, not sure what sort of tests you want? The existing tests all pass with this change, and the lib used for caching is an implementation detail not to be tested, right?
EDIT: If you meant test it as in functional test in the browser, the example from @gabrielpugliese-luizalabs runs with this change
My change to his example was just to show the validation

![image](https://cloud.githubusercontent.com/assets/1404810/12372086/4a7e7046-bc4b-11e5-965b-eefd8b0b6ab4.png)
