### PR TITLE
Return promise when callback function is passed to handleSubmit

### DIFF
--- a/src/__tests__/handleSubmit.spec.js
+++ b/src/__tests__/handleSubmit.spec.js
@@ -34,13 +34,14 @@ describe('handleSubmit', () => {
   it('should stop and return rejected promise if sync validation fails and returnRejectedSubmitPromise', (done) => {
     const values = {foo: 'bar', baz: 42};
     const fields = ['foo', 'baz'];
+    const errorValue = {foo: 'error'};
     const submit = createSpy().andReturn(69);
     const touch = createSpy();
     const startSubmit = createSpy();
     const stopSubmit = createSpy();
     const submitFailed = createSpy();
     const asyncValidate = createSpy();
-    const validate = createSpy().andReturn({foo: 'error'});
+    const validate = createSpy().andReturn(errorValue);
     const props = {fields, startSubmit, stopSubmit, submitFailed, touch, validate, returnRejectedSubmitPromise: true};
 
     const result = handleSubmit(submit, values, props, asyncValidate);
@@ -59,7 +60,10 @@ describe('handleSubmit', () => {
     expect(submitFailed).toHaveBeenCalled();
     result.then(() => {
       expect(false).toBe(true); // should not be in resolve branch
-    }, done);
+    }, (error) => {
+      expect(error).toBe(errorValue);
+      done();
+    });
   });
 
   it('should return result of sync submit', () => {

--- a/src/createHigherOrderComponent.js
+++ b/src/createHigherOrderComponent.js
@@ -90,7 +90,7 @@ const createHigherOrderComponent = (config,
           // submitOrEvent is the submit function: return deferred submit thunk
           silenceEvents(event => {
             silenceEvent(event);
-            handleSubmit(check(submitOrEvent), getValues(fields, form), this.props, this.asyncValidate);
+            return handleSubmit(check(submitOrEvent), getValues(fields, form), this.props, this.asyncValidate);
           });
       }
 

--- a/src/handleSubmit.js
+++ b/src/handleSubmit.js
@@ -34,7 +34,7 @@ const handleSubmit = (submit, values, props, asyncValidate) => {
   submitFailed();
 
   if (returnRejectedSubmitPromise) {
-    return Promise.reject();
+    return Promise.reject(syncErrors);
   }
 };
 


### PR DESCRIPTION
fix for #580 
I hope there is no problem how it should be!

I'm not very sure if other Promise.reject in handleSubmit.js should return rejected promise with the validation errors. 
To be more specific,  here. https://github.com/haradakunihiko/redux-form/blob/master/src/handleSubmit.js#L30