### PR TITLE
[Docs] Remove not relevant to v6 params and description from 'initialize' action creator description

### DIFF
--- a/docs/api/ActionCreators.md
+++ b/docs/api/ActionCreators.md
@@ -30,12 +30,11 @@ for most of your needs.**
 
 > Marks the given field as `active` and `visited`.
 
-### `initialize(form:String, data:Object, fields:Array<String>)`
+### `initialize(form:String, data:Object)`
 
 > Sets the initial values in the form with which future data values will be compared to calculate
 `dirty` and `pristine`. The `data` parameter may contain deep nested array and object values that match the shape of
-your form fields. **IMPORTANT:** The fields array passed must be the same as the one given as a [config parameter to
-`reduxForm()`](#/api/reduxForm).
+your form fields.
 
 ### `initializeWithKey(form:String, formKey, data:Object, fields:Array<String>)`
 


### PR DESCRIPTION
As mentioned in #1140 
> third parameter `fields` doesn't seem to apply to v6 since redux-form no longer needs to define the form fields in the form config.