### PR TITLE
Adding react-widgets example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -74,3 +74,8 @@ open [`localhost:3030`](http://localhost:3030) in your browser.
 > Contains multiple Material-UI examples
 
 ---
+
+### [React-Widegets Examples](react-widgets)
+
+> How to use `react-widgets` components with `redux-form` 
+---

--- a/examples/react-widgets/.babelrc
+++ b/examples/react-widgets/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["react", "es2015", "stage-2"]
+}

--- a/examples/react-widgets/README.md
+++ b/examples/react-widgets/README.md
@@ -1,0 +1,10 @@
+# Simple Material UI Form Example
+
+## To run locally
+
+```
+npm install
+npm start
+```
+
+Then open [`http://localhost:3030/`](http://localhost:3030/).

--- a/examples/react-widgets/README.md
+++ b/examples/react-widgets/README.md
@@ -1,4 +1,4 @@
-# Simple Material UI Form Example
+# Simple React Widgets UI Form Example
 
 ## To run locally
 

--- a/examples/react-widgets/devServer.js
+++ b/examples/react-widgets/devServer.js
@@ -1,0 +1,27 @@
+var path = require('path');
+var express = require('express');
+var webpack = require('webpack');
+var config = require('./webpack.config.dev');
+
+var app = express();
+var compiler = webpack(config);
+
+app.use(require('webpack-dev-middleware')(compiler, {
+  noInfo: true,
+  publicPath: config.output.publicPath
+}));
+
+app.use(require('webpack-hot-middleware')(compiler));
+
+app.get('*', function(req, res) {
+  res.sendFile(path.join(__dirname, 'index.html'));
+});
+
+app.listen(3030, 'localhost', function(err) {
+  if (err) {
+    console.log(err);
+    return;
+  }
+
+  console.log('Listening at http://localhost:3030');
+});

--- a/examples/react-widgets/index.html
+++ b/examples/react-widgets/index.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charSet="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
+  <title>Redux Form</title>
+  <link href="http://redux-form.com/6.0.0-alpha.14/bundle.css"
+    media="screen, projection"
+    rel="stylesheet" type="text/css"/>
+  <link href="//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.3.0/css/font-awesome.min.css"
+    media="screen, projection" rel="stylesheet" type="text/css"/>
+  <meta itemprop="name" content="Redux Form"/>
+  <meta property="og:type" content="website"/>
+  <meta property="og:title" content="Redux Form"/>
+  <meta property="og:site_name" content="Redux Form"/>
+  <meta property="og:description"
+        content="The best way to manage your form state in Redux."/>
+  <meta property="og:image" content="logo.png"/>
+  <meta property="twitter:site" content="@erikras"/>
+  <meta property="twitter:creator" content="@erikras"/>
+  <style>
+  /*
+    Tweaking some CSS for
+    getting it work with react-widgets
+  */
+    form ul li:first-child{
+      text-align:left;
+    }
+    form ul li {
+      padding: 0px;
+      background-image:none;
+    }
+    form>div>div>* {
+      height: 50px
+    }
+  </style>
+</head>
+<body>
+<div id="content">
+  <style type="text/css" scoped>
+    .loader {
+      margin: 10% auto;
+      font-size: 10px;
+      position: relative;
+      text-indent: -9999em;
+      border-top: 1.1em solid rgba(100, 100, 100, 0.2);
+      border-right: 1.1em solid rgba(100, 100, 100, 0.2);
+      border-bottom: 1.1em solid rgba(100, 100, 100, 0.2);
+      border-left: 1.1em solid grey;
+      -webkit-transform: translateZ(0);
+      -ms-transform: translateZ(0);
+      transform: translateZ(0);
+      -webkit-animation: load8 1.1s infinite linear;
+      animation: load8 1.1s infinite linear;
+    }
+
+    .loader,
+    .loader:after {
+      border-radius: 50%;
+      width: 10em;
+      height: 10em;
+    }
+
+    @-webkit-keyframes load8 {
+      0% {
+        -webkit-transform: rotate(0deg);
+        transform: rotate(0deg);
+      }
+      100% {
+        -webkit-transform: rotate(360deg);
+        transform: rotate(360deg);
+      }
+    }
+
+    @keyframes load8 {
+      0% {
+        -webkit-transform: rotate(0deg);
+        transform: rotate(0deg);
+      }
+      100% {
+        -webkit-transform: rotate(360deg);
+        transform: rotate(360deg);
+      }
+    }
+  </style>
+
+  <div class="loader">Loading...</div>
+</div>
+<script type="text/javascript" src="dist/bundle.js"></script>
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+  ga('create', 'UA-69298417-1', 'auto');
+  ga('send', 'pageview');
+</script>
+</body>
+</html>

--- a/examples/react-widgets/package.json
+++ b/examples/react-widgets/package.json
@@ -1,0 +1,51 @@
+{
+  "private": true,
+  "scripts": {
+    "clean": "rimraf dist",
+    "build:webpack": "cross-env NODE_ENV=production webpack --config webpack.config.prod.js",
+    "build": "npm run clean && npm run build:webpack",
+    "lint": "eslint src",
+    "start": "node devServer.js"
+  },
+  "dependencies": {
+    "babel-polyfill": "^6.6.1",
+    "html-loader": "^0.4.3",
+    "json-loader": "^0.5.4",
+    "markdown-loader": "^0.1.7",
+    "raw-loader": "^0.5.1",
+    "react": "^15.0.0-rc.2",
+    "react-dom": "^15.0.0-rc.2",
+    "react-redux": "^4.4.1",
+    "react-tap-event-plugin": "^1.0.0",
+    "react-widgets": "^3.3.1",
+    "redux": "^3.3.1",
+    "redux-form": "file:../../",
+    "redux-form-website-template": "0.0.30"
+  },
+  "devDependencies": {
+    "babel-core": "^6.3.15",
+    "babel-eslint": "^5.0.0-beta4",
+    "babel-loader": "^6.2.0",
+    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-react": "^6.3.13",
+    "babel-preset-stage-2": "^6.1.18",
+    "cross-env": "^1.0.7",
+    "css-loader": "^0.23.1",
+    "eslint": "^1.6.0",
+    "eslint-config-rackt": "^1.1.1",
+    "eslint-loader": "^1.3.0",
+    "eslint-plugin-babel": "^3.0.0",
+    "eslint-plugin-react": "^3.11.3",
+    "eventsource-polyfill": "^0.9.6",
+    "express": "^4.13.3",
+    "extract-text-webpack-plugin": "^1.0.1",
+    "file-loader": "^0.8.5",
+    "redbox-react": "^1.2.2",
+    "rimraf": "^2.4.3",
+    "style-loader": "^0.13.1",
+    "url-loader": "^0.5.7",
+    "webpack": "^1.12.9",
+    "webpack-dev-middleware": "^1.4.0",
+    "webpack-hot-middleware": "^2.6.0"
+  }
+}

--- a/examples/react-widgets/src/ReactWidgets.md
+++ b/examples/react-widgets/src/ReactWidgets.md
@@ -1,0 +1,28 @@
+# React Widgets Example
+
+This is a simple demonstration of how to connect react-widgets
+[react-widgets](https://github.com/jquense/react-widgets) form elements to `redux-form`.
+
+For the most part, it is a matter of wrapping each form control in a `<Field>` component as custom component. For rest of things you should read `react-widgets` docs. 
+
+For all controls we need to  simulate the `onChange` and `onBlur` manually. 
+
+The delay between when you click "Submit" and when the alert dialog pops up is intentional,
+to simulate server latency.
+
+
+# Issue
+
+* Currently there is a warning error for MultiSelect value as the component expect value to be an array. We will be looking more into it.
+
+
+# Some Gotcha
+
+* React-widgets is bound with some css , please do not consider this example with css. We have tricked the css.
+* Goal of this exmaple is how can we connect `react-widgets` to `redux-form`
+* This example is using `style-loader`,`file-loader`,`url-loader` as it has its own css to maniupate.
+* For more details of what `react-widgets` can do and how to setup `react-widgets` go through their [documentation](https://jquense.github.io/react-widgets/docs/#/?_k=mmahpo)
+
+# Initializing Form from state
+
+There is no extra trick to Initialize form for more information please look to InitializeFormState example.

--- a/examples/react-widgets/src/ReactWidgetsForm.js
+++ b/examples/react-widgets/src/ReactWidgetsForm.js
@@ -28,6 +28,36 @@ const validate = values => {
   return errors
 }
 
+const renderDropdownList = props => (
+  <div>
+    <DropdownList
+      {...props}
+      onChange={(value) => props.onChange(value)}
+    />
+    {props.touched && props.error && <span>{props.error}</span>}
+  </div>
+)
+const renderMultiselect = props => (
+  <div>
+    <Multiselect
+      {...props}
+      onChange={value => props.onChange(value)}
+      onBlur = {event => props.onBlur()}
+    />
+    {props.touched && props.error && <span>{props.error}</span>}
+  </div>
+)
+const renderSelectList = props => (
+  <div>
+    <SelectList
+      {...props}
+      onChange={(value) => props.onChange(value)} /* Simulating onChange manually*/
+      onBlur = {event => props.onBlur()} /* Simulating onBlur manually*/
+    />
+    {props.touched && props.error && <span>{props.error}</span>}
+  </div>
+)
+
 let ReactWidgetsForm = props => {
   const { handleSubmit, pristine, reset, submitting, load } = props
   return (
@@ -37,52 +67,21 @@ let ReactWidgetsForm = props => {
     </div>
     <div>
       <label>Favorite Color</label>
-      <Field name="favoriteColor"
-        component={ favoriteColor =>
-          <div>
-            <DropdownList
-              {...favoriteColor}
-              data={colors}
-              valueField="value"
-              textField="color"
-              onChange={(value) => favoriteColor.onChange(value)}
-            />
-            {favoriteColor.touched && favoriteColor.error && <span>{favoriteColor.error}</span>}
-          </div>
-          }
-        />
+      <Field
+        name="favoriteColor"
+        component={renderDropdownList}
+        data={colors}
+        valueField="value"
+        textField="color"
+      />
       </div>
       <div>
       <label>Hobbies</label>
-      <Field name="hobbies"
-        component={ hobbies =>
-          <div>
-            <Multiselect
-              {...hobbies}
-              data={[ 'Guitar', 'Cycling', 'Hiking' ]}
-              onChange={ value => hobbies.onChange(value)}
-              onBlur = {event => hobbies.onBlur()}
-            />
-            {hobbies.touched && hobbies.error && <span>{hobbies.error}</span>}
-          </div>
-          }
-        />
+        <Field name="hobbies" component={renderMultiselect} data={[ 'Guitar', 'Cycling', 'Hiking' ]}/>
       </div>
       <div>
         <label>Sex</label>
-        <Field name="sex"
-          component={ sex =>
-            <div>
-              <SelectList
-                {...sex}
-                data={[ 'male', 'female' ]}
-                onChange={(value) => sex.onChange(value)} /* Simulating onChange manually*/
-                onBlur = {event => sex.onBlur()} /* Simulating onBlur manually*/
-              />
-              {sex.touched && sex.error && <span>{sex.error}</span>}
-            </div>
-            }
-          />
+        <Field name="sex" component={renderSelectList} data={[ 'male', 'female' ]}/>
       </div>
       <div>
         <button type="submit" disabled={pristine || submitting}>Submit</button>

--- a/examples/react-widgets/src/ReactWidgetsForm.js
+++ b/examples/react-widgets/src/ReactWidgetsForm.js
@@ -1,0 +1,109 @@
+import React from 'react'
+import { Field, reduxForm } from 'redux-form'
+import DropdownList from 'react-widgets/lib/DropdownList'
+import SelectList from 'react-widgets/lib/SelectList'
+import Multiselect from 'react-widgets/lib/Multiselect'
+import 'react-widgets/dist/css/react-widgets.css'
+import { connect } from 'react-redux'
+import { load as loadData } from './userData'
+
+const initialData = {
+  hobbies: [ 'Guitar', 'Hiking' ],
+  sex: 'female',
+  favoriteColor: 'Blue'
+}
+
+const colors = [ { color: 'Red', value:'ff0000' },
+  { color: 'Green', value:'00ff00' },
+  { color: 'Blue', value:'0000ff' } ]
+
+const validate = values => {
+  const errors = {}
+  const requiredFields = [ 'favoriteColor', 'hobbies', 'sex' ]
+  requiredFields.forEach(field => {
+    if (!values[ field ]) {
+      errors[ field ] = 'Required'
+    }
+  })
+  return errors
+}
+
+let ReactWidgetsForm = props => {
+  const { handleSubmit, pristine, reset, submitting, load } = props
+  return (
+    <form onSubmit={handleSubmit}>
+    <div>
+        <button type="button" onClick={() => load(initialData)}>Initilalize</button>
+    </div>
+    <div>
+      <label>Favorite Color</label>
+      <Field name="favoriteColor"
+        component={ favoriteColor =>
+          <div>
+            <DropdownList
+              {...favoriteColor}
+              data={colors}
+              valueField="value"
+              textField="color"
+              onChange={(value) => favoriteColor.onChange(value)}
+            />
+            {favoriteColor.touched && favoriteColor.error && <span>{favoriteColor.error}</span>}
+          </div>
+          }
+        />
+      </div>
+      <div>
+      <label>Hobbies</label>
+      <Field name="hobbies"
+        component={ hobbies =>
+          <div>
+            <Multiselect
+              {...hobbies}
+              data={[ 'Guitar', 'Cycling', 'Hiking' ]}
+              onChange={ value => hobbies.onChange(value)}
+              onBlur = {event => hobbies.onBlur()}
+            />
+            {hobbies.touched && hobbies.error && <span>{hobbies.error}</span>}
+          </div>
+          }
+        />
+      </div>
+      <div>
+        <label>Sex</label>
+        <Field name="sex"
+          component={ sex =>
+            <div>
+              <SelectList
+                {...sex}
+                data={[ 'male', 'female' ]}
+                onChange={(value) => sex.onChange(value)} /* Simulating onChange manually*/
+                onBlur = {event => sex.onBlur()} /* Simulating onBlur manually*/
+              />
+              {sex.touched && sex.error && <span>{sex.error}</span>}
+            </div>
+            }
+          />
+      </div>
+      <div>
+        <button type="submit" disabled={pristine || submitting}>Submit</button>
+        <button type="button" disabled={pristine || submitting} onClick={reset}>Clear Values</button>
+      </div>
+      </form>
+  )
+}
+
+// Decorate with reduxForm(). It will read the initialValues prop provided by connect()
+ReactWidgetsForm = reduxForm({
+  validate,
+  form: 'ReactWidgetsForm'  // a unique identifier for this form
+})(ReactWidgetsForm)
+
+// You have to connect() to any reducers that you wish to connect to yourself
+ReactWidgetsForm = connect(
+  state => ({
+    initialValues: state.userData.data // pull initial values from account reducer
+  }),
+  { load: loadData }               // bind account loading action creator
+)(ReactWidgetsForm)
+
+export default ReactWidgetsForm

--- a/examples/react-widgets/src/index.js
+++ b/examples/react-widgets/src/index.js
@@ -1,0 +1,98 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { Provider } from 'react-redux'
+import { createStore, combineReducers } from 'redux'
+import { reducer as reduxFormReducer } from 'redux-form'
+import userData from './userData'
+
+import {
+  App,
+  Code,
+  Markdown,
+  Values,
+  generateExampleBreadcrumbs
+} from 'redux-form-website-template'
+
+const dest = document.getElementById('content')
+const reducer = combineReducers({
+  userData,
+  form: reduxFormReducer // mounted under "form"
+})
+const store =
+  (window.devToolsExtension ? window.devToolsExtension()(createStore) : createStore)(reducer)
+
+const showResults = values =>
+  new Promise(resolve => {
+    setTimeout(() => {  // simulate server latency
+      window.alert(`You submitted:\n\n${JSON.stringify(values, null, 2)}`)
+      resolve()
+    }, 500)
+  })
+
+let render = () => {
+  const ReactWidgetsForm = require('./ReactWidgetsForm').default
+  const readme = require('./ReactWidgets.md')
+  const raw = require('!!raw!./ReactWidgetsForm')
+  const rawUserData = require('!!raw!./userData')
+  ReactDOM.render(
+    <Provider store={store}>
+        <App
+          /**
+           * This <App/> component only provides the site wrapper.
+           * Remove it on your dev server if you wish. It will not affect the functionality.
+           */
+          version="6.0.0-alpha.14"
+          path="/examples/react-widgets/"
+          breadcrumbs={generateExampleBreadcrumbs('react-widgets', 'React Widgets Form Example', '6.0.0-alpha.14')}>
+
+          <Markdown content={readme}/>
+
+          <h2>Form</h2>
+
+          <ReactWidgetsForm onSubmit={showResults}/>
+
+          <Values form="ReactWidgetsForm"/>
+
+          <h2>Code</h2>
+
+          <h4>userData.js</h4>
+
+          <Code source={rawUserData}/>
+
+          <h4>ReactWidgetsForm.js</h4>
+
+          <Code source={raw}/>
+
+        </App>
+    </Provider>,
+    dest
+  )
+}
+
+if (module.hot) {
+  // Support hot reloading of components
+  // and display an overlay for runtime errors
+  const renderApp = render
+  const renderError = (error) => {
+    const RedBox = require('redbox-react')
+    ReactDOM.render(
+      <RedBox error={error} className="redbox"/>,
+      dest
+    )
+  }
+  render = () => {
+    try {
+      renderApp()
+    } catch (error) {
+      renderError(error)
+    }
+  }
+  const rerender = () => {
+    setTimeout(render)
+  }
+  module.hot.accept('./ReactWidgetsForm', rerender)
+  module.hot.accept('./ReactWidgets.md', rerender)
+  module.hot.accept('!!raw!./ReactWidgetsForm', rerender)
+}
+
+render()

--- a/examples/react-widgets/src/userData.js
+++ b/examples/react-widgets/src/userData.js
@@ -1,0 +1,25 @@
+// Quack! This is a duck. https://github.com/erikras/ducks-modular-redux
+const LOAD_USERDATA = 'redux-form-examples/data/LOAD_USERDATA'
+
+const reducer = (state = {}, action) => {
+  switch (action.type) {
+    case LOAD_USERDATA:
+      return {
+        data: action.data
+      }
+    default:
+      return state
+  }
+}
+
+/**
+ * Simulates data loaded into this reducer from somewhere
+ */
+export function load(data) {
+  return {
+    type: LOAD_USERDATA,
+    data
+  }
+}
+
+export default reducer

--- a/examples/react-widgets/webpack.config.dev.js
+++ b/examples/react-widgets/webpack.config.dev.js
@@ -1,0 +1,61 @@
+var path = require('path');
+var webpack = require('webpack');
+
+module.exports = {
+  devtool: 'eval',
+  entry: [
+    'babel-polyfill',
+    'eventsource-polyfill', // necessary for hot reloading with IE
+    'webpack-hot-middleware/client',
+    './src/index'
+  ],
+  output: {
+    path: path.join(__dirname, 'dist'),
+    filename: 'bundle.js',
+    publicPath: '/dist/'
+  },
+  plugins: [
+    new webpack.optimize.OccurenceOrderPlugin(),
+    new webpack.HotModuleReplacementPlugin()
+  ],
+  resolve: {
+    modulesDirectories: [
+      'src',
+      'node_modules'
+    ],
+    extensions: [ '', '.json', '.js' ]
+  },
+  module: {
+    loaders: [
+      {
+        test: /\.jsx?/,
+        loaders: [ 'babel', 'eslint' ],
+        include: path.join(__dirname, 'src')
+      },
+      {
+        test: /\.css$/,
+        loader: "style-loader!css-loader"
+      },
+      {
+        test: /\.gif$/,
+        loader: "url-loader?mimetype=image/png"
+      },
+      {
+        test: /\.woff(2)?(\?v=[0-9].[0-9].[0-9])?$/,
+        loader: "url-loader?mimetype=application/font-woff"
+      },
+      {
+        test: /\.(ttf|eot|svg)(\?v=[0-9].[0-9].[0-9])?$/,
+        loader: "file-loader?name=[name].[ext]"
+      },
+      {
+        test: /\.json$/,
+        loader: 'json-loader'
+      },
+      {
+        test: /\.md/,
+        loaders: [ "html-loader", "markdown-loader" ]
+      }
+    ]
+  }
+};

--- a/examples/react-widgets/webpack.config.prod.js
+++ b/examples/react-widgets/webpack.config.prod.js
@@ -1,0 +1,68 @@
+var path = require('path');
+var webpack = require('webpack');
+
+module.exports = {
+  devtool: 'source-map',
+  entry: [
+    'babel-polyfill',
+    './src/index'
+  ],
+  output: {
+    path: path.join(__dirname, 'dist'),
+    filename: 'bundle.js',
+    publicPath: '/dist/'
+  },
+  plugins: [
+    new webpack.optimize.OccurenceOrderPlugin(),
+    new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: JSON.stringify('production')
+      }
+    }),
+    new webpack.optimize.UglifyJsPlugin({
+      compressor: {
+        warnings: false
+      }
+    })
+  ],
+  resolve: {
+    modulesDirectories: [
+      'src',
+      'node_modules'
+    ],
+    extensions: [ '', '.json', '.js' ]
+  },
+  module: {
+    loaders: [
+      {
+        test: /\.js$/,
+        loaders: [ 'babel' ],
+        include: path.join(__dirname, 'src')
+      },
+      {
+        test: /\.css$/,
+        loader: "style-loader!css-loader"
+      },
+      {
+        test: /\.gif$/,
+        loader: "url-loader?mimetype=image/png"
+      },
+      {
+        test: /\.woff(2)?(\?v=[0-9].[0-9].[0-9])?$/,
+        loader: "url-loader?mimetype=application/font-woff"
+      },
+      {
+        test: /\.(ttf|eot|svg)(\?v=[0-9].[0-9].[0-9])?$/,
+        loader: "file-loader?name=[name].[ext]"
+      },
+      {
+        test: /\.json$/,
+        loader: 'json-loader'
+      },
+      {
+        test: /\.md/,
+        loaders: [ "html-loader", "markdown-loader" ]
+      }
+    ]
+  }
+};


### PR DESCRIPTION
Hi @erikras 

I have added an example which will demonstrate how to use `redux-form` with `react-widgets` components. 

Mostly it works out of the box but we need to trick `onChange` and `onBlur` event as and when required.

### Notes

* `react-widgets` is heavily dependent on their css so there isn't exact UI in our example. I have tweaked root css from `index.html`.
* Their [MultiSelect](http://jquense.github.io/react-widgets/docs/#/multiselect?_k=os7mqb) component has a warning error for the `value` props as it expect `array` and we are passing string , though it works as expected.
* I haven't covered `DateTime` and `Number` Components (Please let me know if you would like to add) 
* I have also implemented how to initialize the form so that users have better understanding how to do that with `react-widgets`
* I have added `style-loader` and some of css related loaders in webpack as we are importing css. 
* I haven't used ExtractTextPlugin let me know if you would like to put into prod.config