### PR TITLE
docs(props): fix propTypes link and error type

### DIFF
--- a/docs/api/Props.md
+++ b/docs/api/Props.md
@@ -5,7 +5,7 @@ to your decorated form component. The `props` that _you pass into your wrapped c
 [here](#/api/reduxForm).
 
 > If you are a strict `PropTypes` completionist, `redux-form` exports all of these
-[`propTypes`](https://github.com/erikras/redux-form/blob/master/src/propTypes.js), 
+[`propTypes`](https://github.com/erikras/redux-form/blob/master/src/createPropTypes.js), 
 so you may import them, like so:
 
 ```javascript
@@ -44,7 +44,7 @@ class SimpleForm extends Component {
 
 > `true` if the form data has changed from its initialized values. Opposite of `pristine`.
 
-### `error : String`
+### `error : any`
 
 > A generic error for the entire form given by the `_error` key in the result from the synchronous validation function,
 the asynchronous validation, or the rejected promise from `onSubmit`.


### PR DESCRIPTION
Fixes https://github.com/erikras/redux-form/issues/958

Maybe the `error` prop for `Field` and `FieldArray` should also be `any` instead of `string`? However, I did not find those files in the repo, so this PR is just updating Props.md. Thanks.