### PR TITLE
v6 — Add React to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "webpack": "^1.12.13"
   },
   "peerDependencies": {
+    "react": "^15.0.0",
     "react-redux": "^4.0.0",
     "redux": "^3.0.0"
   },


### PR DESCRIPTION
Since Redux Form requires React, it is a good idea to add it to `peerDependencies`. Moreover it would indicate what React versions are compatible.