### PR TITLE
Change single quotes in test scripts to escaped double quotes

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "lint": "eslint src",
     "example:simple": "node examples/simple/server.js",
     "prepublish": "npm run test && npm run clean && npm run build",
-    "test": "mocha --compilers js:babel-register --recursive --recursive 'src/**/__tests__/*' --require src/__tests__/setup.js",
-    "test:watch": "mocha --compilers js:babel-register --recursive --recursive 'src/**/__tests__/*' --require src/__tests__/setup.js --watch",
-    "test:cov": "babel-node ./node_modules/isparta/bin/isparta cover ./node_modules/mocha/bin/_mocha -- --recursive 'src/**/__tests__/*' --require src/__tests__/setup.js",
+    "test": "mocha --compilers js:babel-register --recursive --recursive \"src/**/__tests__/*\" --require src/__tests__/setup.js",
+    "test:watch": "npm test -- --watch",
+    "test:cov": "babel-node ./node_modules/isparta/bin/isparta cover ./node_modules/mocha/bin/_mocha -- --recursive \"src/**/__tests__/*\" --require src/__tests__/setup.js",
     "test:codecov": "cat ./coverage/coverage.json | ./node_modules/codecov.io/bin/codecov.io.js"
   },
   "keywords": [


### PR DESCRIPTION
Allows tests to run on windows platforms.
Switched script "test:watch" to append options to the "test" script target.
