### PR TITLE
v6 — Remove classnames dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   },
   "homepage": "https://redux-form.com/",
   "dependencies": {
-    "classnames": "^2.2.3",
     "deep-equal": "^1.0.1",
     "es6-error": "^2.1.0",
     "hoist-non-react-statics": "^1.0.5",


### PR DESCRIPTION
`classnames` is installed by isn't required.