### PR TITLE
V6 - ShallowEqual need nextState

### DIFF
--- a/src/ConnectedFieldArray.js
+++ b/src/ConnectedFieldArray.js
@@ -25,8 +25,8 @@ const createConnectedFieldArray = ({
   const propInitialValue = initialValues && getIn(initialValues, name)
 
   class ConnectedFieldArray extends Component {
-    shouldComponentUpdate(nextProps) {
-      return shallowCompare(this, nextProps)
+    shouldComponentUpdate(nextProps, nextState) {
+      return shallowCompare(this, nextProps, nextState)
     }
 
     get syncError() {

--- a/src/Field.js
+++ b/src/Field.js
@@ -16,7 +16,10 @@ const createField = ({ deepEqual, getIn, setIn }) => {
       this.normalize = this.normalize.bind(this)
     }
 
-    shouldComponentUpdate(nextProps, nextState) {
+    shouldComponentUpdate(nextProps, nextState, nextContext) {
+      if (this.context._reduxForm.syncErrors !== nextContext._reduxForm.syncErrors) {
+        return true
+      }
       return shallowCompare(this, nextProps, nextState)
     }
 
@@ -87,7 +90,7 @@ const createField = ({ deepEqual, getIn, setIn }) => {
       return createElement(this.ConnectedField, {
         ...this.props,
         normalize: this.normalize,
-        syncError: this.getSyncError(),
+        syncError: this.getSyncError(this.context),
         ref: 'connected'
       })
     }

--- a/src/Field.js
+++ b/src/Field.js
@@ -16,8 +16,8 @@ const createField = ({ deepEqual, getIn, setIn }) => {
       this.normalize = this.normalize.bind(this)
     }
 
-    shouldComponentUpdate(nextProps) {
-      return shallowCompare(this, nextProps)
+    shouldComponentUpdate(nextProps, nextState) {
+      return shallowCompare(this, nextProps, nextState)
     }
 
     componentWillMount() {
@@ -58,7 +58,7 @@ const createField = ({ deepEqual, getIn, setIn }) => {
     get value() {
       return this.refs.connected.getWrappedInstance().getValue()
     }
-    
+
     normalize(value) {
       const { normalize } = this.props
       if(!normalize) {
@@ -82,7 +82,7 @@ const createField = ({ deepEqual, getIn, setIn }) => {
       // it can be set directly, it might need to be unwrapped from the _error property
       return error && error._error ? error._error : error
     }
-    
+
     render() {
       return createElement(this.ConnectedField, {
         ...this.props,

--- a/src/FieldArray.js
+++ b/src/FieldArray.js
@@ -14,8 +14,8 @@ const createFieldArray = ({ deepEqual, getIn, size }) => {
       this.ConnectedFieldArray = createConnectedFieldArray(context._reduxForm, { deepEqual, getIn, size }, props.name)
     }
 
-    shouldComponentUpdate(nextProps) {
-      return shallowCompare(this, nextProps)
+    shouldComponentUpdate(nextProps, nextState) {
+      return shallowCompare(this, nextProps, nextState)
     }
 
     componentWillMount() {


### PR DESCRIPTION
Because `shallowequal(undefined, null) === false`, should add mssing `nextState` param to `shallowCompare`


I believe some rerender cases are caused by this problem.