### PR TITLE
v6: getFormValue() to connect conveniently

### DIFF
--- a/src/__tests__/getFormValue.spec.js
+++ b/src/__tests__/getFormValue.spec.js
@@ -1,0 +1,115 @@
+import expect from 'expect'
+import { Map, List } from 'immutable'
+import getFormValue from '../getFormValue'
+
+describe('getFormValue', () => {
+  it('should throw if any argument is missing', () => {
+    const formState = {
+      myForm: {
+        values: {
+          fieldName: 'value'
+        }
+      }
+    }
+    const formName = 'myForm'
+    const field = 'fieldName'
+
+    expect(() => {
+      getFormValue()
+    }).toThrow()
+    expect(() => {
+      getFormValue({})
+    }).toThrow(/Missing argument/)
+    expect(() => {
+      getFormValue({ formState, formName })
+    }).toThrow(/Missing argument/)
+    expect(() => {
+      getFormValue({ formState, field })
+    }).toThrow(/Missing argument/)
+    expect(() => {
+      getFormValue({ formName, field })
+    }).toThrow(/Missing argument/)
+  })
+
+  it('should return undefined for invalid formName', () => {
+    const formState = {}
+    const formName = 'myForm'
+    const field = 'fieldName'
+    expect(getFormValue({ formState, formName, field })).toBeAn('undefined')
+  })
+
+  it('should return undefined if the values property does not exist in the formState', () => {
+    const formState = { myForm: {} }
+    const formName = 'myForm'
+    const field = 'fieldName'
+    expect(getFormValue({ formState, formName, field })).toBeAn('undefined')
+  })
+
+  it('should return undefined for invalid field', () => {
+    const formState = {
+      myForm: {
+        values: {
+          fieldName: 'value'
+        }
+      }
+    }
+    const immutableFormState = Map({
+      myForm: Map({
+        values: Map({
+          fieldName: 'value'
+        })
+      })
+    })
+    const formName = 'myForm'
+    const field = 'wrongKey'
+    expect(getFormValue({ formState, formName, field })).toBeAn('undefined')
+    expect(getFormValue({ formState: immutableFormState, formName, field })).toBeAn('undefined')
+
+  })
+
+  it('should return value', () => {
+    const formState = {
+      myForm: {
+        values: {
+          fieldName: 'value'
+        }
+      }
+    }
+    const immutableFormState = Map({
+      myForm: Map({
+        values: Map({
+          fieldName: 'value'
+        })
+      })
+    })
+    const formName = 'myForm'
+    const field = 'fieldName'
+    expect(getFormValue({ formState, formName, field })).toEqual('value')
+    expect(getFormValue({ formState: immutableFormState, formName, field })).toEqual('value')
+  })
+
+  it('should return value for deeply nested field inside object and array', () => {
+    const formState = {
+      myForm: {
+        values: {
+          fieldName: {
+            nestedField: [ 'wrong', 'expectedValue' ]
+          }
+        }
+      }
+    }
+    const immutableFormState = Map({
+      myForm: Map({
+        values: Map({
+          fieldName: Map({
+            nestedField: List.of('wrong', 'expectedValue')
+          })
+        })
+      })
+    })
+    const formName = 'myForm'
+    const field = 'fieldName.nestedField[1]'
+    expect(getFormValue({ formState, formName, field })).toEqual('expectedValue')
+    expect(getFormValue({ formState: immutableFormState, formName, field })).toEqual('expectedValue')
+  })
+})

--- a/src/createAll.js
+++ b/src/createAll.js
@@ -3,6 +3,7 @@ import createReduxForm from './reduxForm'
 import createField from './Field'
 import createFieldArray from './FieldArray'
 import createValues from './values'
+import getFormValue from './getFormValue'
 import SubmissionError from './SubmissionError'
 import propTypes from './propTypes'
 import * as actions from './actions'
@@ -14,6 +15,7 @@ const createAll = structure => ({
   ...actions,
   Field: createField(structure),
   FieldArray: createFieldArray(structure),
+  getFormValue,
   propTypes,
   reduxForm: createReduxForm(structure),
   reducer: createReducer(structure),

--- a/src/getFormValue.js
+++ b/src/getFormValue.js
@@ -1,0 +1,37 @@
+/**
+ * This is a selector aimed at making it more convenient to connect to form
+ * values, as discussed e.g. here:
+ * https://github.com/erikras/redux-form/issues/945
+ * https://github.com/erikras/redux-form/issues/967
+ *
+ * @param formState The slice of the Redux state where the `redux-form` reducer
+ * has been mounted
+ * @param formName The name of the form passed (under the 'form' key)
+ * to reduxForm()
+ * @param field The key of the value to return. It may be deeply nested, e.g.
+ * like so: 'keyWithObjectValue.keyWithArrayValue[0]'
+ */
+import structure from './structure/immutable'
+
+const getFormValue = ({
+  formState,
+  formName,
+  field
+}) => {
+  if (!formState || !formName || !field) {
+    throw new Error('Missing argument, must include { formState, formName, field }')
+  }
+
+  // getIn() from './structure/immutable' handles both Immutable and plain state
+  const { getIn } = structure
+
+  if (!getIn(formState, formName) ||
+      !getIn(formState, `${formName}.values`)
+  ) {
+    return undefined
+  }
+
+  return getIn(formState, `${formName}.values.${field}`)
+}
+
+export default getFormValue

--- a/src/immutable.js
+++ b/src/immutable.js
@@ -10,6 +10,7 @@ export const {
   Field,
   FieldArray,
   focus,
+  getFormValue,
   reducer,
   reduxForm,
   removeArrayValue,

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ export const {
   Field,
   FieldArray,
   focus,
+  getFormValue,
   reducer,
   reduxForm,
   removeArrayValue,


### PR DESCRIPTION
@erikras I noticed you wrote that the `getFormValue()` selector mentioned in https://github.com/erikras/redux-form/issues/945#issuecomment-218522902 and https://github.com/erikras/redux-form/issues/967#issuecomment-219205319 could be a good first feature for someone to PR and I made an attempt.

Since the syntax is not set in stone, I am fully aware that the code in this PR could be completely discarded or require major refactoring. Also, please excuse me (and enlighten me!) if there are any beginner mistakes in the code or stupid questions below.

Some considerations when writing this:

**1. Handle different form reducer mount points:** I could not figure out a way to access `getFormState()`, hence opted to to ask the user to provide the form state slice (normally `state.form`).

**2. Handle Immutable and plain state:** I have not worked with ImmutableJS and am not sure if an immutable state looks different than in the tests, but if they are OK I figure `getIn()` from `/structure/immutable` can handle both an immutable and a plain state.

**3. Have a clear function signature:** Sometimes 2-3 unnamed arguments can be harder to read/understand than having an object with named arguments, though it requires more typing. I went with `getFormValue({ formState, formName, field })`, but of course `getFormValue(state, form, field)` could be an option. A slightly different approach, to allow removing one argument, could be `getFormValue(formState, field)` where `formState` would be one step deeper, like so: `state.reducerMountPoint.formName`.

What are your thoughts & suggestions?

Update: Here's the error from the CI, it is weird because `npm run test` worked fine locally while I was coding. After seeing this error, I tried making a new clone and got the error locally too. Commenting out the line with the error makes the tests run.
![screenshot 2016-05-16 00 49 58](https://cloud.githubusercontent.com/assets/12738484/15277411/6c4dfd4c-1b03-11e6-9621-091fbe15da73.png)
Update 2: CI error discussed in https://github.com/erikras/redux-form/issues/971 and https://github.com/erikras/redux-form/pull/977