### PR TITLE
Update ImmutableJS example to fix focus issue

### DIFF
--- a/src/pages/faq/ImmutableJs.md
+++ b/src/pages/faq/ImmutableJs.md
@@ -23,7 +23,7 @@ import Immutable from 'immutable';
 
 export const reducer = combineReducers({
   // ...your other reducers
-  form: (state, action) => Immutable.fromJS(formReducer(state, action));  // <--- IMPORTANT PART
+  form: (state = Immutable.fromJS({}), action) => Immutable.fromJS(formReducer(state.toJS(), action));  // <--- IMPORTANT PART
 });
 ```
 


### PR DESCRIPTION
The example for ImmutableJS currently has an [issue](https://github.com/itaylor/redux-form-immutablejs-example/issues/1) where a form with multiple fields will lose the content of other fields when you focus into a new field. This adds the second fix described in that issue, where all state is kept in an immutable object.