### PR TITLE
Prioritizing custom dispatch over global dispatch

### DIFF
--- a/src/ConnectedField.js
+++ b/src/ConnectedField.js
@@ -55,7 +55,6 @@ const createConnectedField = ({
     _reduxForm: PropTypes.object
   }
 
-  const actions = mapValues({ blur, change, focus }, actionCreator => actionCreator.bind(null, name))
   const connector = connect(
     (state, ownProps) => {
       const initial = getIn(getFormState(state), `initial.${name}`) || propInitialValue
@@ -72,7 +71,10 @@ const createConnectedField = ({
         _value: ownProps.value // save value passed in (for checkboxes)
       }
     },
-    actions,
+    (dispatch, initialProps) => mapValues({ blur, change, focus }, actionCreator => (...args) => {
+      const prioritizedDispatch = initialProps.dispatch || dispatch
+      return prioritizedDispatch(actionCreator(name, ...args))
+    }),
     undefined,
     { withRef: true }
   )

--- a/src/reduxForm.js
+++ b/src/reduxForm.js
@@ -375,7 +375,7 @@ const createReduxForm =
               change: boundChange,
               array: connectedArrayACs,
               focus: boundFocus,
-              dispatch
+              dispatch: initialProps.dispatch || dispatch
             }
 
             return () => computedActions


### PR DESCRIPTION
As [we discussed on twitter](https://twitter.com/tomkisw/status/742364129915240452) I believe that `redux-form` should prioritize `dispatch` which has been passed via props over global `connect`ed dispatch. The implementation is rather trivial and involves simple unit test.

Please, do you feel like this might be an issue? I am open to any improvements / suggestions.

