### PR TITLE
Normalize nested fields

### DIFF
--- a/src/normalizeFields.js
+++ b/src/normalizeFields.js
@@ -1,0 +1,103 @@
+import {makeFieldValue} from './fieldValue';
+
+function extractKey(field) {
+  const dotIndex = field.indexOf('.');
+  const openIndex = field.indexOf('[');
+  const closeIndex = field.indexOf(']');
+
+  if (openIndex > 0 && closeIndex !== openIndex + 1) {
+    throw new Error('found [ not followed by ]');
+  }
+
+  const isArray = openIndex > 0 && (dotIndex < 0 || openIndex < dotIndex);
+  let key;
+  let nestedPath;
+
+  if (isArray) {
+    key = field.substring(0, openIndex);
+    nestedPath = field.substring(closeIndex + 1);
+
+    if (nestedPath[0] === '.') {
+      nestedPath = nestedPath.substring(1);
+    }
+  } else if (dotIndex > 0) {
+    key = field.substring(0, dotIndex);
+    nestedPath = field.substring(dotIndex + 1);
+  } else {
+    key = field;
+  }
+
+  return { isArray, key, nestedPath };
+}
+
+function normalizeField(field, fullFieldPath, state, previousState, values, previousValues, normalizers) {
+  if (field.isArray && field.nestedPath) {
+    const array = state && state[field.key] || [];
+    const previousArray = previousState && previousState[field.key] || [];
+    const nestedField = extractKey(field.nestedPath);
+
+    return array.map((nestedState, i) => {
+      nestedState[nestedField.key] = normalizeField(
+        nestedField,
+        fullFieldPath,
+        nestedState,
+        previousArray[i],
+        values,
+        previousValues,
+        normalizers
+      );
+
+      return nestedState;
+    });
+  } else if (field.nestedPath) {
+    const nestedState = state && state[field.key] || {};
+    const nestedField = extractKey(field.nestedPath);
+
+    nestedState[nestedField.key] = normalizeField(
+      nestedField,
+      fullFieldPath,
+      nestedState,
+      previousState && previousState[field.key],
+      values,
+      previousValues,
+      normalizers
+    );
+
+    return nestedState;
+  }
+
+  const finalField = state && state[field.key] || {};
+  const normalizer = normalizers[fullFieldPath];
+
+  finalField.value = normalizer(
+    finalField.value,
+    previousState && previousState[field.key] && previousState[field.key].value,
+    values,
+    previousValues
+  );
+
+  return makeFieldValue(finalField);
+}
+
+export default function normalizeFields(normalizers, state, previousState, values, previousValues) {
+  const newState = Object.keys(normalizers).reduce((accumulator, field) => {
+    const extracted = extractKey(field);
+
+    accumulator[extracted.key] = normalizeField(
+      extracted,
+      field,
+      state,
+      previousState,
+      values,
+      previousValues,
+      normalizers
+    );
+
+    return accumulator;
+  }, {});
+
+  return {
+    ...state,
+    ...newState
+  };
+}

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -8,6 +8,7 @@ import initializeState from './initializeState';
 import resetState from './resetState';
 import setErrors from './setErrors';
 import {makeFieldValue} from './fieldValue';
+import normalizeFields from './normalizeFields';
 
 export const globalErrorKey = '_error';
 
@@ -237,18 +238,8 @@ function decorate(target) {
               ...initialState,
               ...currentResult
             };
-            return {
-              ...formResult,
-              ...mapValues(formNormalizers, (fieldNormalizer, field) => {
-                const newValue = makeFieldValue(fieldNormalizer(
-                  formResult[field] ? formResult[field].value : undefined,         // value
-                  previous && previous[field] ? previous[field].value : undefined, // previous value
-                  getValuesFromState(formResult),                                  // all field values
-                  previousValues));                                                // all previous field values
-
-                return Object.assign(formResult[field] || {}, { value: newValue });
-              })
-            };
+            const values = getValuesFromState(formResult);
+            return normalizeFields(formNormalizers, formResult, previous, values, previousValues);
           };
           if (action.key) {
             return {


### PR DESCRIPTION
This is my first hacky stab at fixing #516 after I realized I needed this functionality yesterday :)

The code has some repetitiveness and isn't the cleanest at the moment. All current tests pass, and I added some minimal nested fields to existing tests to ensure they work. Regardless, we might want some more tests. I also made sure to replicate the work done in #562 recently to preserve non-enumerable keys, but we might want tests for that as well.

I took the approach of nested normalizers instead of using the nested key sytax (e.g. `foo[].bar`). I found it easier to walk down the state and normalizer objects at the same time with this approach. Using the nested key syntax was a little more difficult.

For an idea of the syntax here is a test I changed:

```js
it('should normalize simple form values', () => {
  const defaultFields = {
    _active: undefined,
    _asyncValidating: false,
    [globalErrorKey]: undefined,
    _initialized: false,
    _submitting: false,
    _submitFailed: false
  };
  const normalize = reducer.normalize({
    foo: {
      name: () => 'normalized',
      person: {
        name: (name) => name && name.toUpperCase()
      },
      'pets[]': {
        name: (name) => name && name.toLowerCase()
      }
    }
  });
  const state = normalize({
    foo: {
      name: {
        value: 'dog'
      },
      person: {
        name: {
          value: 'John Doe',
        }
      },
      pets: [
        { name: { value: 'Fido' } },
        { name: { value: 'Tucker' } }
      ]
    }
  });
  expect(state)
    .toExist()
    .toBeA('object');
  expect(state.foo)
    .toExist()
    .toBeA('object')
    .toEqual({
      ...defaultFields,
      name: {
        value: 'normalized'
      },
      person: {
        name: {
          value: 'JOHN DOE'
        }
      },
      pets: [
        { name: { value: 'fido' } },
        { name: { value: 'tucker' } }
      ]
    });
});
```

One thing I'm still figuring out is how to handle this array situation:

```js
const normalize = reducer.normalize({
  // Array contains string field values
  'hobbies[]': (value) => value && value.toUpperCase()

  // Or array IS the field value
  'hobbies[]': (array) => array && array.map(hobby => hobby.toUpperCase())

  // Or array contains nested fields
  'people[]': (person) => {
    if (person) {
      return { name: person.name.toUpperCase() };
    }
    return { name: '' };
  }
});
```

Basically, if you don't specify nested properties, do you assume the array is a field value or that it still contains nested field values? What happens if the nested values have nested properties of their own? What would you expect to be the use case for this syntax? Or don't support it? If those questions don't make sense, let me know. Right now, I just have it assume that the array itself is the field value if you don't specify nested properties.

Please let me know if this is what you would like to see for normalizing nested fields and what I need to modify with this implementation.