### PR TITLE
[BUG] Fix support for async validation with onSubmitFail

### DIFF
--- a/src/__tests__/handleSubmit.spec.js
+++ b/src/__tests__/handleSubmit.spec.js
@@ -329,7 +329,9 @@ describe('handleSubmit', () => {
           .toHaveBeenCalledWith(submitErrors);
         expect(submitFailed).toNotHaveBeenCalled();
         expect(onSubmitSuccess).toNotHaveBeenCalled();
-        expect(onSubmitFail).toNotHaveBeenCalled();
+        expect(onSubmitFail)
+          .toHaveBeenCalled()
+          .toHaveBeenCalledWith(submitErrors);
       }, () => {
         expect(false).toBe(true); // should not get into reject branch
       });
@@ -377,7 +379,9 @@ describe('handleSubmit', () => {
           .toHaveBeenCalledWith(submitErrors);
         expect(submitFailed).toNotHaveBeenCalled();
         expect(onSubmitSuccess).toNotHaveBeenCalled();
-        expect(onSubmitFail).toNotHaveBeenCalled();
+        expect(onSubmitFail)
+          .toHaveBeenCalled()
+          .toHaveBeenCalledWith(submitErrors);
       });
   });
 });

--- a/src/handleSubmit.js
+++ b/src/handleSubmit.js
@@ -21,6 +21,9 @@ const handleSubmit = (submit, values, props, asyncValidate) => {
           return submitResult;
         }, submitError => {
           stopSubmit(submitError);
+          if (onSubmitFail) {
+            onSubmitFail(submitError);
+          }
           if (returnRejectedSubmitPromise) {
             return Promise.reject(submitError);
           }


### PR DESCRIPTION
The initial implementation of onSubmitFail was not reporting failures correctly for asynchronous validation functions, instead it didn't do anything. This was not the intended behavior.

This was an overlook on my part, as I didn't include this in the initial implementation. I hope I fixed up the issue before anyone else experienced this in their code.