### PR TITLE
v6 — Add broken formValueSelector test case

### DIFF
--- a/src/__tests__/formValueSelector.spec.js
+++ b/src/__tests__/formValueSelector.spec.js
@@ -191,7 +191,7 @@ const describeFormValueSelector = (name, structure, expect) => {
             values: {
               rodent: {
                 rat: {
-                  hog: 'Willbur'
+                  hog: 'Wilbur'
                 },
                 mice: [ 'Jaq', 'Gus', 'Major', 'Bruno' ]
               }
@@ -203,9 +203,9 @@ const describeFormValueSelector = (name, structure, expect) => {
         .toEqual({
           rodent: {
             rat: {
-              hog: 'Willbur'
+              hog: 'Wilbur'
             },
-            mice: [ 'Jaq', 'Gus', 'Major', 'Bruno' ]
+            mice: fromJS([ 'Jaq', 'Gus', 'Major', 'Bruno' ])
           }
         })
     })

--- a/src/__tests__/formValueSelector.spec.js
+++ b/src/__tests__/formValueSelector.spec.js
@@ -183,6 +183,33 @@ const describeFormValueSelector = (name, structure, expect) => {
         .toEqualMap([ 'Jaq', 'Gus', 'Major', 'Bruno' ])
     })
 
+    it('should get a deep array', () => {
+      const selector = formValueSelector('myForm')
+      const state = fromJS({
+        form: {
+          myForm: {
+            values: {
+              rodent: {
+                rat: {
+                  hog: 'Willbur'
+                },
+                mice: [ 'Jaq', 'Gus', 'Major', 'Bruno' ]
+              }
+            }
+          }
+        }
+      })
+      expect(selector(state, 'rodent.rat.hog', 'rodent.mice'))
+        .toEqual({
+          rodent: {
+            rat: {
+              hog: 'Willbur'
+            },
+            mice: [ 'Jaq', 'Gus', 'Major', 'Bruno' ]
+          }
+        })
+    })
+
     it('should get a single value using a different mount point', () => {
       const selector = formValueSelector('myForm', state => getIn(state, 'otherMountPoint'))
       const state = fromJS({


### PR DESCRIPTION
This test is broken. `'rodent.mice'` returns a `List` instead of an `Array`.
See #1106 

```diff
1) formValueSelector.immutable should get a deep array:

Error: Expected { rodent: { mice: List [ "Jaq", "Gus", "Major", "Bruno" ], rat: { hog: 'Willbur' } } } to equal { rodent: { mice: [ 'Jaq', 'Gus', 'Major', 'Bruno' ], rat: { hog: 'Willbur' } } }
+ expected - actual

 {
   "rodent": {
-    "mice": {
-      "__altered": false
-      "__hash": [undefined]
-      "__ownerID": [undefined]
-      "_capacity": 4
-      "_level": 5
-      "_origin": 0
-      "_root": [null]
-      "_tail": {
-        "array": [
-          "Jaq"
-          "Gus"
-          "Major"
-          "Bruno"
-        ]
-        "ownerID": [undefined]
-      }
-      "size": 4
-    }
+    "mice": [
+      "Jaq"
+      "Gus"
+      "Major"
+      "Bruno"
+    ]
     "rat": {
       "hog": "Willbur"
     }
   }

at assert (node_modules/expect/lib/assert.js:29:9)
at Expectation.toEqual (node_modules/expect/lib/Expectation.js:85:30)
at Context.<anonymous> (formValueSelector.spec.js:204:10)
```