### PR TITLE
fix(readField): Generate correct prefix when reading inside array fields, fixes #1090

### DIFF
--- a/src/__tests__/createReduxForm.spec.js
+++ b/src/__tests__/createReduxForm.spec.js
@@ -1573,7 +1573,8 @@ describe('createReduxForm', () => {
         'proposals[].note',
         'proposals[].rooms[].name',
         'proposals[].rooms[].adults',
-        'proposals[].rooms[].children'
+        'proposals[].rooms[].children',
+        'proposals[].meta.items[].name'
       ]
     })(Form);
     const dom = TestUtils.renderIntoDocument(
@@ -1597,13 +1598,22 @@ describe('createReduxForm', () => {
         name: 'Room 1',
         adults: 2,
         children: 0
-      } ]
+      } ],
+      meta: {
+        items: [{
+          name: 'Bilbo'
+        }]
+      }
     });
 
     stub.props.fields.proposals[ 0 ].rooms.addField({
       name: 'Room 2',
       adults: 0,
       children: 2
+    });
+
+    stub.props.fields.proposals[ 0 ].meta.items.addField({
+      name: 'Frodo',
     });
 
     // check field
@@ -1702,6 +1712,30 @@ describe('createReduxForm', () => {
       name: 'proposals[0].rooms[1].children',
       value: 2,
       initial: 2,
+      valid: true,
+      dirty: false,
+      error: undefined,
+      touched: false,
+      visited: false
+    });
+
+    expectField({
+      field: stub.props.fields.proposals[ 0 ].meta.items[ 0 ].name,
+      name: 'proposals[0].meta.items[0].name',
+      value: 'Bilbo',
+      initial: 'Bilbo',
+      valid: true,
+      dirty: false,
+      error: undefined,
+      touched: false,
+      visited: false
+    });
+
+    expectField({
+      field: stub.props.fields.proposals[ 0 ].meta.items[ 1 ].name,
+      name: 'proposals[0].meta.items[1].name',
+      value: 'Frodo',
+      initial: 'Frodo',
       valid: true,
       dirty: false,
       error: undefined,

--- a/src/readField.js
+++ b/src/readField.js
@@ -100,9 +100,10 @@ const readField = (state, fieldName, pathToHere = '', fields, syncErrors, asyncV
     let subobject = fields[key] || {};
     const nextPath = pathToHere + key + '.';
     const nextKey = getNextKey(rest);
+    const nextPrefix = prefix + key + '.';
     const previous = subobject[nextKey];
     const result = readField(state[key] || {}, rest, nextPath, subobject, syncErrors, asyncValidate,
-      isReactNative, props, callback, nextPath);
+      isReactNative, props, callback, nextPrefix);
     if (result !== previous) {
       subobject = {
         ...subobject,


### PR DESCRIPTION
fixes #1090

The issue was that the prefix passed to `readField` wasn't being generated like it is for object fields. e.g. incorrect: `proposals[0].meta.items[].` correct: `proposals[].meta.items[].`

That is, `pathToHere` *may* actually contain indices for deeply nested stuff so you cannot use it.