### PR TITLE
v6 — Add Redux and React Redux as external dependencies to UMD builds

### DIFF
--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -8,9 +8,25 @@ var reactExternal = {
   amd: 'react'
 }
 
+var reduxExternal = {
+  root: 'Redux',
+  commonjs2: 'redux',
+  commonjs: 'redux',
+  amd: 'redux'
+}
+
+var reactReduxExternal = {
+  root: 'ReactRedux',
+  commonjs2: 'react-redux',
+  commonjs: 'react-redux',
+  amd: 'react-redux'
+}
+
 module.exports = {
   externals: {
-    'react': reactExternal
+    'react': reactExternal,
+    'redux': reduxExternal,
+    'react-redux': reactReduxExternal
   },
   module: {
     loaders: [


### PR DESCRIPTION
The UMD builds must not include `redux` and `react-redux`.

```
> webpack src/index.js dist/redux-form.js --config webpack.config.development.js

Hash: 94a4e77b0d02a5717496
Version: webpack 1.13.0
Time: 2208ms
        Asset    Size  Chunks             Chunk Names
redux-form.js  174 kB       0  [emitted]  main
    + 117 hidden modules

> webpack src/index.js dist/redux-form.min.js --config webpack.config.production.js

Hash: 72e7ef383112e424e4c2
Version: webpack 1.13.0
Time: 3278ms
            Asset     Size  Chunks             Chunk Names
redux-form.min.js  57.9 kB       0  [emitted]  main
    + 117 hidden modules
```