### PR TITLE
Add a test to invalid #383

### DIFF
--- a/src/__tests__/getValuesFromState.spec.js
+++ b/src/__tests__/getValuesFromState.spec.js
@@ -176,6 +176,15 @@ describe('getValuesFromState', () => {
       });
   });
 
+  it('should ignore empty values from state', () => {
+    const state = {
+      name: makeFieldValue({}),
+    };
+    expect(getValuesFromState(state))
+      .toBeA('object')
+      .toEqual({});
+  });
+
   it('should ignore values starting with _', () => {
     const state = {
       foo: makeFieldValue({


### PR DESCRIPTION
The following test shows that the behavior described in #383 is no longer reproducible using `v5.1.3`.