### PR TITLE
fix(type=number): Don't parseFloat empty value strings, they NaN

### DIFF
--- a/src/events/__tests__/getValue.spec.js
+++ b/src/events/__tests__/getValue.spec.js
@@ -101,7 +101,7 @@ describe('getValue', () => {
     }, false)).toBe(false)
   })
 
-  it('should return a number type for numeric inputs', () => {
+  it('should return a number type for numeric inputs, when a value is set', () => {
     expect(getValue({
       preventDefault: noop,
       stopPropagation: noop,
@@ -134,6 +134,15 @@ describe('getValue', () => {
         value: '3.1415'
       }
     }, false)).toBe(3.1415)
+
+    expect(getValue({
+      preventDefault: noop,
+      stopPropagation: noop,
+      target: {
+        type: 'range',
+        value: ''
+      }
+    }, false)).toBe('')
   })
 
   it('should return event.target.files if file', () => {

--- a/src/events/getValue.js
+++ b/src/events/getValue.js
@@ -31,7 +31,7 @@ const getValue = (event, isReactNative) => {
     if (type === 'select-multiple') {
       return getSelectedValues(event.target.options)
     }
-    if (type === 'number' || type === 'range') {
+    if (value !== '' && (type === 'number' || type === 'range')) {
       return parseFloat(value)
     }
     return value


### PR DESCRIPTION
#1100 added automatic number parsing of `<input type="number">` fields but if the field is empty it currently applies `parseFloat` to an empty string, which produces `NaN` which could be argued either way as right or wrong, but this has the consequence of making the `<input>` warn in Google Chrome with:

> The specified value "NaN" is not a valid number. The value must match to the following regular expression: -?(\d+|\d+\.\d+|\.\d+)([eE][-+]?\d+)?

This happens on every re-render, once that field has been touched. Using `undefined` also invokes the warning, the only thing that doesn't is the default empty string or a string that is a valid number.

Because of #1089 I can't create a JSBin to reproduce, but here's some code:

```js
console.clear();

const { createStore, combineReducers } = Redux;
const { Provider } = ReactRedux;
const { reduxForm, Field, reducer: form } = ReduxForm;

/////////////////////////////////////////////////

const Form = reduxForm({
  form: 'example-form'
})(
  () =>
    <div>
      <Field name="count" type="number" component="input" />
    </div>
);

/////////////////////////////////////////////////


const store = createStore(
  combineReducers({ form })
);


ReactDOM.render(
  <Provider store={store}>
    <Form />
  </Provider>,
  document.getElementById('app')
);
```

If it's too awkward now the value might be an empty string or a parsed number, I think removing the parsing number behavior altogether is probably the right call. Then the behavior is the same as the browser. Especially because `parseFloat` has [known quirks](http://stackoverflow.com/a/13676265/1770633) that may causes issues in browsers that don't actually restrict you from typing non-number characters in the input (like Chrome does). e.g. they type `'1-dal@41'` and `parseFloat('1-dal@41') === 1`