### PR TITLE
v6 — Improve redux connector performances

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   },
   "peerDependencies": {
     "react": "^15.0.0",
-    "react-redux": "^4.0.0",
+    "react-redux": "^4.3.0",
     "redux": "^3.0.0"
   },
   "files": [

--- a/src/ConnectedField.js
+++ b/src/ConnectedField.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from 'react'
+import { Component, PropTypes, createElement } from 'react'
 import { connect } from 'react-redux'
 import createFieldProps from './createFieldProps'
 import { partial, mapValues } from 'lodash'
@@ -48,7 +48,7 @@ const createConnectedField = ({
       if (withRef) {
         props.ref = 'renderedComponent'
       }
-      return React.createElement(component, props)
+      return createElement(component, props)
     }
   }
 

--- a/src/ConnectedFieldArray.js
+++ b/src/ConnectedFieldArray.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from 'react'
+import { Component, PropTypes, createElement } from 'react'
 import { connect } from 'react-redux'
 import createFieldArrayProps from './createFieldArrayProps'
 import { partial, mapValues } from 'lodash'
@@ -58,7 +58,7 @@ const createConnectedFieldArray = ({
       if (withRef) {
         props.ref = 'renderedComponent'
       }
-      return React.createElement(component, props)
+      return createElement(component, props)
     }
   }
 

--- a/src/Field.js
+++ b/src/Field.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from 'react'
+import { Component, PropTypes, createElement } from 'react'
 import invariant from 'invariant'
 import createConnectedField from './ConnectedField'
 import shallowCompare from 'react-addons-shallow-compare'
@@ -54,8 +54,10 @@ const createField = ({ deepEqual, getIn }) => {
     }
 
     render() {
-      const { ConnectedField } = this
-      return <ConnectedField {...this.props} ref="connected"/>
+      return createElement(this.ConnectedField, {
+        ...this.props,
+        ref: 'connected'
+      })
     }
   }
 

--- a/src/FieldArray.js
+++ b/src/FieldArray.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from 'react'
+import { Component, PropTypes, createElement } from 'react'
 import invariant from 'invariant'
 import createConnectedFieldArray from './ConnectedFieldArray'
 import shallowCompare from 'react-addons-shallow-compare'
@@ -54,8 +54,10 @@ const createFieldArray = ({ deepEqual, getIn, size }) => {
     }
 
     render() {
-      const { ConnectedFieldArray } = this
-      return <ConnectedFieldArray {...this.props} ref="connected"/>
+      return createElement(this.ConnectedFieldArray, {
+        ...this.props,
+        ref: 'connected'
+      })
     }
   }
 

--- a/src/reduxForm.js
+++ b/src/reduxForm.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from 'react'
+import { Component, PropTypes, createElement } from 'react'
 import hoistStatics from 'hoist-non-react-statics'
 import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
@@ -121,7 +121,7 @@ const createReduxForm =
               destroy()
             }
           }
-          
+
           getSyncErrors() {
             return this.props.syncErrors
           }
@@ -245,13 +245,10 @@ const createReduxForm =
               values,
               ...passableProps
             } = this.props // eslint-disable-line no-redeclare
-            return (
-              <WrappedComponent
-                {...passableProps}
-                {...{
-                  handleSubmit: this.submit
-                }}/>
-            )
+            return createElement(WrappedComponent, {
+              ...passableProps,
+              handleSubmit: this.submit
+            })
           }
         }
         Form.displayName = `Form(${getDisplayName(WrappedComponent)})`
@@ -367,8 +364,12 @@ const createReduxForm =
 
           render() {
             const { initialValues, ...rest } = this.props
-            // convert initialValues if need to
-            return <ConnectedForm ref="wrapped" initialValues={fromJS(initialValues)} {...rest}/>
+            return createElement(ConnectedForm, {
+              ...rest,
+              ref: 'wrapped',
+              // convert initialValues if need to
+              initialValues: fromJS(initialValues)
+            })
           }
         }
       }


### PR DESCRIPTION
Use Redux's memoization API to improve `ConnectedForm` performances by avoiding closure re-creations.

**NOTE:** It introduces 2 breaking changes:

- `react-redux` MUST match `>=4.3` (previously `>=4.0`)
- `form`, `touchOnBlur` and `touchOnChange` can't change over time. In order to prevent WTF behaviors, we could add a warning when `NODE_ENV` is not `production` if these props change.

**Disclaimer:** I haven't tested the examples since they rely on the latest published version on Redux Form instead of the local one.