### PR TITLE
Fix typo in Props doc page

### DIFF
--- a/docs/api/Props.md
+++ b/docs/api/Props.md
@@ -1,6 +1,6 @@
 # `props`
 
-> The `props` listed on this page are are the `props` that `redux-form` generates to give
+> The `props` listed on this page are the `props` that `redux-form` generates to give
 to your decorated form component. The `props` that _you pass into your wrapped component_ are listed
 [here](#/api/reduxForm).
 


### PR DESCRIPTION
Found a typo while reading through the docs.