### PR TITLE
Fixed problems caused by #1184

### DIFF
--- a/src/__tests__/readFields.spec.js
+++ b/src/__tests__/readFields.spec.js
@@ -460,7 +460,7 @@ describe('readFields', () => {
       asyncBlurFields: [],
       blur,
       change,
-      fields: [ 'foo', 'bar', 'another', 'stringField' ],
+      fields: [ 'foo', 'bar', 'another', 'stringBoolFoo', 'stringBoolBar', 'stringField' ],
       focus,
       form: {
         foo: {

--- a/src/isChecked.js
+++ b/src/isChecked.js
@@ -1,0 +1,17 @@
+const isChecked = value => {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const lower = value.toLowerCase();
+    if (lower === 'true') {
+      return true;
+    }
+    if (lower === 'false') {
+      return false;
+    }
+  }
+  return undefined;
+};
+
+export default isChecked;

--- a/src/readField.js
+++ b/src/readField.js
@@ -6,6 +6,7 @@ import createOnFocus from './events/createOnFocus';
 import silencePromise from './silencePromise';
 import read from './read';
 import updateField from './updateField';
+import isChecked from './isChecked';
 
 function getSuffix(input, closeIndex) {
   let suffix = input.substring(closeIndex + 1);
@@ -121,7 +122,7 @@ const readField = (state, fieldName, pathToHere = '', fields, syncErrors, asyncV
     let initialValue = initialFormValue || read(name, initialValues);
     initialValue = initialValue === undefined ? '' : initialValue;
     field.name = name;
-    field.checked = String(initialValue).toLowerCase() === 'true' || undefined;
+    field.checked = isChecked(initialValue);
     field.value = initialValue;
     field.initialValue = initialValue;
     if (!readonly) {

--- a/src/updateField.js
+++ b/src/updateField.js
@@ -1,5 +1,6 @@
 import isPristine from './isPristine';
 import isValid from './isValid';
+import isChecked from './isChecked';
 
 /**
  * Updates a field object from the store values
@@ -11,7 +12,7 @@ const updateField = (field, formField, active, syncError) => {
   // update field value
   if (field.value !== formFieldValue) {
     diff.value = formFieldValue;
-    diff.checked = typeof formFieldValue === 'boolean' ? formFieldValue : undefined;
+    diff.checked = isChecked(formFieldValue);
   }
 
   // update dirty/pristine


### PR DESCRIPTION
Reworked how 'checked' is determined to allow string values. Originally started in #1184.

It's a shame that `Boolean('false') === true`. Silly javascript!

This change makes any case of `'true'` or `'false'` convert properly to boolean for checkboxes.

@ooflorent Review?