### PR TITLE
Add alwaysAsyncValidate option, to always perform async validation on blur

### DIFF
--- a/docs/api/ReduxForm.md
+++ b/docs/api/ReduxForm.md
@@ -1,7 +1,7 @@
 # `reduxForm(config:Object, mapStateToProps?, mapDispatchToProps?, mergeProps?, options?)`
 
-Creates a decorator with which you use `redux-form` to connect your form component to Redux. It takes a `config` 
-parameter and then optionally `mapStateToProps`, `mapDispatchToProps`, `mergeProps` and `options` parameters which 
+Creates a decorator with which you use `redux-form` to connect your form component to Redux. It takes a `config`
+parameter and then optionally `mapStateToProps`, `mapDispatchToProps`, `mergeProps` and `options` parameters which
 [correspond exactly to the parameters taken by `react-redux`'s `connect()`
 function](https://github.com/rackt/react-redux/blob/master/docs/api.md#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options),
 allowing you to connect your form component to other state in Redux.
@@ -32,25 +32,34 @@ props to your component at runtime.**
 
 ### Optional
 
+#### -`alwaysAsyncValidate : boolean` [optional]
+
+> By default, async blur validation is only triggered if synchronous validation passes, and the form is dirty or was
+never initialized (or if submitting). Sometimes it may be desirable to trigger asynchronous validation even in these
+cases, for example if all validation is performed asynchronously and you want to display validation messages if a
+user does not change a field, but does touch and blur it. Setting alwaysAsyncValidate to `true` will always run
+asynchronous validation on blur, even if the form is pristine or sync validation fails.
+
+
 #### -`asyncBlurFields : Array<String>` [optional]
 
 > field names for which `onBlur` should trigger a call to the `asyncValidate` function. Defaults to `[]`.
 
-> See [Asynchronous Blur Validation Example](../../examples/asynchronous-blur-validation) for more 
+> See [Asynchronous Blur Validation Example](../../examples/asynchronous-blur-validation) for more
 details.
 
 #### `asyncValidate : (values:Object, dispatch:Function, props:Object) => Promise<undefined, errors:Object>` [optional]
 
-> a function that takes all the form values, the `dispatch` function, and the `props` given to your component, and 
+> a function that takes all the form values, the `dispatch` function, and the `props` given to your component, and
 returns a Promise that will resolve if the validation is passed, or will reject with an object of validation errors
 in the form `{ field1: <String>, field2: <String> }`.
 
-> See [Asynchronous Blur Validation Example](../../examples/asynchronous-blur-validation) for more 
+> See [Asynchronous Blur Validation Example](../../examples/asynchronous-blur-validation) for more
 details.
 
 #### `destroyOnUnmount : boolean` [optional]
 
-> Whether or not to automatically destroy your form's state in the Redux store when your component is unmounted. 
+> Whether or not to automatically destroy your form's state in the Redux store when your component is unmounted.
 Defaults to `true`.
 
 #### `formKey : String` [optional]
@@ -62,15 +71,15 @@ Defaults to `true`.
 #### `getFormState : Function` [optional]
 
 > A function that takes the entire Redux state and the `reduxMountPoint` (which defaults to `"form"`). It defaults to:
-`(state, reduxMountPoint) => state[reduxMountPoint]`. The only reason you should provide this is if you are keeping 
+`(state, reduxMountPoint) => state[reduxMountPoint]`. The only reason you should provide this is if you are keeping
 your Redux state as something other than plain javascript objects, e.g. an
 [`Immutable.Map`](https://github.com/facebook/immutable-js).
 
 #### `initialValues : Object<String, String>` [optional]
 
 > The values with which to initialize your form in `componentWillMount()`. Particularly useful when
-[Editing Multiple Records](../../examples/multirecord), but can also be used with single-record 
-forms. The values 
+[Editing Multiple Records](../../examples/multirecord), but can also be used with single-record
+forms. The values
 should be in the form `{ field1: 'value1', field2: 'value2' }`.
 
 #### `onSubmit : Function` [optional]
@@ -81,25 +90,25 @@ do not specify it as a prop here, you must pass it as a parameter to `handleSubm
 > If your `onSubmit` function returns a promise, the `submitting` property will be set to
 `true` until the promise has been resolved or rejected. If it is rejected with an object matching
 `{ field1: 'error', field2: 'error' }` then the submission errors will be added to each field (to the
-`error` prop) just like async validation errors are. If there is an error that is not specific 
+`error` prop) just like async validation errors are. If there is an error that is not specific
 to any field, but applicable to the entire form, you may pass that as if it were the error for a field
 called `_error`, and it will be given as the `error` prop.
 
 #### `propNamespace : string` [optional]
 
-> If specified, all the props normally passed into your decorated component directly will be passed under the key 
+> If specified, all the props normally passed into your decorated component directly will be passed under the key
 specified. Useful if using other decorator libraries on the same component to avoid prop namespace collisions.
 
 #### `readonly : boolean` [optional]
 
-> if `true`, the decorated component will not be passed any of the `onX` functions as props that will allow 
+> if `true`, the decorated component will not be passed any of the `onX` functions as props that will allow
 it to mutate the state. Useful for decorating another component that is not your form, but that needs to know
 about the state of your form.
 
 #### `reduxMountPoint : String` [optional]
 
-> The use of this property is highly discouraged, but if you absolutely need to mount your `redux-form` reducer at 
-somewhere other than `form` in your Redux state, you will need to specify the key you mounted it under with this 
+> The use of this property is highly discouraged, but if you absolutely need to mount your `redux-form` reducer at
+somewhere other than `form` in your Redux state, you will need to specify the key you mounted it under with this
 property. Defaults to `'form'`.
 
 > See [Alternate Mount Point Example](../../examples/alternate-mount-point) for more details.
@@ -124,4 +133,3 @@ If validation passes, it should return `{}`. If validation fails, it should retu
 form `{ field1: <String>, field2: <String> }`. Defaults to `(values, props) => ({})`.
 
 > See [Synchronous Validation Example](../../examples/synchronous-validation) for more details.
-

--- a/src/__tests__/createReduxForm.spec.js
+++ b/src/__tests__/createReduxForm.spec.js
@@ -1082,6 +1082,33 @@ describe('createReduxForm', () => {
     expect(submit).toNotHaveBeenCalled();
   });
 
+  it('should call async validation if form is pristine and initialized but alwaysAsyncValidate is true', () => {
+    const store = makeStore();
+    const form = 'testForm';
+    const errorValue = { foo: 'no bears allowed' };
+    const asyncValidate = createSpy().andReturn(Promise.reject(errorValue));
+    const Decorated = reduxForm({
+      form,
+      fields: [ 'foo', 'bar' ],
+      asyncValidate,
+      asyncBlurFields: [ 'foo' ],
+      alwaysAsyncValidate: true,
+      initialValues: {
+        foo: 'dog',
+        bar: 'cat'
+      }
+    })(Form);
+    const dom = TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <Decorated/>
+      </Provider>
+    );
+    const stub = TestUtils.findRenderedComponentWithType(dom, Form);
+
+    stub.props.fields.foo.onBlur('dog');
+    expect(asyncValidate).toHaveBeenCalled();
+  });
+
   it('should call submit function passed to handleSubmit', (done) => {
     const submit = (values) => {
       expect(values).toEqual({

--- a/src/createHigherOrderComponent.js
+++ b/src/createHigherOrderComponent.js
@@ -61,7 +61,7 @@ const createHigherOrderComponent = (config,
       }
 
       asyncValidate(name, value) {
-        const {asyncValidate, dispatch, fields, form, startAsyncValidation, stopAsyncValidation, validate} = this.props;
+        const {alwaysAsyncValidate, asyncValidate, dispatch, fields, form, startAsyncValidation, stopAsyncValidation, validate} = this.props;
         const isSubmitting = !name;
         if (asyncValidate) {
           const values = getValues(fields, form);
@@ -74,8 +74,9 @@ const createHigherOrderComponent = (config,
 
           // if blur validating, only run async validate if sync validation passes
           // and submitting (not blur validation) or form is dirty or form was never initialized
+          // unless alwaysAsyncValidate is true
           const syncValidationPasses = isSubmitting || isValid(syncErrors[name]);
-          if (syncValidationPasses && (isSubmitting || !allPristine || !initialized)) {
+          if (alwaysAsyncValidate || (syncValidationPasses && (isSubmitting || !allPristine || !initialized))) {
             return asyncValidation(() =>
               asyncValidate(values, dispatch, this.props), startAsyncValidation, stopAsyncValidation, name);
           }
@@ -145,6 +146,7 @@ const createHigherOrderComponent = (config,
     ReduxForm.WrappedComponent = WrappedComponent;
     ReduxForm.propTypes = {
       // props:
+      alwaysAsyncValidate: PropTypes.bool,
       asyncBlurFields: PropTypes.arrayOf(PropTypes.string),
       asyncValidate: PropTypes.func,
       dispatch: PropTypes.func.isRequired,


### PR DESCRIPTION
Submitting this as a "straw man" solution to https://github.com/erikras/redux-form/issues/614. For my use case, I always want to perform asynchronous validation, even if the form is pristine (e.g. for required fields which have been touched) and this seemed like the most direct way to achieve it. Happy to discuss further if this is not ideal though!

--

This allows forms which use purely async validation to perform validation even if a field's value has been changed (e.g. show an error message if a user touches a required field, does not change it, then blurs it).

See https://github.com/erikras/redux-form/issues/614 and https://github.com/erikras/redux-form/issues/742 for example use cases.