### PR TITLE
Use shallowEqual in shouldComponentUpdate

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "invariant": "^2.2.1",
     "is-promise": "^2.1.0",
     "lodash": "^4.12.0",
-    "lodash-es": "^4.12.0"
+    "lodash-es": "^4.12.0",
+    "react-addons-shallow-compare": "^15.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.3.17",

--- a/src/ConnectedFieldArray.js
+++ b/src/ConnectedFieldArray.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux'
 import createFieldArrayProps from './createFieldArrayProps'
 import { partial, mapValues } from 'lodash'
 import plain from './structure/plain'
+import shallowCompare from 'react-addons-shallow-compare'
 
 const createConnectedFieldArray = ({
   arrayInsert,
@@ -23,7 +24,7 @@ const createConnectedFieldArray = ({
 
   class ConnectedFieldArray extends Component {
     shouldComponentUpdate(nextProps) {
-      return size(this.props.value) !== size(nextProps.value)
+      return shallowCompare(this, nextProps)
     }
 
     get syncError() {

--- a/src/Field.js
+++ b/src/Field.js
@@ -1,6 +1,7 @@
 import React, { Component, PropTypes } from 'react'
 import invariant from 'invariant'
 import createConnectedField from './ConnectedField'
+import shallowCompare from 'react-addons-shallow-compare'
 
 let keys = 0
 const generateKey = () => `redux-form-field-${keys++}`
@@ -18,7 +19,7 @@ const createField = ({ deepEqual, getIn }) => {
     }
 
     shouldComponentUpdate(nextProps) {
-      return this.props.name !== nextProps.name
+      return shallowCompare(this, nextProps)
     }
 
     componentWillMount() {

--- a/src/FieldArray.js
+++ b/src/FieldArray.js
@@ -1,6 +1,7 @@
 import React, { Component, PropTypes } from 'react'
 import invariant from 'invariant'
 import createConnectedFieldArray from './ConnectedFieldArray'
+import shallowCompare from 'react-addons-shallow-compare'
 
 let keys = 0
 const generateKey = () => `redux-form-field-array-${keys++}`
@@ -15,6 +16,10 @@ const createFieldArray = ({ deepEqual, getIn, size }) => {
       }
       this.key = generateKey()
       this.ConnectedFieldArray = createConnectedFieldArray(context._reduxForm, { deepEqual, getIn, size }, props.name)
+    }
+
+    shouldComponentUpdate(nextProps) {
+      return shallowCompare(this, nextProps)
     }
 
     componentWillMount() {
@@ -40,14 +45,14 @@ const createFieldArray = ({ deepEqual, getIn, size }) => {
     get name() {
       return this.props.name
     }
-    
+
     getRenderedComponent() {
       invariant(this.props.withRef,
         'If you want to access getRenderedComponent(), ' +
         'you must specify a withRef prop to FieldArray')
       return this.refs.connected.getWrappedInstance().getRenderedComponent()
     }
-    
+
     render() {
       const { ConnectedFieldArray } = this
       return <ConnectedFieldArray {...this.props} ref="connected"/>

--- a/src/__tests__/Field.spec.js
+++ b/src/__tests__/Field.spec.js
@@ -202,7 +202,7 @@ const describeField = (name, structure, combineReducers, expect) => {
       const stub = TestUtils.findRenderedComponentWithType(dom, Field)
       expect(stub.name).toBe('foo')
     })
-    
+
     it('should provide access to rendered component', () => {
       const store = makeStore({
         testForm: {
@@ -224,7 +224,7 @@ const describeField = (name, structure, combineReducers, expect) => {
       )
       const field = TestUtils.findRenderedComponentWithType(dom, Field)
       const input = TestUtils.findRenderedComponentWithType(dom, TestInput)
-      
+
       expect(field.getRenderedComponent()).toBe(input)
     })
 
@@ -273,6 +273,41 @@ const describeField = (name, structure, combineReducers, expect) => {
       expect(input.calls.length).toBe(2)
       expect(input.calls[ 1 ].arguments[ 0 ].value).toBe('barValue')
       expect(input.calls[ 1 ].arguments[ 0 ].touched).toBe(true)
+    })
+
+    it('should reconnect when props change', () => {
+      const store = makeStore()
+      const input = createSpy(props => <input {...props}/>).andCallThrough()
+      class Form extends Component {
+        constructor() {
+          super()
+          this.state = { foo: 'foo', bar: 'bar' }
+        }
+
+        render() {
+          return (<div>
+            <Field name="foo" foo={this.state.foo} bar={this.state.bar} component={input}/>
+            <button onClick={() => this.setState({ foo: 'qux', bar: 'baz' })}>Change</button>
+          </div>)
+        }
+      }
+      const TestForm = reduxForm({ form: 'testForm' })(Form)
+      const dom = TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <TestForm/>
+        </Provider>
+      )
+      expect(input).toHaveBeenCalled()
+      expect(input.calls.length).toBe(1)
+      expect(input.calls[ 0 ].arguments[ 0 ].foo).toBe('foo')
+      expect(input.calls[ 0 ].arguments[ 0 ].bar).toBe('bar')
+
+      const button = TestUtils.findRenderedDOMComponentWithTag(dom, 'button')
+      TestUtils.Simulate.click(button)
+
+      expect(input.calls.length).toBe(2)
+      expect(input.calls[ 1 ].arguments[ 0 ].foo).toBe('qux')
+      expect(input.calls[ 1 ].arguments[ 0 ].bar).toBe('baz')
     })
   })
 }


### PR DESCRIPTION
Do you think it makes sense to use `shallowEqual` or even remove the entire `shouldComponentUpdate` as `Field` should be treated as a simple component to connects form's state and so `shouldComponentUpdate` shouldn't be part of the job.

Fixes #936 