### PR TITLE
Allow initial value to change to falsey value

### DIFF
--- a/src/__tests__/updateField.spec.js
+++ b/src/__tests__/updateField.spec.js
@@ -116,4 +116,11 @@ describe('updateField', () => {
     expect(updateField({visited: true}, {visited: false}, false, undefined).visited).toBe(false);
     expect(updateField({visited: true}, {}, false, undefined).visited).toBe(false);
   });
+
+  it('should change initial and default values when initial changes', () => {
+    expect(updateField({ initialValue: 1, defaultValue: 1 }, { initial: 2 }, false, undefined).initialValue).toBe(2);
+    expect(updateField({ initialValue: 1, defaultValue: 1 }, { initial: 2 }, false, undefined).defaultValue).toBe(2);
+    expect(updateField({ initialValue: 1, defaultValue: 1 }, { initial: undefined }, false, undefined).initialValue).toBe(undefined);
+    expect(updateField({ initialValue: 1, defaultValue: 1 }, { initial: undefined }, false, undefined).defaultValue).toBe(undefined);
+  });
 });

--- a/src/updateField.js
+++ b/src/updateField.js
@@ -43,7 +43,7 @@ const updateField = (field, formField, active, syncError) => {
     diff.visited = visited;
   }
 
-  if (formField.initial && formField.initial !== field.initialValue) {
+  if ('initial' in formField && formField.initial !== field.initialValue) {
     field.defaultChecked = formField.initial === true;
     field.defaultValue = formField.initial;
     field.initialValue = formField.initial;


### PR DESCRIPTION
Fixes: https://github.com/erikras/redux-form/issues/559

This allows `initialValue` and `defaultValue` to be changed to falsey values, but prevents updates when there is no `initial` key on the field