### PR TITLE
fixes File transformed to Object after setErrors()

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "eslint-plugin-react": "^3.16.1",
     "expect": "^1.14.0",
     "isparta": "^4.0.0",
-    "jsdom": "~5.4.3",
+    "jsdom": "^8.4.1",
     "mocha": "^2.4.5",
     "mocha-lcov-reporter": "^1.1.0",
     "react": "^15.0.0",

--- a/src/__tests__/setup.js
+++ b/src/__tests__/setup.js
@@ -3,3 +3,4 @@ import { jsdom } from 'jsdom';
 global.document = jsdom('<!doctype html><html><body></body></html>');
 global.window = document.defaultView;
 global.navigator = global.window.navigator;
+global.File = global.window.File;

--- a/src/setErrors.js
+++ b/src/setErrors.js
@@ -25,6 +25,9 @@ const setErrors = (state, errors, destKey) => {
     }
     return makeFieldValue(state);
   };
+  if (state instanceof File) {
+    return state;
+  }
   if (!errors) {
     if (!state) {
       return state;


### PR DESCRIPTION
fixes #740
I was trying to reproduce it with tests without a success, but was easy to reproduce it in  
browser, I guess jsdom acts differently then browsers.
So i'm attaching screenshots of the issue before the fix and after:
Before failed validation:
<img width="695" alt="before_validation" src="https://cloud.githubusercontent.com/assets/36814/14927592/830c0448-0e5b-11e6-9ef8-6ef36432e939.png">

After failed validation before the fix:
<img width="590" alt="after validation_broken" src="https://cloud.githubusercontent.com/assets/36814/14927606/98f8b314-0e5b-11e6-8131-c327301f64ce.png">

After failed validation with fix:
<img width="688" alt="after_validation_fixed" src="https://cloud.githubusercontent.com/assets/36814/14927617/ad4419f8-0e5b-11e6-8ba6-b5fd31e3ae3f.png">

I also had to upgrade the jsdom because previous version has no File support.

