### PR TITLE
fix Getting Started link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ## Documentation
 
-* [Getting Started](http://redux-form.com/#/docs/GettingStarted.md)
+* [Getting Started](http://redux-form.com/#/getting-started)
 * [Examples](http://redux-form.com/#/examples)
 * [API](http://redux-form.com/#/api)
 * [FAQ](http://redux-form.com/#/faq)


### PR DESCRIPTION
This pull request fixes the invalid getting started link listed in the readme.

**Previous value**

* [Getting Started](http://redux-form.com/#/docs/GettingStarted.md)`

**Fix value**

* [Getting Started](http://redux-form.com/#/getting-started)