### PR TITLE
[V6] Use lodash.values instead of Object.values

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "lodash.mapvalues": "^4.2.0",
     "lodash.noop": "^3.0.1",
     "lodash.partial": "^4.1.3",
-    "lodash.topath": "^4.2.0"
+    "lodash.topath": "^4.2.0",
+    "lodash.values": "^4.1.0"
   },
   "devDependencies": {
     "babel-cli": "^6.3.17",

--- a/src/reduxForm.js
+++ b/src/reduxForm.js
@@ -10,7 +10,7 @@ import silenceEvent from './events/silenceEvent'
 import silenceEvents from './events/silenceEvents'
 import asyncValidation from './asyncValidation'
 import plain from './structure/plain'
-import values from 'lodash.values';
+import values from 'lodash.values'
 
 const { blur, change, focus, ...formActions } = importedActions
 

--- a/src/reduxForm.js
+++ b/src/reduxForm.js
@@ -10,6 +10,7 @@ import silenceEvent from './events/silenceEvent'
 import silenceEvents from './events/silenceEvents'
 import asyncValidation from './asyncValidation'
 import plain from './structure/plain'
+import values from 'lodash.values';
 
 const { blur, change, focus, ...formActions } = importedActions
 
@@ -108,7 +109,7 @@ const createReduxForm =
           }
 
           get fieldList() {
-            return Object.values(this.fields).map(field => field.name)
+            return values(this.fields).map(field => field.name)
           }
 
           asyncValidate(name, value) {


### PR DESCRIPTION
Since Object.values is not currently widely supported, it may be a safer option to use lodash version instead!