### PR TITLE
Add es build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,14 @@
 {
-  "presets": ["es2015", "react", "stage-2"],
-  "plugins": ["lodash"]
+  "presets": ["es2015-webpack", "react", "stage-2"],
+  "env": {
+    "development": {
+      "plugins": ["lodash", "transform-es2015-modules-commonjs"]
+    },
+    "production": {
+      "plugins": ["lodash", "transform-es2015-modules-commonjs"]
+    },
+    "es": {
+      "plugins": ["lodash", "./babel-lodash-es"]
+    }
+  }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 node_modules
 dist
 lib
+es
 npm-debug.log
 .DS_Store

--- a/babel-lodash-es.js
+++ b/babel-lodash-es.js
@@ -1,0 +1,10 @@
+module.exports = function () {
+  return {
+    visitor: {
+      ImportDeclaration(path) {
+        const source = path.node.source
+        source.value = source.value.replace(/^lodash($|\/)/, 'lodash-es$1')
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,13 +3,15 @@
   "version": "6.0.0-alpha.8",
   "description": "A higher order component decorator for forms using Redux and React",
   "main": "./lib/index.js",
+  "jsnext:main": "./es/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/erikras/redux-form"
   },
   "scripts": {
-    "build": "npm run build:lib && npm run build:umd && npm run build:umd:min",
+    "build": "npm run build:lib && npm run build:es && npm run build:umd && npm run build:umd:min",
     "build:lib": "babel src --out-dir lib",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es",
     "build:umd": "webpack src/index.js dist/redux-form.js --config webpack.config.development.js",
     "build:umd:min": "webpack src/index.js dist/redux-form.min.js --config webpack.config.production.js",
     "clean": "rimraf dist lib",
@@ -43,7 +45,8 @@
     "hoist-non-react-statics": "^1.0.5",
     "invariant": "^2.2.1",
     "is-promise": "^2.1.0",
-    "lodash": "^4.12.0"
+    "lodash": "^4.12.0",
+    "lodash-es": "^4.12.0"
   },
   "devDependencies": {
     "babel-cli": "^6.3.17",
@@ -52,12 +55,15 @@
     "babel-loader": "^6.2.0",
     "babel-plugin-lodash": "^3.1.2",
     "babel-plugin-syntax-async-functions": "^6.5.0",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.8.0",
     "babel-plugin-transform-regenerator": "^6.6.5",
     "babel-polyfill": "^6.7.4",
     "babel-preset-es2015": "^6.1.18",
+    "babel-preset-es2015-webpack": "^6.4.1",
     "babel-preset-react": "^6.1.18",
     "babel-preset-stage-2": "^6.1.18",
     "babel-register": "^6.3.13",
+    "cross-env": "^1.0.7",
     "eslint": "^1.7.1",
     "eslint-config-rackt": "^1.1.1",
     "eslint-plugin-react": "^3.6.3",


### PR DESCRIPTION
Lets package consumers tree-shake with webpack2, just like redux. In fact, I lifted the lodash-es babel plugin from the redux repo. 😉 