### PR TITLE
Fix #621 - Account for initialValues in getValues

### DIFF
--- a/src/__tests__/getValues.spec.js
+++ b/src/__tests__/getValues.spec.js
@@ -18,6 +18,21 @@ describe('getValues', () => {
       });
   });
 
+  it('should fallback to initialValues when values are undefined', () => {
+    const form = {
+      someText: {value: 'Hello Again!', initialValue: 'Hello'},
+      someArray: {value: undefined, initialValue: [1, 2, 3]},
+      someBool: {value: undefined, initialValue: false},
+    };
+    const fields = ['someText', 'someArray', 'someBool'];
+    expect(getValues(fields, form))
+      .toEqual({
+        someText: 'Hello Again!',
+        someArray: [1, 2, 3],
+        someBool: false,
+      });
+  });
+
   it('should allow undefined values', () => {
     const form = {
       foo: {value: 'bar'}
@@ -59,7 +74,7 @@ describe('getValues', () => {
     const form = {
       foo: [
         {value: 'bar'},
-        {value: 'baz'},
+        {value: undefined, initialValue: 'baz'},
         {}
       ],
       alive: {value: true}

--- a/src/getValues.js
+++ b/src/getValues.js
@@ -1,3 +1,11 @@
+/**
+ * Given a state[field], get the value.
+ *  Fallback to .initialValue when .value is undefined to prevent double render/initialize cycle.
+ *  See {@link https://github.com/erikras/redux-form/issues/621}.
+ */
+const itemToValue =
+  ({value, initialValue}) => typeof value !== 'undefined' ? value : initialValue;
+
 const getValue = (field, state, dest) => {
   const dotIndex = field.indexOf('.');
   const openIndex = field.indexOf('[');
@@ -24,7 +32,7 @@ const getValue = (field, state, dest) => {
         getValue(rest, item, dest[key][index]);
       });
     } else {
-      dest[key] = array.map(item => item && item.value);
+      dest[key] = array.map(itemToValue);
     }
   } else if (dotIndex > 0) {
     // subobject field
@@ -35,7 +43,7 @@ const getValue = (field, state, dest) => {
     }
     getValue(rest, state && state[key] || {}, dest[key]);
   } else {
-    dest[field] = state[field] && state[field].value;
+    dest[field] = state[field] && itemToValue(state[field]);
   }
 };
 


### PR DESCRIPTION
- [x] getValues - should fallback to initialValues when values are undefined

Previously, form values were not being initialized from initialValues until the 2nd render cycle. This caused difficulties with server side rendering, double render cycles, and other related pains.

See https://github.com/erikras/redux-form/issues/621 for more discussion and links to possibly related issues.

This is addressed by falling back to `field.initialValue` when `field.value` is `undefined`

```js
/**
 * Given a state[field], get the value.
 *  Fallback to .initialValue when .value is undefined to prevent double render/initialize cycle.
 *  See {@link https://github.com/erikras/redux-form/issues/621}.
 */
const itemToValue =
  ({value, initialValue}) => typeof value !== 'undefined' ? value : initialValue;
```

:memo: this also affected array fields. This was accounted for in both implementation and existing test.