### PR TITLE
Always return rejected promise when submit is rejected

### DIFF
--- a/docs/api/ReduxForm.md
+++ b/docs/api/ReduxForm.md
@@ -94,11 +94,6 @@ called `_error`, and it will be given as the `error` prop.
 under the key specified. Useful if using other decorator libraries on the same component to avoid
 prop namespace collisions.
 
-#### `returnRejectedSubmitPromise : boolean` [optional]
-
-> If set to `true`, a failed submit will return a rejected promise. Defaults to `false`. Only use this if you need to
-detect submit failures and run some code when a submit fails.
-
 #### `shouldAsyncValidate(params) : boolean` [optional]
 
 > An optional function you may provide to have full control over when async validation happens.

--- a/src/__tests__/handleSubmit.spec.js
+++ b/src/__tests__/handleSubmit.spec.js
@@ -29,7 +29,7 @@ describe('handleSubmit', () => {
       .toHaveBeenCalledWith('foo', 'baz')
   })
 
-  it('should stop and return rejected promise if sync validation fails and returnRejectedSubmitPromise', (done) => {
+  it('should stop and return rejected promise if sync validation fails', (done) => {
     const values = { foo: 'bar', baz: 42 }
     const submit = createSpy().andReturn(69)
     const syncErrors = { foo: 'error' }
@@ -39,7 +39,6 @@ describe('handleSubmit', () => {
     const setSubmitFailed = createSpy()
     const asyncValidate = createSpy()
     const props = {
-      returnRejectedSubmitPromise: true,
       startSubmit,
       stopSubmit,
       touch,
@@ -91,7 +90,7 @@ describe('handleSubmit', () => {
     expect(setSubmitFailed).toNotHaveBeenCalled()
   })
 
-  it('should not submit if async validation fails', () => {
+  it('should not submit if async validation fails', done => {
     const values = { foo: 'bar', baz: 42 }
     const submit = createSpy().andReturn(69)
     const dispatch = noop
@@ -103,7 +102,7 @@ describe('handleSubmit', () => {
     const props = { dispatch, startSubmit, stopSubmit, touch, setSubmitFailed, values }
 
     return handleSubmit(submit, props, true, asyncValidate, [ 'foo', 'baz' ])
-      .then(result => {
+      .catch(result => {
         expect(result).toBe(undefined)
         expect(asyncValidate)
           .toHaveBeenCalled()
@@ -117,6 +116,7 @@ describe('handleSubmit', () => {
         expect(setSubmitFailed)
           .toHaveBeenCalled()
           .toHaveBeenCalledWith('foo', 'baz')
+        done()
       })
   })
 
@@ -131,8 +131,7 @@ describe('handleSubmit', () => {
     const asyncErrors = { foo: 'async error' }
     const asyncValidate = createSpy().andReturn(Promise.reject(asyncErrors))
     const props = {
-      dispatch, startSubmit, stopSubmit, touch, setSubmitFailed, values,
-      returnRejectedSubmitPromise: true
+      dispatch, startSubmit, stopSubmit, touch, setSubmitFailed, values
     }
 
     return handleSubmit(submit, props, true, asyncValidate, [ 'foo', 'baz' ])
@@ -215,7 +214,7 @@ describe('handleSubmit', () => {
       })
   })
 
-  it('should set submit errors if async submit fails', () => {
+  it('should set submit errors if async submit fails', done => {
     const values = { foo: 'bar', baz: 42 }
     const submitErrors = { foo: 'submit error' }
     const submit = createSpy().andReturn(Promise.reject(new SubmissionError(submitErrors)))
@@ -228,8 +227,8 @@ describe('handleSubmit', () => {
     const props = { dispatch, startSubmit, stopSubmit, touch, setSubmitFailed, values }
 
     return handleSubmit(submit, props, true, asyncValidate, [ 'foo', 'baz' ])
-      .then(result => {
-        expect(result).toBe(undefined)
+      .catch(error => {
+        expect(error).toBe(submitErrors)
         expect(asyncValidate)
           .toHaveBeenCalled()
           .toHaveBeenCalledWith()
@@ -246,6 +245,7 @@ describe('handleSubmit', () => {
           .toHaveBeenCalledWith('foo', 'baz')
         expect(setSubmitFailed)
           .toNotHaveBeenCalled()
+        done()
       })
   })
 
@@ -262,7 +262,7 @@ describe('handleSubmit', () => {
     const props = { dispatch, startSubmit, stopSubmit, touch, setSubmitFailed, values }
 
     return handleSubmit(submit, props, true, asyncValidate, [ 'foo', 'baz' ])
-      .then(result => {
+      .catch(result => {
         expect(result).toBe(undefined)
         expect(asyncValidate)
           .toHaveBeenCalled()
@@ -294,14 +294,12 @@ describe('handleSubmit', () => {
     const setSubmitFailed = createSpy()
     const asyncValidate = createSpy().andReturn(Promise.resolve())
     const props = {
-      dispatch, startSubmit, stopSubmit, touch, setSubmitFailed, values,
-      returnRejectedSubmitPromise: true
+      dispatch, startSubmit, stopSubmit, touch, setSubmitFailed, values
     }
 
     return handleSubmit(submit, props, true, asyncValidate, [ 'foo', 'baz' ])
-      .catch(result => {
-        expect(result instanceof SubmissionError).toBe(true)
-        expect(result.errors).toBe(submitErrors)
+      .catch(error => {
+        expect(error).toBe(submitErrors)
         expect(asyncValidate)
           .toHaveBeenCalled()
           .toHaveBeenCalledWith()

--- a/src/__tests__/reduxForm.spec.js
+++ b/src/__tests__/reduxForm.spec.js
@@ -1207,7 +1207,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
 
       const Decorated = reduxForm({
         form: 'testForm',
-        onSubmit: () => Promise.reject(new SubmissionError("Rejection"))
+        onSubmit: () => Promise.reject(new SubmissionError('Rejection'))
       })(Form)
 
       const dom = TestUtils.renderIntoDocument(

--- a/src/__tests__/reduxForm.spec.js
+++ b/src/__tests__/reduxForm.spec.js
@@ -15,6 +15,7 @@ import plainExpectations from '../structure/plain/expectations'
 import immutable from '../structure/immutable'
 import immutableExpectations from '../structure/immutable/expectations'
 import addExpectations from './addExpectations'
+import SubmissionError from '../SubmissionError'
 import { change } from '../actions'
 
 const describeReduxForm = (name, structure, combineReducers, expect) => {
@@ -559,7 +560,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(inputRender.calls.length).toBe(2)
       checkInputProps(inputRender.calls[ 1 ].arguments[ 0 ], 'baz')
     })
-    
+
     it('should destroy on unmount by default', () => {
       const store = makeStore({})
       const inputRender = createSpy(props => <input {...props}/>).andCallThrough()
@@ -1187,6 +1188,39 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(asyncValidate).toHaveBeenCalled()
       expect(asyncValidate.calls.length).toBe(1)
       expect(asyncValidate.calls[ 0 ].arguments[ 0 ]).toEqualMap({ bar: 'foo' })
+    })
+
+    it('should return rejected promise when submit is rejected', () => {
+      const store = makeStore({
+        testForm: {
+          values: {
+            bar: 'foo'
+          }
+        }
+      })
+
+      const Form = () => (
+        <form>
+          <Field name="bar" component="input" type="text"/>
+        </form>
+      )
+
+      const Decorated = reduxForm({
+        form: 'testForm',
+        onSubmit: () => Promise.reject(new SubmissionError("Rejection"))
+      })(Form)
+
+      const dom = TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <Decorated/>
+        </Provider>
+      )
+
+      const stub = TestUtils.findRenderedComponentWithType(dom, Decorated)
+      return stub.submit()
+        .catch(err => {
+          expect(err).toBe('Rejection')
+        })
     })
 
     it('should not call async validation more than once if submit is clicked fast when handleSubmit receives a function', (done) => {

--- a/src/reduxForm.js
+++ b/src/reduxForm.js
@@ -223,7 +223,10 @@ const createReduxForm =
               return promise
             }
             this.submitPromise = promise
-            return promise.then(this.submitCompleted, this.submitCompleted)
+            return promise.then(this.submitCompleted, err => {
+              this.submitCompleted()
+              return Promise.reject(err)
+            })
           }
 
           submit(submitOrEvent) {


### PR DESCRIPTION
Addresses #1201.

Also removed `returnRejectedSubmitPromise`. That was put in as a stopgap measure to avoid a breaking change, but I think the promise that is returned from submitting should always be rejected if there was an error.

@ooflorent, please review.