### PR TITLE
cloned field array on change

### DIFF
--- a/src/__tests__/createReduxForm.spec.js
+++ b/src/__tests__/createReduxForm.spec.js
@@ -1304,6 +1304,8 @@ describe('createReduxForm', () => {
     expect(stub.props.fields.users.length).toBe(0);
     expect(stub.props.fields.users.addField).toBeA('function');
 
+    const before = stub.props.fields.users;
+
     // add field
     stub.props.fields.users.addField({name: 'Bob', age: 27});
 
@@ -1332,6 +1334,8 @@ describe('createReduxForm', () => {
       touched: false,
       visited: false
     });
+    const after = stub.props.fields.users;
+    expect(after).toNotBe(before);  // should be a new instance
 
     // check state
     expect(store.getState().form.testForm.users).toBeA('array');

--- a/src/readField.js
+++ b/src/readField.js
@@ -39,8 +39,8 @@ const readField = (state, fieldName, pathToHere = '', fields, syncErrors, asyncV
         return accumulator;
       }, [])
       .map(field => getSuffix(field, prefix.length + closeIndex));
-    if (!fields[key]) {
-      fields[key] = [];
+    if (!fields[key] || fields[key].length !== stateArray.length) {
+      fields[key] = fields[key] ? [...fields[key]] : [];
       Object.defineProperty(fields[key], 'addField', {
         value: (value, index) => addArrayValue(pathToHere + key, value, index, subfields)
       });


### PR DESCRIPTION
The field arrays were being mutated. They should be cloned whenever a field is added or removed.