### PR TITLE
v6 — Improve perfs

### DIFF
--- a/src/util/__tests__/every.spec.js
+++ b/src/util/__tests__/every.spec.js
@@ -4,19 +4,20 @@ import every from '../every'
 describe('every', () => {
   it('should return true when given undefined', () => {
     const spy = createSpy()
-    expect(every(undefined)).toBe(true)
+    expect(every(undefined, spy)).toBe(true)
+    expect(every(null, spy)).toBe(true)
     expect(spy).toNotHaveBeenCalled()
   })
 
   it('should return true when given an empty array', () => {
     const spy = createSpy()
-    expect(every([])).toBe(true)
+    expect(every([], spy)).toBe(true)
     expect(spy).toNotHaveBeenCalled()
   })
 
   it('should return true when given an empty object', () => {
     const spy = createSpy()
-    expect(every({})).toBe(true)
+    expect(every({}, spy)).toBe(true)
     expect(spy).toNotHaveBeenCalled()
   })
 

--- a/src/util/__tests__/toPath.spec.js
+++ b/src/util/__tests__/toPath.spec.js
@@ -2,6 +2,10 @@ import expect from 'expect'
 import toPath from '../toPath'
 
 describe('toPath', () => {
+  it('should return empty array for null', () => {
+    expect(toPath(null)).toEqual([])
+  })
+
   it('should return empty array for undefined', () => {
     expect(toPath(undefined)).toEqual([])
   })

--- a/src/util/every.js
+++ b/src/util/every.js
@@ -2,12 +2,21 @@
  * Returns true of the predicate is true for every (value, key) pair in the Object or array
  */
 export default function every(object, predicate) {
-  if(!object) {
+  if (object !== Object(object)) {
     return true
   }
-  if(Array.isArray(object)) {
+
+  if (Array.isArray(object)) {
     return !object.length || object.every(predicate)
   }
+
   const keys = Object.keys(object)
-  return !keys.length || keys.every(key => predicate(object[key], key, object))
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i]
+    if (!predicate(object[key], key, object)) {
+      return false
+    }
+  }
+
+  return true
 }

--- a/src/util/mapValues.js
+++ b/src/util/mapValues.js
@@ -2,10 +2,18 @@
  * Maps all the values in the given object through the given function and saves them, by key, to a result object
  */
 const mapValues = (obj, fn) => {
-  return obj ? Object.keys(obj).reduce((accumulator, key) => ({
-    ...accumulator,
-    [key]: fn(obj[key], key)
-  }), {}) : obj
+  if (obj !== Object(obj)) {
+    return obj
+  } else {
+    const acc = {}
+    const keys = Object.keys(obj)
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i]
+      acc[key] = fn(obj[key], key)
+    }
+
+    return acc
+  }
 }
 
 export default mapValues

--- a/src/util/toPath.js
+++ b/src/util/toPath.js
@@ -1,7 +1,15 @@
+const DELIMITER_PATTERN = /[.\[\]]/
+const isNotEmpty = token => token.length > 0
+
 /**
  * Converts a string in dot-and-bracket notation to an array of keys
  */
-const toPath = value =>
-  value === undefined ? [] : String(value).split(/[.\[\]]/).filter(token => token.length)
+const toPath = value => {
+  if (value === undefined || value === null) {
+    return []
+  } else {
+    return String(value).split(DELIMITER_PATTERN).filter(isNotEmpty)
+  }
+}
 
 export default toPath


### PR DESCRIPTION
This PR improves the performance of various utilities. These perf optimizations were previously done by `lodash`.

- Fix broken `every` tests (8590d4a6c32996326da942a39de4a450ff05bc80)
- Modify `toPath` to accept `null` literals (b1bbbe527966b78ab78b4d73d84b33e61c92250a)
- Remove closures created a runtime in `every` and `mapValues` and `toPath`