### PR TITLE
Disallow async validation when the form is pristine

### DIFF
--- a/src/createHigherOrderComponent.js
+++ b/src/createHigherOrderComponent.js
@@ -66,9 +66,10 @@ const createHigherOrderComponent = (config,
             values[name] = value;
           }
           const syncErrors = validate(values, this.props);
+          const { allPristine } = this.fields._meta;
 
-          // if blur validating, only run async validate if sync validation passes
-          if (!name || isValid(syncErrors[name])) {
+          // if blur validating, only run async validate if the form is dirty and sync validation passes
+          if (!allPristine && (!name || isValid(syncErrors[name]))) {
             return asyncValidation(() =>
               asyncValidate(values, dispatch, this.props), startAsyncValidation, stopAsyncValidation, name);
           }


### PR DESCRIPTION
This fix addresses an issue where forms with `asyncValidate` and `asyncBlurFields` specified call `asyncValidate` on every blur, even when the form has not been changed from its initial values.

@erikras please let me know if you have any other ideas on how to handle this one.