### PR TITLE
Make _isFieldValue property enumerable in store

### DIFF
--- a/src/__tests__/createReduxForm.spec.js
+++ b/src/__tests__/createReduxForm.spec.js
@@ -1495,12 +1495,14 @@ describe('createReduxForm', () => {
     expect(store.getState().form.testForm.users[ 0 ].name)
       .toEqual({
         initial: 'Bob',
-        value: 'Bob'
+        value: 'Bob',
+        _isFieldValue: true
       });
     expect(store.getState().form.testForm.users[ 0 ].age)
       .toEqual({
         initial: 27,
-        value: 27
+        value: 27,
+        _isFieldValue: true
       });
   });
 
@@ -1794,7 +1796,8 @@ describe('createReduxForm', () => {
     expect(store.getState().form.testForm.children)
       .toEqual({
         initial: [ 3, 4 ],
-        value: [ 3, 4 ]
+        value: [ 3, 4 ],
+        _isFieldValue: true
       });
     // reset form to newly initialized values
     stub.props.resetForm();
@@ -1842,7 +1845,8 @@ describe('createReduxForm', () => {
     expect(store.getState().form.testForm.name)
       .toEqual({
         initial: 'Bob',
-        value: 'Bob'
+        value: 'Bob',
+        _isFieldValue: true
       });
     // set value
     stub.props.fields.name.onChange('Dan');
@@ -1862,7 +1866,8 @@ describe('createReduxForm', () => {
     expect(store.getState().form.testForm.name)
       .toEqual({
         initial: 'Bob',
-        value: 'Dan'
+        value: 'Dan',
+        _isFieldValue: true
       });
 
     // should NOT dispatch INITIALIZE this time
@@ -1888,7 +1893,8 @@ describe('createReduxForm', () => {
     expect(store.getState().form.testForm.name)
       .toEqual({
         initial: 'Bob',
-        value: 'Dan'
+        value: 'Dan',
+        _isFieldValue: true
       });
 
     // manually initialize new values
@@ -1909,7 +1915,8 @@ describe('createReduxForm', () => {
     expect(store.getState().form.testForm.name)
       .toEqual({
         initial: 'Tom',
-        value: 'Tom'
+        value: 'Tom',
+        _isFieldValue: true
       });
   });
 
@@ -1945,7 +1952,8 @@ describe('createReduxForm', () => {
     expect(store.getState().form.testForm.name)
       .toEqual({
         initial: 'Tom',
-        value: 'Tom'
+        value: 'Tom',
+        _isFieldValue: true
       });
     // check value
     expectField({
@@ -2038,7 +2046,8 @@ describe('createReduxForm', () => {
           .toEqual({
             initial: 'Tom',
             value: 'Moe',
-            asyncError: deepError
+            asyncError: deepError,
+            _isFieldValue: true
           });
         // check field
         expectField({
@@ -2095,7 +2104,8 @@ describe('createReduxForm', () => {
             initial: 'Tom',
             value: 'Tom',
             submitError: deepError,
-            touched: true
+            touched: true,
+            _isFieldValue: true
           });
         // check field
         expectField({

--- a/src/__tests__/fieldValue.spec.js
+++ b/src/__tests__/fieldValue.spec.js
@@ -19,10 +19,9 @@ describe('fieldValue', () => {
       const someObject = {b: 1};
       expect(someObject).toEqual({b: 1});
       makeFieldValue(someObject);
-      expect(someObject).toEqual({
-        b: 1,
-        _isFieldValue: true
-      });
+      expect(someObject).toEqual(Object.defineProperties({b: 1}, {
+        _isFieldValue: {value: true, enumerable: false} // hide property
+      }));
     });
 
     it('should set the field value flag', () => {
@@ -30,6 +29,14 @@ describe('fieldValue', () => {
       expect(isFieldValue(someObject)).toBe(false);
       makeFieldValue(someObject);
       expect(isFieldValue(someObject)).toBe(true);
+    });
+
+    it('should be still field value after object recreation', () => {
+      const someObject = makeFieldValue({b: 1});
+      expect(isFieldValue(someObject)).toBe(true);
+
+      const recreatedObject = JSON.parse(JSON.stringify(someObject));
+      expect(isFieldValue(recreatedObject)).toBe(true);
     });
   });
 

--- a/src/__tests__/fieldValue.spec.js
+++ b/src/__tests__/fieldValue.spec.js
@@ -19,7 +19,10 @@ describe('fieldValue', () => {
       const someObject = {b: 1};
       expect(someObject).toEqual({b: 1});
       makeFieldValue(someObject);
-      expect(someObject).toEqual({b: 1});
+      expect(someObject).toEqual({
+        b: 1,
+        _isFieldValue: true
+      });
     });
 
     it('should set the field value flag', () => {

--- a/src/__tests__/getValuesFromState.spec.js
+++ b/src/__tests__/getValuesFromState.spec.js
@@ -236,4 +236,23 @@ describe('getValuesFromState', () => {
         }
       });
   });
+
+  it('should retrieve values from recreated state', () => {
+    const initialState = {
+      foo: makeFieldValue({
+        value: 'bar'
+      })
+    };
+
+    expect(getValuesFromState(initialState)).toEqual({
+      foo: 'bar'
+    });
+
+    const serializedState = JSON.stringify(initialState);
+    const unSerializedState = JSON.parse(serializedState);
+
+    expect(getValuesFromState(unSerializedState)).toEqual({
+      foo: 'bar'
+    });
+  });
 });

--- a/src/__tests__/initializeState.spec.js
+++ b/src/__tests__/initializeState.spec.js
@@ -13,7 +13,14 @@ describe('initializeState', () => {
 
   it('should return empty field entries for each field', () => {
     const result = initializeState({}, ['foo', 'bar'], {});
-    expect(result).toEqual({foo: {}, bar: {}});
+    expect(result).toEqual({
+      foo: {
+        _isFieldValue: true
+      },
+      bar: {
+        _isFieldValue: true
+      }
+    });
     expect(isFieldValue(result.foo)).toBe(true);
     expect(isFieldValue(result.bar)).toBe(true);
   });
@@ -29,15 +36,18 @@ describe('initializeState', () => {
       .toEqual({
         foo: {
           initial: 'bar',
-          value: 'bar'
+          value: 'bar',
+          _isFieldValue: true
         },
         catLives: {
           initial: 9,
-          value: 9
+          value: 9,
+          _isFieldValue: true
         },
         alive: {
           initial: true,
-          value: true
+          value: true,
+          _isFieldValue: true
         }
       });
     expect(isFieldValue(result.foo)).toBe(true);
@@ -61,18 +71,21 @@ describe('initializeState', () => {
         foo: {
           bar: {
             initial: 'baz',
-            value: 'baz'
+            value: 'baz',
+            _isFieldValue: true
           }
         },
         lives: {
           cat: {
             initial: 9,
-            value: 9
+            value: 9,
+            _isFieldValue: true
           }
         },
         alive: {
           initial: true,
-          value: true
+          value: true,
+          _isFieldValue: true
         }
       });
     expect(isFieldValue(result.foo)).toBe(false);
@@ -93,17 +106,22 @@ describe('initializeState', () => {
         foo: [
           {
             initial: 'bar',
-            value: 'bar'
+            value: 'bar',
+            _isFieldValue: true
           },
           {
             initial: 'baz',
-            value: 'baz'
+            value: 'baz',
+            _isFieldValue: true
           },
-          {}
+          {
+            _isFieldValue: true
+          }
         ],
         alive: {
           initial: true,
-          value: true
+          value: true,
+          _isFieldValue: true
         }
       });
     expect(isFieldValue(result.foo)).toBe(false);
@@ -123,7 +141,8 @@ describe('initializeState', () => {
         foo: [],
         bar: {
           initial: 42,
-          value: 42
+          value: 42,
+          _isFieldValue: true
         }
       });
     expect(isFieldValue(result.foo)).toBe(false);
@@ -150,11 +169,13 @@ describe('initializeState', () => {
       .toEqual({
         animals: {
           initial: ['cat', 'dog', 'rat'],
-          value: ['cat', 'dog', 'rat']
+          value: ['cat', 'dog', 'rat'],
+          _isFieldValue: true
         },
         bar: {
           initial: [{deeper: 42}],
-          value: [{deeper: 42}]
+          value: [{deeper: 42}],
+          _isFieldValue: true
         }
       });
     expect(isFieldValue(result.animals)).toBe(true);
@@ -178,11 +199,13 @@ describe('initializeState', () => {
       .toEqual({
         animals: {
           initial: ['cat', 'dog', 'rat'],
-          value: ['cat', 'dog', 'rat']
+          value: ['cat', 'dog', 'rat'],
+          _isFieldValue: true
         },
         bar: {
           initial: [],
-          value: []
+          value: [],
+          _isFieldValue: true
         }
       });
     expect(isFieldValue(result.animals)).toBe(true);
@@ -200,11 +223,13 @@ describe('initializeState', () => {
       .toEqual({
         foo: {
           initial: {bar: 'baz'},
-          value: {bar: 'baz'}
+          value: {bar: 'baz'},
+          _isFieldValue: true
         },
         lives: {
           initial: {cat: 9},
-          value: {cat: 9}
+          value: {cat: 9},
+          _isFieldValue: true
         }
       });
     expect(isFieldValue(result.foo)).toBe(true);

--- a/src/__tests__/reducer.spec.js
+++ b/src/__tests__/reducer.spec.js
@@ -1405,7 +1405,8 @@ describe('reducer', () => {
       .toEqual({
         myField: [
           {
-            value: 'foo',_isFieldValue: true
+            value: 'foo',
+            _isFieldValue: true
           }
         ],
         _active: undefined,

--- a/src/__tests__/reducer.spec.js
+++ b/src/__tests__/reducer.spec.js
@@ -58,7 +58,8 @@ describe('reducer', () => {
       .toEqual({
         myField: [
           {
-            value: undefined
+            value: undefined,
+            _isFieldValue: true
           }
         ],
         _active: undefined,
@@ -82,7 +83,8 @@ describe('reducer', () => {
         myField: {
           myArray: [
             {
-              value: undefined
+              value: undefined,
+              _isFieldValue: true
             }
           ]
         },
@@ -108,7 +110,8 @@ describe('reducer', () => {
         myField: {
           myArray: [
             {
-              value: 20
+              value: 20,
+              _isFieldValue: true
             }
           ]
         },
@@ -150,13 +153,16 @@ describe('reducer', () => {
       .toEqual({
         myField: [
           {
-            value: 'foo'
+            value: 'foo',
+            _isFieldValue: true
           },
           {
-            value: 'bar'
+            value: 'bar',
+            _isFieldValue: true
           },
           {
-            value: 'baz'
+            value: 'baz',
+            _isFieldValue: true
           }
         ],
         _active: undefined,
@@ -198,13 +204,16 @@ describe('reducer', () => {
       .toEqual({
         myField: [
           {
-            value: 'foo'
+            value: 'foo',
+            _isFieldValue: true
           },
           {
-            value: 'baz'
+            value: 'baz',
+            _isFieldValue: true
           },
           {
-            value: 'bar'
+            value: 'bar',
+            _isFieldValue: true
           }
         ],
         _active: undefined,
@@ -361,7 +370,7 @@ describe('reducer', () => {
               initial: {a: 'bar-a2', b: 'bar-b2'},
               value: {a: 'bar-a2', b: 'bar-b2'},
             })
-          },
+          }
         ],
         _active: undefined,
         _asyncValidating: false,
@@ -384,32 +393,38 @@ describe('reducer', () => {
             foo: {
               initial: {a: 'foo-a1', b: 'foo-b1'},
               value: {a: 'foo-a1', b: 'foo-b1'},
+              _isFieldValue: true
             },
             bar: {
               initial: {a: 'bar-a1', b: 'bar-b1'},
               value: {a: 'bar-a1', b: 'bar-b1'},
+              _isFieldValue: true
             }
           },
           {
             foo: {
               initial: {a: 'foo-a2', b: 'foo-b2'},
               value: {a: 'foo-a2', b: 'foo-b2'},
+              _isFieldValue: true
             },
             bar: {
               initial: {a: 'bar-a2', b: 'bar-b2'},
               value: {a: 'bar-a2', b: 'bar-b2'},
+              _isFieldValue: true
             }
           },
           {
             foo: {
               initial: {a: 'foo-a3', b: 'foo-b3'},
               value: {a: 'foo-a3', b: 'foo-b3'},
+              _isFieldValue: true
             },
             bar: {
               initial: {a: 'bar-a3', b: 'bar-b3'},
               value: {a: 'bar-a3', b: 'bar-b3'},
+              _isFieldValue: true
             }
-          },
+          }
         ],
         _active: undefined,
         _asyncValidating: false,
@@ -502,59 +517,69 @@ describe('reducer', () => {
               {
                 foo: {
                   initial: 'foo-1-1',
-                  value: 'foo-1-1'
+                  value: 'foo-1-1',
+                  _isFieldValue: true
                 },
                 bar: {
                   initial: 'bar-1-1',
-                  value: 'bar-1-1'
+                  value: 'bar-1-1',
+                  _isFieldValue: true
                 }
               },
               {
                 foo: {
                   initial: 'foo-1-2',
-                  value: 'foo-1-2'
+                  value: 'foo-1-2',
+                  _isFieldValue: true
                 },
                 bar: {
                   initial: 'bar-1-2',
-                  value: 'bar-1-2'
+                  value: 'bar-1-2',
+                  _isFieldValue: true
                 }
-              },
-            ],
+              }
+            ]
           },
           {
             myField2: [
               {
                 foo: {
                   initial: 'foo-2-1',
-                  value: 'foo-2-1'
+                  value: 'foo-2-1',
+                  _isFieldValue: true
                 },
                 bar: {
                   initial: 'bar-2-1',
-                  value: 'bar-2-1'
+                  value: 'bar-2-1',
+                  _isFieldValue: true
                 }
               },
               {
                 foo: {
                   initial: 'foo-2-2',
-                  value: 'foo-2-2'
+                  value: 'foo-2-2',
+                  _isFieldValue: true
                 },
                 bar: {
                   initial: 'bar-2-2',
-                  value: 'bar-2-2'
+                  value: 'bar-2-2',
+                  _isFieldValue: true
                 }
               },
               {
                 foo: {
                   initial: 'foo-2-3',
-                  value: 'foo-2-3'
+                  value: 'foo-2-3',
+                  _isFieldValue: true
                 },
                 bar: {
                   initial: 'bar-2-3',
-                  value: 'bar-2-3'
+                  value: 'bar-2-3',
+                  _isFieldValue: true
                 }
-              },
-            ],
-          },
+              }
+            ]
+          }
         ],
         _active: undefined,
         _asyncValidating: false,
@@ -594,7 +619,8 @@ describe('reducer', () => {
       .toEqual({
         myField: {
           value: 'myValue',
-          autofilled: true
+          autofilled: true,
+          _isFieldValue: true
         },
         _active: undefined,
         _asyncValidating: false,
@@ -627,7 +653,8 @@ describe('reducer', () => {
       .toEqual({
         myField: {
           value: 'different',
-          autofilled: true
+          autofilled: true,
+          _isFieldValue: true
         },
         _active: 'myField',
         _asyncValidating: false,
@@ -647,7 +674,8 @@ describe('reducer', () => {
     expect(state.foo)
       .toEqual({
         myField: {
-          value: 'myValue'
+          value: 'myValue',
+          _isFieldValue: true
         },
         _asyncValidating: false,
         [globalErrorKey]: undefined,
@@ -668,7 +696,8 @@ describe('reducer', () => {
       .toEqual({
         myField: {
           value: 'myValue',
-          touched: true
+          touched: true,
+          _isFieldValue: true
         },
         _asyncValidating: false,
         [globalErrorKey]: undefined,
@@ -703,7 +732,8 @@ describe('reducer', () => {
         myField: {
           initial: 'initialValue',
           value: 'myValue',
-          touched: true
+          touched: true,
+          _isFieldValue: true
         },
         _asyncValidating: false,
         [globalErrorKey]: undefined,
@@ -739,7 +769,8 @@ describe('reducer', () => {
         myField: {
           initial: 'initialValue',
           value: 'myValue',
-          touched: true
+          touched: true,
+          _isFieldValue: true
         },
         _asyncValidating: false,
         [globalErrorKey]: undefined,
@@ -772,7 +803,8 @@ describe('reducer', () => {
       .toEqual({
         myField: {
           value: undefined,
-          touched: true
+          touched: true,
+          _isFieldValue: true
         },
         _asyncValidating: false,
         [globalErrorKey]: undefined,
@@ -808,7 +840,8 @@ describe('reducer', () => {
         myField: {
           mySubField: {
             value: 'hello',
-            touched: true
+            touched: true,
+            _isFieldValue: true
           }
         },
         _asyncValidating: false,
@@ -844,7 +877,8 @@ describe('reducer', () => {
         myArray: [
           {
             value: 'hello',
-            touched: true
+            touched: true,
+            _isFieldValue: true
           }
         ],
         _asyncValidating: false,
@@ -864,7 +898,8 @@ describe('reducer', () => {
     expect(state.foo)
       .toEqual({
         myField: {
-          value: 'myValue'
+          value: 'myValue',
+          _isFieldValue: true
         },
         _active: undefined, // CHANGE doesn't touch _active
         _asyncValidating: false,
@@ -886,7 +921,8 @@ describe('reducer', () => {
       .toEqual({
         myField: {
           value: 'myValue',
-          touched: true
+          touched: true,
+          _isFieldValue: true
         },
         _active: undefined, // CHANGE doesn't touch _active
         _asyncValidating: false,
@@ -923,7 +959,8 @@ describe('reducer', () => {
         myField: {
           initial: 'initialValue',
           value: 'myValue',
-          touched: true
+          touched: true,
+          _isFieldValue: true
         },
         _active: 'myField',
         _asyncValidating: false,
@@ -957,7 +994,8 @@ describe('reducer', () => {
     expect(state.foo)
       .toEqual({
         myField: {
-          value: 'different'
+          value: 'different',
+          _isFieldValue: true
         },
         _active: 'myField',
         _asyncValidating: false,
@@ -990,7 +1028,8 @@ describe('reducer', () => {
     expect(state.foo)
       .toEqual({
         myField: {
-          value: 'different'
+          value: 'different',
+          _isFieldValue: true
         },
         _active: 'myField',
         _asyncValidating: false,
@@ -1011,7 +1050,8 @@ describe('reducer', () => {
       .toEqual({
         myField: {
           mySubField: {
-            value: 'myValue'
+            value: 'myValue',
+            _isFieldValue: true
           }
         },
         _active: undefined, // CHANGE doesn't touch _active
@@ -1033,7 +1073,8 @@ describe('reducer', () => {
     expect(state.foo)
       .toEqual({
         myField: {
-          visited: true
+          visited: true,
+          _isFieldValue: true
         },
         _active: 'myField',
         _asyncValidating: false,
@@ -1054,7 +1095,8 @@ describe('reducer', () => {
       .toEqual({
         myField: {
           subField: {
-            visited: true
+            visited: true,
+            _isFieldValue: true
           }
         },
         _active: 'myField.subField',
@@ -1092,7 +1134,8 @@ describe('reducer', () => {
         myField: {
           initial: 'initialValue',
           value: 'initialValue',
-          visited: true
+          visited: true,
+          _isFieldValue: true
         },
         _active: 'myField',
         _asyncValidating: false,
@@ -1113,7 +1156,8 @@ describe('reducer', () => {
       .toEqual({
         myField: {
           initial: 'initialValue',
-          value: 'initialValue'
+          value: 'initialValue',
+          _isFieldValue: true
         },
         _active: undefined,
         _asyncValidating: false,
@@ -1134,11 +1178,13 @@ describe('reducer', () => {
       .toEqual({
         bar: {
           initial: 'baz',
-          value: 'baz'
+          value: 'baz',
+          _isFieldValue: true
         },
         dog: {
           initial: null,
-          value: null
+          value: null,
+          _isFieldValue: true
         },
         _active: undefined,
         _asyncValidating: false,
@@ -1161,7 +1207,8 @@ describe('reducer', () => {
         myField: {
           subField: {
             initial: 'initialValue',
-            value: 'initialValue'
+            value: 'initialValue',
+            _isFieldValue: true
           }
         },
         _active: undefined,
@@ -1185,7 +1232,8 @@ describe('reducer', () => {
         myField: [
           {
             initial: 'initialValue',
-            value: 'initialValue'
+            value: 'initialValue',
+            _isFieldValue: true
           }
         ],
         _active: undefined,
@@ -1221,21 +1269,25 @@ describe('reducer', () => {
           {
             name: {
               initial: 'Bobby Tables',
-              value: 'Bobby Tables'
+              value: 'Bobby Tables',
+              _isFieldValue: true
             },
             email: {
               initial: 'bobby@gmail.com',
-              value: 'bobby@gmail.com'
+              value: 'bobby@gmail.com',
+              _isFieldValue: true
             }
           },
           {
             name: {
               initial: 'Sammy Tables',
-              value: 'Sammy Tables'
+              value: 'Sammy Tables',
+              _isFieldValue: true
             },
             email: {
               initial: 'sammy@gmail.com',
-              value: 'sammy@gmail.com'
+              value: 'sammy@gmail.com',
+              _isFieldValue: true
             }
           }
         ],
@@ -1278,7 +1330,8 @@ describe('reducer', () => {
       .toEqual({
         myField: {
           initial: 'cleanValue',
-          value: 'cleanValue'
+          value: 'cleanValue',
+          _isFieldValue: true
         },
         _active: undefined,
         _asyncValidating: false,
@@ -1313,7 +1366,8 @@ describe('reducer', () => {
       .toEqual({
         myField: {
           initial: 'cleanValue',
-          value: 'dirtyValue'
+          value: 'dirtyValue',
+          _isFieldValue: true
         },
         _active: undefined,
         _asyncValidating: false,
@@ -1351,7 +1405,7 @@ describe('reducer', () => {
       .toEqual({
         myField: [
           {
-            value: 'foo'
+            value: 'foo',_isFieldValue: true
           }
         ],
         _active: undefined,
@@ -1421,10 +1475,12 @@ describe('reducer', () => {
       .toEqual({
         myField: [
           {
-            value: 'bar'
+            value: 'bar',
+            _isFieldValue: true
           },
           {
-            value: 'baz'
+            value: 'baz',
+            _isFieldValue: true
           }
         ],
         _active: undefined,
@@ -1468,10 +1524,12 @@ describe('reducer', () => {
       .toEqual({
         myField: [
           {
-            value: 'foo'
+            value: 'foo',
+            _isFieldValue: true
           },
           {
-            value: 'baz'
+            value: 'baz',
+            _isFieldValue: true
           }
         ],
         _active: undefined,
@@ -1542,13 +1600,16 @@ describe('reducer', () => {
       .toEqual({
         myField: [
           {
-            value: 'baz'
+            value: 'baz',
+            _isFieldValue: true
           },
           {
-            value: 'bar'
+            value: 'bar',
+            _isFieldValue: true
           },
           {
-            value: 'foo'
+            value: 'foo',
+            _isFieldValue: true
           }
         ],
         _active: undefined,
@@ -1594,13 +1655,16 @@ describe('reducer', () => {
       .toEqual({
         myField: [
           {
-            value: 'foo'
+            value: 'foo',
+            _isFieldValue: true
           },
           {
-            value: 'bar'
+            value: 'bar',
+            _isFieldValue: true
           },
           {
-            value: 'baz'
+            value: 'baz',
+            _isFieldValue: true
           }
         ],
         _active: undefined,
@@ -1646,13 +1710,16 @@ describe('reducer', () => {
       .toEqual({
         myField: [
           {
-            value: 'foo'
+            value: 'foo',
+            _isFieldValue: true
           },
           {
-            value: 'bar'
+            value: 'bar',
+            _isFieldValue: true
           },
           {
-            value: 'baz'
+            value: 'baz',
+            _isFieldValue: true
           }
         ],
         _active: undefined,
@@ -1697,11 +1764,13 @@ describe('reducer', () => {
       .toEqual({
         myField: {
           initial: 'initialValue',
-          value: 'initialValue'
+          value: 'initialValue',
+          _isFieldValue: true
         },
         myOtherField: {
           initial: 'otherInitialValue',
-          value: 'otherInitialValue'
+          value: 'otherInitialValue',
+          _isFieldValue: true
         },
         _active: undefined,
         _asyncValidating: false,
@@ -1745,11 +1814,13 @@ describe('reducer', () => {
         deepField: {
           myField: {
             initial: 'initialValue',
-            value: 'initialValue'
+            value: 'initialValue',
+            _isFieldValue: true
           },
           myOtherField: {
             initial: 'otherInitialValue',
-            value: 'otherInitialValue'
+            value: 'otherInitialValue',
+            _isFieldValue: true
           }
         },
         _active: undefined,
@@ -1817,7 +1888,8 @@ describe('reducer', () => {
       .toEqual({
         myField: {
           initial: 'initialValue',
-          value: 'initialValue'
+          value: 'initialValue',
+          _isFieldValue: true
         },
         doesnt: 'matter',
         should: 'notchange',
@@ -1927,12 +1999,14 @@ describe('reducer', () => {
             initial: 'initialValue',
             value: 'dirtyValue',
             touched: true,
+            _isFieldValue: true,
             asyncError: 'Error about myField'
           },
           myOtherField: {
             initial: 'otherInitialValue',
             value: 'otherDirtyValue',
             touched: true,
+            _isFieldValue: true,
             asyncError: 'Error about myOtherField'
           }
         },
@@ -1986,12 +2060,14 @@ describe('reducer', () => {
             initial: 'initialValue',
             value: 'dirtyValue',
             touched: true,
+            _isFieldValue: true,
             asyncError: 'Error about myField'
           },
           {
             initial: 'otherInitialValue',
             value: 'otherDirtyValue',
             touched: true,
+            _isFieldValue: true,
             asyncError: 'Error about myOtherField'
           }
         ],
@@ -2040,12 +2116,14 @@ describe('reducer', () => {
           initial: 'initialValue',
           value: 'dirtyValue',
           touched: true,
+          _isFieldValue: true,
           asyncError: 'Error about myField'
         },
         myOtherField: {
           initial: 'otherInitialValue',
           value: 'otherDirtyValue',
           touched: true,
+          _isFieldValue: true,
           asyncError: 'Error about myOtherField'
         },
         _active: undefined,
@@ -2090,12 +2168,14 @@ describe('reducer', () => {
         myField: {
           initial: 'initialValue',
           value: 'dirtyValue',
-          touched: true
+          touched: true,
+          _isFieldValue: true
         },
         myOtherField: {
           initial: 'otherInitialValue',
           value: 'otherDirtyValue',
-          touched: true
+          touched: true,
+          _isFieldValue: true
         },
         _active: undefined,
         _asyncValidating: false,
@@ -2139,12 +2219,14 @@ describe('reducer', () => {
         myField: {
           initial: 'initialValue',
           value: 'dirtyValue',
-          touched: true
+          touched: true,
+          _isFieldValue: true
         },
         myOtherField: {
           initial: 'otherInitialValue',
           value: 'otherDirtyValue',
-          touched: true
+          touched: true,
+          _isFieldValue: true
         },
         _active: undefined,
         _asyncValidating: false,
@@ -2224,12 +2306,14 @@ describe('reducer', () => {
             initial: 'initialValue',
             value: 'dirtyValue',
             touched: true,
+            _isFieldValue: true,
             submitError: 'Error about myField'
           },
           myOtherField: {
             initial: 'otherInitialValue',
             value: 'otherDirtyValue',
             touched: true,
+            _isFieldValue: true,
             submitError: 'Error about myOtherField'
           }
         },
@@ -2283,12 +2367,14 @@ describe('reducer', () => {
             initial: 'initialValue',
             value: 'dirtyValue',
             touched: true,
+            _isFieldValue: true,
             submitError: 'Error about myField'
           },
           {
             initial: 'otherInitialValue',
             value: 'otherDirtyValue',
             touched: true,
+            _isFieldValue: true,
             submitError: 'Error about myOtherField'
           }
         ],
@@ -2366,12 +2452,14 @@ describe('reducer', () => {
           initial: 'initialValue',
           value: 'dirtyValue',
           touched: true,
+          _isFieldValue: true,
           submitError: 'Error about myField'
         },
         myOtherField: {
           initial: 'otherInitialValue',
           value: 'otherDirtyValue',
           touched: true,
+          _isFieldValue: true,
           submitError: 'Error about myOtherField'
         },
         _active: undefined,
@@ -2416,12 +2504,14 @@ describe('reducer', () => {
         myField: {
           initial: 'initialValue',
           value: 'dirtyValue',
-          touched: true
+          touched: true,
+          _isFieldValue: true
         },
         myOtherField: {
           initial: 'otherInitialValue',
           value: 'otherDirtyValue',
-          touched: true
+          touched: true,
+          _isFieldValue: true
         },
         _active: undefined,
         _asyncValidating: false,
@@ -2460,11 +2550,13 @@ describe('reducer', () => {
       .toEqual({
         myField: {
           value: 'initialValue',
-          touched: true
+          touched: true,
+          _isFieldValue: true
         },
         myOtherField: {
           value: 'otherInitialValue',
-          touched: true
+          touched: true,
+          _isFieldValue: true
         },
         _active: undefined,
         _asyncValidating: false,
@@ -2488,7 +2580,7 @@ describe('reducer', () => {
           myOtherField: makeFieldValue({
             value: 'otherInitialValue',
             touched: false
-          }),
+          })
         },
         _active: undefined,
         _asyncValidating: false,
@@ -2506,11 +2598,13 @@ describe('reducer', () => {
         deep: {
           myField: {
             value: 'initialValue',
-            touched: true
+            touched: true,
+            _isFieldValue: true
           },
           myOtherField: {
             value: 'otherInitialValue',
-            touched: true
+            touched: true,
+            _isFieldValue: true
           }
         },
         _active: undefined,
@@ -2554,11 +2648,13 @@ describe('reducer', () => {
         myFields: [
           {
             value: 'initialValue',
-            touched: true
+            touched: true,
+            _isFieldValue: true
           },
           {
             value: 'otherInitialValue',
-            touched: true
+            touched: true,
+            _isFieldValue: true
           }
         ],
         _active: undefined,
@@ -2602,11 +2698,13 @@ describe('reducer', () => {
         myFields: [
           {
             value: 'initialValue',
-            touched: true
+            touched: true,
+            _isFieldValue: true
           },
           {
             value: 'otherInitialValue',
-            touched: true
+            touched: true,
+            _isFieldValue: true
           }
         ],
         _active: undefined,
@@ -2655,13 +2753,15 @@ describe('reducer', () => {
           {
             name: {
               value: 'initialValue',
-              touched: true
+              touched: true,
+              _isFieldValue: true
             }
           },
           {
             name: {
               value: 'otherInitialValue',
-              touched: true
+              touched: true,
+              _isFieldValue: true
             }
           }
         ],
@@ -2754,10 +2854,12 @@ describe('reducer', () => {
     expect(state.foo)
       .toEqual({
         myField: {
-          value: 'initialValue'
+          value: 'initialValue',
+          _isFieldValue: true
         },
         myOtherField: {
-          value: 'otherInitialValue'
+          value: 'otherInitialValue',
+          _isFieldValue: true
         },
         _active: undefined,
         _asyncValidating: false,
@@ -2798,10 +2900,12 @@ describe('reducer', () => {
       .toEqual({
         deep: {
           myField: {
-            value: 'initialValue'
+            value: 'initialValue',
+            _isFieldValue: true
           },
           myOtherField: {
-            value: 'otherInitialValue'
+            value: 'otherInitialValue',
+            _isFieldValue: true
           }
         },
         _active: undefined,
@@ -2844,10 +2948,12 @@ describe('reducer', () => {
       .toEqual({
         myFields: [
           {
-            value: 'initialValue'
+            value: 'initialValue',
+            _isFieldValue: true
           },
           {
-            value: 'otherInitialValue'
+            value: 'otherInitialValue',
+            _isFieldValue: true
           }
         ],
         _active: undefined,
@@ -2890,10 +2996,12 @@ describe('reducer', () => {
       .toEqual({
         myFields: [
           {
-            value: 'initialValue'
+            value: 'initialValue',
+            _isFieldValue: true
           },
           {
-            value: 'otherInitialValue'
+            value: 'otherInitialValue',
+            _isFieldValue: true
           }
         ],
         _active: undefined,
@@ -2941,12 +3049,14 @@ describe('reducer', () => {
         myFields: [
           {
             name: {
-              value: 'initialValue'
+              value: 'initialValue',
+              _isFieldValue: true
             }
           },
           {
             name: {
-              value: 'otherInitialValue'
+              value: 'otherInitialValue',
+              _isFieldValue: true
             }
           }
         ],
@@ -3101,11 +3211,13 @@ describe('reducer', () => {
           _submitting: false,
           _submitFailed: false,
           myField: {
-            value: 'normalized'
+            value: 'normalized',
+            _isFieldValue: true
           },
           person: {
             name: {
-              value: 'John Doe'
+              value: 'John Doe',
+              _isFieldValue: true
             }
           },
           pets: []
@@ -3151,11 +3263,13 @@ describe('reducer', () => {
           firstSubform: {
             ...defaultFields,
             myField: {
-              value: 'normalized'
+              value: 'normalized',
+              _isFieldValue: true
             },
             person: {
               name: {
-                value: 'John Doe'
+                value: 'John Doe',
+                _isFieldValue: true
               }
             },
             pets: []
@@ -3166,11 +3280,13 @@ describe('reducer', () => {
           firstSubform: {
             ...defaultFields,
             myField: {
-              value: 'normalized'
+              value: 'normalized',
+              _isFieldValue: true
             },
             person: {
               name: {
-                value: 'John Doe'
+                value: 'John Doe',
+                _isFieldValue: true
               }
             },
             pets: []
@@ -3178,11 +3294,13 @@ describe('reducer', () => {
           secondSubForm: {
             ...defaultFields,
             myField: {
-              value: 'normalized'
+              value: 'normalized',
+              _isFieldValue: true
             },
             person: {
               name: {
-                value: 'John Doe'
+                value: 'John Doe',
+                _isFieldValue: true
               }
             },
             pets: []
@@ -3214,11 +3332,22 @@ describe('reducer', () => {
           person: {
             name: {
               value: 'John Doe',
+              _isFieldValue: true
             }
           },
           pets: [
-            {name: {value: 'Fido'}},
-            {name: {value: 'Tucker'}}
+            {
+              name: {
+                value: 'Fido',
+                _isFieldValue: true
+              }
+            },
+            {
+              name: {
+                value: 'Tucker',
+                _isFieldValue: true
+              }
+            }
           ]
         }
       });
@@ -3231,16 +3360,28 @@ describe('reducer', () => {
         .toEqual({
           ...defaultFields,
           name: {
-            value: 'normalized'
+            value: 'normalized',
+            _isFieldValue: true
           },
           person: {
             name: {
-              value: 'JOHN DOE'
+              value: 'JOHN DOE',
+              _isFieldValue: true
             }
           },
           pets: [
-            {name: {value: 'fido'}},
-            {name: {value: 'tucker'}}
+            {
+              name: {
+                value: 'fido',
+                _isFieldValue: true
+              }
+            },
+            {
+              name: {
+                value: 'tucker',
+                _isFieldValue: true
+              }
+            }
           ]
         });
     });
@@ -3283,17 +3424,20 @@ describe('reducer', () => {
         .toEqual({
           ...defaultFields,
           name: {
-            value: 'DOG'
+            value: 'DOG',
+            _isFieldValue: true
           },
           person: {
             name: {
-              value: 'JOHN DOE'
+              value: 'JOHN DOE',
+              _isFieldValue: true
             }
           },
           pets: [{
             name: {
               initial: 'Fido',
-              value: 'fido'
+              value: 'fido',
+              _isFieldValue: true
             }
           }]
         });
@@ -3310,17 +3454,20 @@ describe('reducer', () => {
         .toEqual({
           ...defaultFields,
           name: {
-            value: undefined
+            value: undefined,
+            _isFieldValue: true
           },
           person: {
             name: {
-              value: undefined
+              value: undefined,
+              _isFieldValue: true
             }
           },
           pets: [{
             name: {
               initial: 'Fido',
-              value: 'fido'
+              value: 'fido',
+              _isFieldValue: true
             }
           }]
         });
@@ -3443,51 +3590,127 @@ describe('reducer', () => {
         .toBeA('object')
         .toEqual({
           ...defaultFields,
-          name: {value: 'normalized'},
+          name: {
+            value: 'normalized',
+            _isFieldValue: true
+          },
           person: {
-            name: {value: 'JOHN DOE'}
+            name: {
+              value: 'JOHN DOE',
+              _isFieldValue: true
+            }
           },
           pets: [
-            {name: {value: 'fido'}},
-            {name: {value: 'tucker'}}
+            {
+              name: {
+                value: 'fido',
+                _isFieldValue: true
+              }
+            },
+            {
+              name: {
+                value: 'tucker',
+                _isFieldValue: true
+              }
+            }
           ],
           cats: [
-            {value: 'LION'},
-            {value: 'PANTHER'},
-            {value: 'GARFIELD'},
-            {value: 'WHISKERS'}
+            {
+              value: 'LION',
+              _isFieldValue: true
+            },
+            {
+              value: 'PANTHER',
+              _isFieldValue: true
+            },
+            {
+              value: 'GARFIELD',
+              _isFieldValue: true
+            },
+            {
+              value: 'WHISKERS',
+              _isFieldValue: true
+            }
           ],
           programming: [{
             langs: [
-              {value: 'f#'},
-              {value: 'haskell'},
-              {value: 'lisp'},
-              {value: 'ml'},
-              {value: 'ocaml'}
+              {
+                value: 'f#',
+                _isFieldValue: true
+              },
+              {
+                value: 'haskell',
+                _isFieldValue: true
+              },
+              {
+                value: 'lisp',
+                _isFieldValue: true
+              },
+              {
+                value: 'ml',
+                _isFieldValue: true
+              },
+              {
+                value: 'ocaml',
+                _isFieldValue: true
+              }
             ]
           }, {
             langs: [
-              {value: 'c#'},
-              {value: 'c++'},
-              {value: 'java'},
-              {value: 'ruby'},
-              {value: 'smalltalk'}
+              {
+                value: 'c#',
+                _isFieldValue: true
+              },
+              {
+                value: 'c++',
+                _isFieldValue: true
+              },
+              {
+                value: 'java',
+                _isFieldValue: true
+              },
+              {
+                value: 'ruby',
+                _isFieldValue: true
+              },
+              {
+                value: 'smalltalk',
+                _isFieldValue: true
+              }
             ]
           }],
           some: {
             numbers: [
-              {value: 2},
-              {value: 4},
-              {value: 6},
-              {value: 8},
-              {value: 10}
+              {
+                value: 2,
+                _isFieldValue: true
+              },
+              {
+                value: 4,
+                _isFieldValue: true
+              },
+              {
+                value: 6,
+                _isFieldValue: true
+              },
+              {
+                value: 8,
+                _isFieldValue: true
+              },
+              {
+                value: 10,
+                _isFieldValue: true
+              }
             ]
           },
           a: {
             very: {
               deep: {
                 object: {
-                  property: {value: 'TEST'}
+                  property: {
+                    value: 'TEST',
+                    _isFieldValue: true
+                  }
                 }
               }
             }
@@ -3495,33 +3718,75 @@ describe('reducer', () => {
           my: [{
             deeply: [{
               nested: {
-                item: {value: 'HELLO'},
-                not: {value: 'lost'}
+                item: {
+                  value: 'HELLO',
+                  _isFieldValue: true
+                },
+                not: {
+                  value: 'lost',
+                  _isFieldValue: true
+                }
               },
-              otherKey: {value: 'Goodbye'}
+              otherKey: {
+                value: 'Goodbye',
+                _isFieldValue: true
+              }
             }, {
               nested: {
-                item: {value: 'HOLA'},
-                not: {value: 'lost'}
+                item: {
+                  value: 'HOLA',
+                  _isFieldValue: true
+                },
+                not: {
+                  value: 'lost',
+                  _isFieldValue: true
+                }
               },
-              otherKey: {value: 'Adios'}
+              otherKey: {
+                value: 'Adios',
+                _isFieldValue: true
+              }
             }],
-            stays: {value: 'intact'}
+            stays: {
+              value: 'intact',
+              _isFieldValue: true
+            }
           }, {
             deeply: [{
               nested: {
-                item: {value: 'WORLD'},
-                not: {value: 'lost'}
+                item: {
+                  value: 'WORLD',
+                  _isFieldValue: true
+                },
+                not: {
+                  value: 'lost',
+                  _isFieldValue: true
+                }
               },
-              otherKey: {value: 'Later'}
+              otherKey: {
+                value: 'Later',
+                _isFieldValue: true
+              }
             }, {
               nested: {
-                item: {value: 'MUNDO'},
-                not: {value: 'lost'}
+                item: {
+                  value: 'MUNDO',
+                  _isFieldValue: true
+                },
+                not: {
+                  value: 'lost',
+                  _isFieldValue: true
+                }
               },
-              otherKey: {value: 'Hasta luego'}
+              otherKey: {
+                value: 'Hasta luego',
+                _isFieldValue: true
+              }
             }],
-            stays: {value: 'intact'}
+            stays: {
+              value: 'intact',
+              _isFieldValue: true
+            }
           }]
         });
       expect(isFieldValue(state.foo.name)).toBe(true);

--- a/src/__tests__/resetState.spec.js
+++ b/src/__tests__/resetState.spec.js
@@ -27,15 +27,18 @@ describe('resetState', () => {
       .toEqual({
         foo: {
           initial: 'dog',
-          value: 'dog'
+          value: 'dog',
+          _isFieldValue: true
         },
         bar: {
           initial: 'rat',
-          value: 'rat'
+          value: 'rat',
+          _isFieldValue: true
         },
         baz: {
           initial: 'hog',
-          value: 'hog'
+          value: 'hog',
+          _isFieldValue: true
         }
       });
     expect(isFieldValue(result.foo)).toBe(true);
@@ -67,15 +70,19 @@ describe('resetState', () => {
         foo: {
           bar: {
             initial: 'dog',
-            value: 'dog'
+            value: 'dog',
+            _isFieldValue: true
           }
         },
         baz: {
           chad: {
             initial: 'fun',
-            value: 'fun'
+            value: 'fun',
+            _isFieldValue: true
           },
-          chaz: {}
+          chaz: {
+            _isFieldValue: true
+          }
         }
       });
     expect(isFieldValue(result.foo.bar)).toBe(true);
@@ -105,13 +112,17 @@ describe('resetState', () => {
         foo: [
           {
             initial: 'cat',
-            value: 'cat'
+            value: 'cat',
+            _isFieldValue: true
           },
           {
             initial: 'rat',
-            value: 'rat'
+            value: 'rat',
+            _isFieldValue: true
           },
-          {}
+          {
+            _isFieldValue: true
+          }
         ]
       });
     expect(isFieldValue(result.foo[0])).toBe(true);
@@ -143,13 +154,15 @@ describe('resetState', () => {
           {
             value: {
               initial: 'cat',
-              value: 'cat'
+              value: 'cat',
+              _isFieldValue: true
             }
           },
           {
             value: {
               initial: 'pig',
-              value: 'pig'
+              value: 'pig',
+              _isFieldValue: true
             }
           }
         ]

--- a/src/__tests__/setErrors.spec.js
+++ b/src/__tests__/setErrors.spec.js
@@ -20,10 +20,12 @@ describe('setErrors', () => {
     }, '__err'))
       .toEqual({
         foo: {
-          __err: 'fooError'
+          __err: 'fooError',
+          _isFieldValue: true
         },
         bar: {
-          __err: 'barError'
+          __err: 'barError',
+          _isFieldValue: true
         }
       });
   });
@@ -34,8 +36,9 @@ describe('setErrors', () => {
     }, '__err'))
       .toEqual({
         foo: {
-          __err: 'fooError'
-        },
+          __err: 'fooError',
+          _isFieldValue: true
+        }
       });
   });
 
@@ -56,10 +59,12 @@ describe('setErrors', () => {
       .toEqual({
         dog: {
           foo: {
-            __err: 'fooError'
+            __err: 'fooError',
+            _isFieldValue: true
           },
           bar: {
-            __err: 'barError'
+            __err: 'barError',
+            _isFieldValue: true
           }
         }
       });
@@ -75,10 +80,12 @@ describe('setErrors', () => {
       .toEqual({
         dog: [
           {
-            __err: 'fooError'
+            __err: 'fooError',
+            _isFieldValue: true
           },
           {
-            __err: 'barError'
+            __err: 'barError',
+            _isFieldValue: true
           }
         ]
       });
@@ -99,10 +106,12 @@ describe('setErrors', () => {
       .toEqual({
         foo: {
           value: 'bar',
+          _isFieldValue: true,
           __err: 'fooError'
         },
         cat: {
           value: 'rat',
+          _isFieldValue: true,
           __err: 'meow'
         }
       });
@@ -121,10 +130,12 @@ describe('setErrors', () => {
     }, {}, '__err'))
       .toEqual({
         foo: {
-          value: 'bar'
+          value: 'bar',
+          _isFieldValue: true
         },
         cat: {
-          value: 'rat'
+          value: 'rat',
+          _isFieldValue: true
         }
       });
   });
@@ -140,6 +151,7 @@ describe('setErrors', () => {
       .toEqual({
         foo: {
           value: 'bar',
+          _isFieldValue: true,
           __err: 'fooError1'
         }
       });
@@ -161,6 +173,7 @@ describe('setErrors', () => {
         dog: {
           foo: {
             value: 'bar',
+            _isFieldValue: true,
             __err: 'fooError'
           }
         }
@@ -179,7 +192,8 @@ describe('setErrors', () => {
       .toEqual({
         dog: {
           foo: {
-            value: 'bar'
+            value: 'bar',
+            _isFieldValue: true
           }
         }
       });
@@ -199,6 +213,7 @@ describe('setErrors', () => {
       .toEqual({
         foo: {
           value: 'bar',
+          _isFieldValue: true,
           __err: {
             some: 'complex',
             error: 'value'
@@ -223,6 +238,7 @@ describe('setErrors', () => {
         dog: {
           foo: {
             value: 'bar',
+            _isFieldValue: true,
             __err: 'fooError1'
           }
         }
@@ -246,10 +262,12 @@ describe('setErrors', () => {
         foo: [
           {
             value: 'bar',
+            _isFieldValue: true,
             __err: 'fooError'
           },
           {
-            __err: 'additionalErrorForUndefinedField'
+            __err: 'additionalErrorForUndefinedField',
+            _isFieldValue: true
           }
         ]
       });
@@ -269,7 +287,8 @@ describe('setErrors', () => {
       .toEqual({
         foo: [
           {
-            value: 'bar'
+            value: 'bar',
+            _isFieldValue: true
           }
         ]
       });
@@ -284,7 +303,8 @@ describe('setErrors', () => {
       .toEqual({
         foo: [
           {
-            value: 'bar'
+            value: 'bar',
+            _isFieldValue: true
           }
         ]
       });

--- a/src/fieldValue.js
+++ b/src/fieldValue.js
@@ -3,7 +3,14 @@ const isObject = object => typeof object === 'object';
 
 export function makeFieldValue(object) {
   if (object && isObject(object)) {
-    Object.defineProperty(object, flag, {value: true});
+    // This flag has to be enumerable, because otherwise it is not possible
+    // to serialize object with this field.
+    // The consequence is you lose information that particular field is
+    // field or nested group of fields, so you're not able to fetch
+    // field value from state when it has been affected in some way
+    // by serializing/using immutable and so on.
+    // @fixme marking field as leaf should be made in other way
+    Object.defineProperty(object, flag, {value: true, enumerable: true});
   }
   return object;
 }


### PR DESCRIPTION
Fix of issue https://github.com/erikras/redux-form/issues/887 introduced another issue that didn't let you serialize state or use it with immutable.js. Whole background is presented below.

As far as I can see, everything started with this commit 87579e0, which was released with version 5.2.3.

In commit 7b5cb0f64911dffd2ac80e254719ec75333cb8f4 ([release 4.0.7](https://github.com/erikras/redux-form/releases/tag/v4.0.7)) two functions `makeFieldValue` and `isFieldValue` were introduced.
`makeFieldValue` is assigning not enumerable property to field object, so when trying to make Immutable from such object, not-enumerable property is lost.
It does matter, because on store, there is no `_isFieldValue` property assigned to field object, and because of that `isFieldValue` is failing when used in [`src/getValuesFromState`](https://github.com/erikras/redux-form/blob/v5.2.5/src/getValuesFromState.js#L17).

This is not only related to Immutable.js, but also to any form of state serialization, for example `JSON.stringify`.

That's why I've created this pull request, with simply patch that fixes enumeration of mentioned field. Unfortunately, it comes with loads of test changes.
In general this is only patch. To make it work well, it's probably required to rewrite whole concept of nested field.
