### PR TITLE
Preserve non-enumerable fields when normalizing

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -239,14 +239,15 @@ function decorate(target) {
             };
             return {
               ...formResult,
-              ...mapValues(formNormalizers, (fieldNormalizer, field) => ({
-                ...formResult[field],
-                value: makeFieldValue(fieldNormalizer(
+              ...mapValues(formNormalizers, (fieldNormalizer, field) => {
+                const newValue = makeFieldValue(fieldNormalizer(
                   formResult[field] ? formResult[field].value : undefined,         // value
                   previous && previous[field] ? previous[field].value : undefined, // previous value
                   getValuesFromState(formResult),                                  // all field values
-                  previousValues))                                                 // all previous field values
-              }))
+                  previousValues));                                                // all previous field values
+
+                return Object.assign(formResult[field] || {}, { value: newValue });
+              })
             };
           };
           if (action.key) {


### PR DESCRIPTION
Potentially fixes https://github.com/erikras/redux-form/issues/393

I don't know where the code for the examples is, so I can't be sure if this is the source of the problem that was originally reported, but this fixes the problem that I was having, which is that fields which use a normalizer are unable to be reset with `resetForm`

The source of the issue here is that `_isFieldValue` is non enumerable, so the spread isn't copying it when computing the final object. However, `_isFieldValue` is needed for the reducer to handle the `RESET` action correctly.

There are a couple different approaches I can think of to handle this and this is probably the least clean, but in `fieldValues.makeField`, it's explicitly using `defineProperty`, which I can only assume is to make `_isFieldValue` non enumerable for some reason. Sure enough, making it enumerable breaks a bunch of tests.

I also couldn't figure out a reasonable way to test this, so I'm open to feedback on how I can improve this PR