### PR TITLE
Fix for react-native 0.18+ with react-redux 4+

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,8 @@ import React from 'react';
 import {connect} from 'react-redux';
 import createAll from './createAll';
 
+const isNative = window.navigator && window.navigator.product && window.navigator.product === 'ReactNative';
+
 export const {
   actionTypes,
   addArrayValue,
@@ -27,4 +29,4 @@ export const {
   touchWithKey,
   untouch,
   untouchWithKey
-} = createAll(false, React, connect);
+} = createAll(isNative, React, connect);


### PR DESCRIPTION
redux-form/native depends on react-redux/native which does not exist in react-redux 4+.
So the original redux-form has to be used instead. But it passes isNative as false, so most functions won't work.
A detection for react-native environment in index.js fixes the issue.