### PR TITLE
'checked' attribute should be set when string boolean like "true" is used

### DIFF
--- a/src/__tests__/readFields.spec.js
+++ b/src/__tests__/readFields.spec.js
@@ -472,9 +472,16 @@ describe('readFields', () => {
         another: {
           value: undefined
         },
+        stringBoolFoo: {
+          value: 'false'
+        },
+        stringBoolBar: {
+          value: 'true'
+        },
         stringField: {
           value: 'baz'
         }
+
       },
       validate: noValidation
     }, {}, {});
@@ -510,6 +517,28 @@ describe('readFields', () => {
       error: undefined,
       readonly: false,
       checked: undefined
+    });
+    expectField({
+      field: result.stringBoolFoo,
+      name: 'stringBoolFoo',
+      value: 'false',
+      dirty: true,
+      touched: false,
+      visited: false,
+      error: undefined,
+      readonly: false,
+      checked: false
+    });
+    expectField({
+      field: result.stringBoolBar,
+      name: 'stringBoolBar',
+      value: 'true',
+      dirty: true,
+      touched: false,
+      visited: false,
+      error: undefined,
+      readonly: false,
+      checked: true
     });
     expectField({
       field: result.stringField,

--- a/src/readField.js
+++ b/src/readField.js
@@ -115,7 +115,7 @@ const readField = (state, fieldName, pathToHere = '', fields, syncErrors, asyncV
     const initialFormValue = read(`${name}.initial`, form);
     const initialValue = initialFormValue || read(name, initialValues);
     field.name = name;
-    field.checked = initialValue === true || undefined;
+    field.checked = String(initialValue).toLowerCase() === 'true' || undefined;
     field.value = initialValue;
     field.initialValue = initialValue;
     if (!readonly) {


### PR DESCRIPTION
I am using a key-value map as `intialValues`. The map is coming from server but the server has no knowledge about values so it sends all values as string. 

String `"true"` is a valid value for the `checked` attribute in react so it should also be for redux-form. 