### PR TITLE
Stop mutating state in initialize reducer 

### DIFF
--- a/src/initializeState.js
+++ b/src/initializeState.js
@@ -21,7 +21,7 @@ const initializeState = (values, fields, state = {}) => {
     }
     const openIndex = path.indexOf('[');
     const closeIndex = path.indexOf(']');
-    const result = dest || {};
+    const result = {...dest} || {};
     if (dotIndex >= 0 && (openIndex < 0 || dotIndex < openIndex)) {
       // is dot notation
       const key = path.substring(0, dotIndex);


### PR DESCRIPTION
I think calling initialize action with deep form does not pass new fields to my component.
`componentWillReceiveProps` function in ReduxForm component is trying to check the previous props and current props, but the previous form props and current form props is almost same when I define deeply nested form.(https://github.com/erikras/redux-form/blob/master/src/createHigherOrderComponent.js#L47)

The reason seems that the previous state is mutated in initialize reducer.
Sorry I could not write test cases to reproduce this, since I do not have much time for this right now...