### PR TITLE
fixes #596 - handle unexpected/unhandled async error

### DIFF
--- a/src/__tests__/createReduxForm.spec.js
+++ b/src/__tests__/createReduxForm.spec.js
@@ -8,6 +8,7 @@ import {combineReducers, createStore} from 'redux';
 import {Provider} from 'react-redux';
 import reducer from '../reducer';
 import createReduxForm from '../createReduxForm';
+import SubmissionError from '../submissionError';
 
 const createRestorableSpy = (fn) => {
   return createSpy(fn, function restore() {
@@ -1696,7 +1697,7 @@ describe('createReduxForm', () => {
       form,
       fields: ['name'],
       initialValues: {name: 'Tom'},
-      onSubmit: () => Promise.reject({name: deepError})
+      onSubmit: () => Promise.reject(new SubmissionError({name: deepError}))
     })(Form);
     const dom = TestUtils.renderIntoDocument(
       <Provider store={store}>

--- a/src/createAll.js
+++ b/src/createAll.js
@@ -6,6 +6,7 @@ import * as actions from './actions';
 import * as actionTypes from './actionTypes';
 import createPropTypes from './createPropTypes';
 import getValues from './getValuesFromState';
+import SubmissionError from './submissionError';
 
 // bind form as first parameter of action creators
 const boundActions = {
@@ -67,6 +68,7 @@ export default function createAll(isReactNative, React, connect) {
     touch,
     touchWithKey,
     untouch,
-    untouchWithKey
+    untouchWithKey,
+    SubmissionError
   };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -26,5 +26,6 @@ export const {
   touch,
   touchWithKey,
   untouch,
-  untouchWithKey
+  untouchWithKey,
+  SubmissionError
 } = createAll(false, React, connect);

--- a/src/submissionError.js
+++ b/src/submissionError.js
@@ -1,0 +1,12 @@
+function SubmissionError(opts) {
+  if (!opts) {
+    throw new ReferenceError('missing field keys or _error key');
+  }
+  if (!Object.keys(opts).length) {
+    opts._error = 'Form submission failed';
+  }
+  Object.assign(this, opts);
+}
+SubmissionError.prototype = Object.create(Error.prototype);
+SubmissionError.prototype.constructor = SubmissionError;
+export default SubmissionError;


### PR DESCRIPTION
# problem statement
if an unexpected application error occurs in `handleSubmit`, it will swallow it.  this is because handleSubmit _expects_ an error filled with error messages for respective fields.  however, async actions can be complicated.  400s, 500s, bad application code, etc can all be at play, and simply get eaten up because of thoughtful, but risky strategy of using all rejections as mechanisms to put `error`s strictly into form state.

for me, this meant meaningful information about my failing application was hidden from me.

# solution
distinguish between expected errors and unexpected errors.

my proposed strategy is to wrap all submission/validation errors in a `SubmissionError`.  if any other error occurs, the rejection will flow to the users `.catch` or `.on('uncaughtRejection', ...)` handler.

in this regard, we can safely know to update the state, or explode because our app died.  if the reviewer finds such a strategy agreeable, it's well known that this is a major bump and requires documentation updates. i'd imagine some folks may really not like having to type all 15 characters of `SubmissionError`, but I think it's well worth it.  Alternatives may be a `cb(errorFields)` strategy, but no matter what, separating good errors from bad errors is a major.  This is actually a pretty low impact, code-wise!