### PR TITLE
v6 — Remove lodash's `partial` and `partialRight`

### DIFF
--- a/src/ConnectedField.js
+++ b/src/ConnectedField.js
@@ -1,7 +1,7 @@
 import { Component, PropTypes, createElement } from 'react'
 import { connect } from 'react-redux'
 import createFieldProps from './createFieldProps'
-import { partial, mapValues } from 'lodash'
+import { mapValues } from 'lodash'
 import plain from './structure/plain'
 
 const createConnectedField = ({
@@ -65,7 +65,7 @@ const createConnectedField = ({
     _reduxForm: PropTypes.object
   }
 
-  const actions = mapValues({ blur, change, focus }, actionCreator => partial(actionCreator, name))
+  const actions = mapValues({ blur, change, focus }, actionCreator => actionCreator.bind(null, name))
   const connector = connect(
     (state, ownProps) => {
       const initial = getIn(getFormState(state), `initial.${name}`) || propInitialValue

--- a/src/ConnectedFieldArray.js
+++ b/src/ConnectedFieldArray.js
@@ -1,7 +1,7 @@
 import { Component, PropTypes, createElement } from 'react'
 import { connect } from 'react-redux'
 import createFieldArrayProps from './createFieldArrayProps'
-import { partial, mapValues } from 'lodash'
+import { mapValues } from 'lodash'
 import plain from './structure/plain'
 import shallowCompare from 'react-addons-shallow-compare'
 
@@ -85,7 +85,7 @@ const createConnectedFieldArray = ({
     arraySplice,
     arraySwap,
     arrayUnshift
-  }, actionCreator => partial(actionCreator, name))
+  }, actionCreator => actionCreator.bind(null, name))
   const connector = connect(
     state => {
       const initial = getIn(getFormState(state), `initial.${name}`) || propInitialValue

--- a/src/createFieldProps.js
+++ b/src/createFieldProps.js
@@ -3,7 +3,7 @@ import createOnChange from './events/createOnChange'
 import createOnDragStart from './events/createOnDragStart'
 import createOnDrop from './events/createOnDrop'
 import createOnFocus from './events/createOnFocus'
-import { partial, noop } from 'lodash'
+import { noop } from 'lodash'
 
 const processProps = (props, _value) => {
   const { type, value, ...rest } = props
@@ -43,7 +43,7 @@ const createFieldProps = (getIn, name,
     error,
     invalid: !!error,
     name,
-    onBlur: createOnBlur(blur, normalize, partial(asyncValidate, name)),
+    onBlur: createOnBlur(blur, normalize, asyncValidate.bind(null, name)),
     onChange,
     onDragStart: createOnDragStart(name, value),
     onDrop: createOnDrop(name, change),

--- a/src/reduxForm.js
+++ b/src/reduxForm.js
@@ -2,7 +2,7 @@ import { Component, PropTypes, createElement } from 'react'
 import hoistStatics from 'hoist-non-react-statics'
 import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
-import { mapValues, partial, partialRight } from 'lodash'
+import { mapValues } from 'lodash'
 import isPromise from 'is-promise'
 import getDisplayName from './util/getDisplayName'
 import * as importedActions from './actions'
@@ -339,13 +339,13 @@ const createReduxForm =
             }
           },
           (dispatch, initialProps) => {
-            const bindForm = actionCreator => partial(actionCreator, initialProps.form)
+            const bindForm = actionCreator => actionCreator.bind(null, initialProps.form)
 
             // Bind the first parameter on `props.form`
             const boundFormACs = mapValues(formActions, bindForm)
             const boundArrayACs = mapValues(arrayActions, bindForm)
-            const boundBlur = partialRight(bindForm(blur), !!initialProps.touchOnBlur)
-            const boundChange = partialRight(bindForm(change), !!initialProps.touchOnChange)
+            const boundBlur = (field, value) => blur(initialProps.form, field, value, !!initialProps.touchOnBlur)
+            const boundChange = (field, value) => change(initialProps.form, field, value, !!initialProps.touchOnChange)
             const boundFocus = bindForm(focus)
 
             // Wrap action creators with `dispatch`


### PR DESCRIPTION
We can substitute these helpers by `Function#bind` and closures.

Removing them ease the configuration of `LodashModuleReplacementPlugin` because it no longer requires `placeholders` to be enabled.