### PR TITLE
v6 fix doc example of FormValueSelector

### DIFF
--- a/docs/api/FormValueSelector.md
+++ b/docs/api/FormValueSelector.md
@@ -70,10 +70,10 @@ connect(
 ```javascript
 connect(
   state => {
-    const { firstValue, secondValue } = selector(state, 'first', 'second')
+    const { first, second } = selector(state, 'first', 'second')
     // do some calculation
     return {
-      sum: firstValue + secondValue
+      sum: first + second
     }
   }
 )(MyFormComponent)


### PR DESCRIPTION
Object destructuring assignment had wrong variables names