### PR TITLE
Fixed bug where field was not rerendering when sync error changed

### DIFF
--- a/src/ConnectedField.js
+++ b/src/ConnectedField.js
@@ -20,14 +20,6 @@ const createConnectedField = ({
       return !deepEqual(this.props, nextProps)
     }
 
-    getSyncError() {
-      const { _reduxForm: { getSyncErrors } } = this.context
-      const error = plain.getIn(getSyncErrors(), name)
-      // Because the error for this field might not be at a level in the error structure where
-      // it can be set directly, it might need to be unwrapped from the _error property
-      return error && error._error ? error._error : error
-    }
-
     isPristine() {
       return this.props.pristine
     }
@@ -45,7 +37,6 @@ const createConnectedField = ({
       const props = createFieldProps(getIn,
         name,
         rest,
-        this.getSyncError(),
         asyncValidate
       )
       if (withRef) {

--- a/src/ConnectedField.js
+++ b/src/ConnectedField.js
@@ -2,7 +2,6 @@ import { Component, PropTypes, createElement } from 'react'
 import { connect } from 'react-redux'
 import createFieldProps from './createFieldProps'
 import { mapValues } from 'lodash'
-import plain from './structure/plain'
 
 const createConnectedField = ({
   asyncValidate,

--- a/src/Field.js
+++ b/src/Field.js
@@ -2,6 +2,7 @@ import { Component, PropTypes, createElement } from 'react'
 import invariant from 'invariant'
 import createConnectedField from './ConnectedField'
 import shallowCompare from 'react-addons-shallow-compare'
+import plain from './structure/plain'
 
 const createField = ({ deepEqual, getIn, setIn }) => {
 
@@ -74,10 +75,19 @@ const createField = ({ deepEqual, getIn, setIn }) => {
       )
     }
 
+    getSyncError() {
+      const { _reduxForm: { getSyncErrors } } = this.context
+      const error = plain.getIn(getSyncErrors(), this.props.name)
+      // Because the error for this field might not be at a level in the error structure where
+      // it can be set directly, it might need to be unwrapped from the _error property
+      return error && error._error ? error._error : error
+    }
+    
     render() {
       return createElement(this.ConnectedField, {
         ...this.props,
         normalize: this.normalize,
+        syncError: this.getSyncError(),
         ref: 'connected'
       })
     }

--- a/src/__tests__/Field.spec.js
+++ b/src/__tests__/Field.spec.js
@@ -18,7 +18,7 @@ const describeField = (name, structure, combineReducers, expect) => {
   const reduxForm = createReduxForm(structure)
   const Field = createField(structure)
   const reducer = createReducer(structure)
-  const { fromJS } = structure
+  const { fromJS, getIn } = structure
   const makeStore = (initial) => createStore(
     combineReducers({ form: reducer }), fromJS({ form: initial }))
 
@@ -606,58 +606,61 @@ const describeField = (name, structure, combineReducers, expect) => {
     // ----------------------------------------------
     // Uncomment this to confirm that #1024 is fixed.
     // ----------------------------------------------
-    // it('should rerender when sync error changes', () => {
-    //   const store = makeStore({
-    //     testForm: {
-    //       values: {
-    //         password: 'redux-form sucks',
-    //         confirm: 'redux-form rocks'
-    //       }
-    //     }
-    //   })
-    //   const passwordInput = createSpy(props => <input {...props}/>).andCallThrough()
-    //   const confirmInput = createSpy(props => <input {...props}/>).andCallThrough()
-    //   const validate = ({ password, confirm }) =>
-    //     password === confirm ? {} : { confirm: 'Must match!' }
-    //   class Form extends Component {
-    //     render() {
-    //       return (<div>
-    //         <Field name="password" component={passwordInput}/>
-    //         <Field name="confirm" component={confirmInput}/>
-    //       </div>)
-    //     }
-    //   }
-    //   const TestForm = reduxForm({
-    //     form: 'testForm',
-    //     validate
-    //   })(Form)
-    //   const dom = TestUtils.renderIntoDocument(
-    //     <Provider store={store}>
-    //       <TestForm/>
-    //     </Provider>
-    //   )
-    //
-    //   // password input rendered
-    //   expect(passwordInput).toHaveBeenCalled()
-    //   expect(passwordInput.calls.length).toBe(1)
-    //
-    //   // confirm input rendered with error
-    //   expect(confirmInput).toHaveBeenCalled()
-    //   expect(confirmInput.calls.length).toBe(1)
-    //   expect(confirmInput.calls[ 0 ].arguments[ 0 ].valid).toBe(false)
-    //   expect(confirmInput.calls[ 0 ].arguments[ 0 ].error).toBe('Must match!')
-    //
-    //   // update password field so that they match
-    //   passwordInput.calls[ 0 ].arguments[ 0 ].onChange('redux-form rocks')
-    //
-    //   // password input rerendered
-    //   expect(passwordInput.calls.length).toBe(2)
-    //
-    //   // confirm input should also rerender, but with no error
-    //   expect(confirmInput.calls.length).toBe(2)
-    //   expect(confirmInput.calls[ 1 ].arguments[ 0 ].valid).toBe(true)
-    //   expect(confirmInput.calls[ 1 ].arguments[ 0 ].error).toBe(undefined)
-    // })
+    it('should rerender when sync error changes', () => {
+      const store = makeStore({
+        testForm: {
+          values: {
+            password: 'redux-form sucks',
+            confirm: 'redux-form rocks'
+          }
+        }
+      })
+      const passwordInput = createSpy(props => <input {...props}/>).andCallThrough()
+      const confirmInput = createSpy(props => <input {...props}/>).andCallThrough()
+      const validate = values => {
+        const password = getIn(values, 'password')
+        const confirm = getIn(values, 'confirm')
+        return password === confirm ? {} : { confirm: 'Must match!' }
+      }
+      class Form extends Component {
+        render() {
+          return (<div>
+            <Field name="password" component={passwordInput}/>
+            <Field name="confirm" component={confirmInput}/>
+          </div>)
+        }
+      }
+      const TestForm = reduxForm({
+        form: 'testForm',
+        validate
+      })(Form)
+      const dom = TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <TestForm/>
+        </Provider>
+      )
+
+      // password input rendered
+      expect(passwordInput).toHaveBeenCalled()
+      expect(passwordInput.calls.length).toBe(1)
+
+      // confirm input rendered with error
+      expect(confirmInput).toHaveBeenCalled()
+      expect(confirmInput.calls.length).toBe(1)
+      expect(confirmInput.calls[ 0 ].arguments[ 0 ].valid).toBe(false)
+      expect(confirmInput.calls[ 0 ].arguments[ 0 ].error).toBe('Must match!')
+
+      // update password field so that they match
+      passwordInput.calls[ 0 ].arguments[ 0 ].onChange('redux-form rocks')
+
+      // password input rerendered
+      expect(passwordInput.calls.length).toBe(2)
+
+      // confirm input should also rerender, but with no error
+      expect(confirmInput.calls.length).toBe(2)
+      expect(confirmInput.calls[ 1 ].arguments[ 0 ].valid).toBe(true)
+      expect(confirmInput.calls[ 1 ].arguments[ 0 ].error).toBe(undefined)
+    })
   })
 }
 

--- a/src/__tests__/Field.spec.js
+++ b/src/__tests__/Field.spec.js
@@ -634,7 +634,7 @@ const describeField = (name, structure, combineReducers, expect) => {
         form: 'testForm',
         validate
       })(Form)
-      const dom = TestUtils.renderIntoDocument(
+      TestUtils.renderIntoDocument(
         <Provider store={store}>
           <TestForm/>
         </Provider>

--- a/src/__tests__/createFieldProps.spec.js
+++ b/src/__tests__/createFieldProps.spec.js
@@ -121,7 +121,7 @@ const describeCreateFieldProps = (name, structure, expect) => {
       expect(visitedResult.visited).toBe(true)
     })
 
-    it('should read sync errors from param', () => {
+    it('should read sync errors from prop', () => {
       const noErrorResult = createFieldProps(getIn, 'foo', {
         value: 'bar',
         state: empty
@@ -131,8 +131,9 @@ const describeCreateFieldProps = (name, structure, expect) => {
       expect(noErrorResult.invalid).toBe(false)
       const errorResult = createFieldProps(getIn, 'foo', {
         value: 'bar',
-        state: empty
-      }, 'This is an error')
+        state: empty,
+        syncError: 'This is an error'
+      })
       expect(errorResult.error).toBe('This is an error')
       expect(errorResult.valid).toBe(false)
       expect(errorResult.invalid).toBe(true)
@@ -148,8 +149,9 @@ const describeCreateFieldProps = (name, structure, expect) => {
       expect(noErrorResult.invalid).toBe(false)
       const errorResult = createFieldProps(getIn, 'foo', {
         value: 'bar',
-        state: empty
-      }, 'This is an error')
+        state: empty,
+        syncError: 'This is an error'
+      })
       expect(errorResult.error).toBe('This is an error')
       expect(errorResult.valid).toBe(false)
       expect(errorResult.invalid).toBe(true)
@@ -184,8 +186,9 @@ const describeCreateFieldProps = (name, structure, expect) => {
       const errorResult = createFieldProps(getIn, 'foo', {
         value: 'bar',
         asyncError: 'async error',
-        submitError: 'submit error'
-      }, 'sync error')
+        submitError: 'submit error',
+        syncError: 'sync error'
+      })
       expect(errorResult.error).toBe('sync error')
       expect(errorResult.valid).toBe(false)
       expect(errorResult.invalid).toBe(true)

--- a/src/createFieldProps.js
+++ b/src/createFieldProps.js
@@ -33,8 +33,8 @@ const processProps = (props, _value) => {
 }
 
 const createFieldProps = (getIn, name,
-  { asyncError, blur, change, defaultValue = '', dirty, focus, normalize, pristine, state,
-    submitError, value, _value, props, ...rest }, syncError, asyncValidate = noop) => {
+  { asyncError, blur, change, defaultValue = '', dirty, focus, normalize, pristine, props, state,
+    submitError, value, _value, syncError, ...rest }, asyncValidate = noop) => {
   const error = syncError || asyncError || submitError
   const onChange = createOnChange(change, normalize)
   return processProps({


### PR DESCRIPTION
Fixes #1024.

Moved `getSyncError()` from `ConnectedField` to `Field`.