### PR TITLE
found focus-loss rerender bug. fixes #961

### DIFF
--- a/src/Field.js
+++ b/src/Field.js
@@ -19,7 +19,11 @@ const createField = ({ deepEqual, getIn }) => {
     }
 
     shouldComponentUpdate(nextProps) {
-      return shallowCompare(this, nextProps)
+      const propsWithoutComponent = { ...this.props }
+      const nextPropsWithoutComponent = { ...nextProps }
+      delete propsWithoutComponent.component
+      delete nextPropsWithoutComponent.component
+      return shallowCompare({ props: propsWithoutComponent }, nextPropsWithoutComponent)
     }
 
     componentWillMount() {

--- a/src/FieldArray.js
+++ b/src/FieldArray.js
@@ -19,7 +19,11 @@ const createFieldArray = ({ deepEqual, getIn, size }) => {
     }
 
     shouldComponentUpdate(nextProps) {
-      return shallowCompare(this, nextProps)
+      const propsWithoutComponent = { ...this.props }
+      const nextPropsWithoutComponent = { ...nextProps }
+      delete propsWithoutComponent.component
+      delete nextPropsWithoutComponent.component
+      return shallowCompare({ props: propsWithoutComponent }, nextPropsWithoutComponent)
     }
 
     componentWillMount() {


### PR DESCRIPTION
Ignores `component` property when deciding to rerender `Field` and `FieldArray`, since, to allow stateless function components, must allow them to be different every time.