### PR TITLE
[v6] Fix broken links and typos in docs

### DIFF
--- a/docs/api/ReduxForm.md
+++ b/docs/api/ReduxForm.md
@@ -111,7 +111,7 @@ Your `shouldAsyncValidate()` function will be given an object with the following
 
 > The reason to possibly run async validation. It will either be: `'blur'` or `'submit'`, 
 depending on whether an async blur field had triggered the async validation or if submitting the 
-form has triggered it, respecitively.
+form has triggered it, respectively.
 
 > ##### `blurredField : string` [optional]
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -70,7 +70,7 @@ open [`localhost:3030`](http://localhost:3030) in your browser.
 
 ---
 
-### [React-Widegets Examples](react-widgets)
+### [React-Widgets Examples](react-widgets)
 
 > How to use `react-widgets` components with `redux-form` 
 

--- a/examples/asyncValidation/src/AsyncValidation.md
+++ b/examples/asyncValidation/src/AsyncValidation.md
@@ -1,7 +1,7 @@
 # Async Blur Validation Example
 
 The recommended way to provide server-side validation is to use
-[Submit Validation](submitValidation), but there may be instances when you want to run
+[Submit Validation](../../submitValidation), but there may be instances when you want to run
 server-side validation _while the form is being filled out_. The classic example of this
 letting someone choose a value, like a username, that must be unique within your system.
 
@@ -16,12 +16,12 @@ they are blurred with the `asyncBlurFields` config property.
 
 1. Asynchronous validation _will_ be called before the `onSubmit` is fired, but if all
 you care about is validation `onSubmit`, you should use
-[Submit Validation](submitValidation).
+[Submit Validation](../../submitValidation).
 2. Asynchronous validation will _not_ be called if synchronous validation is failing
 _for the field just blurred_.
 
 The errors are displayed in the exact same way as validation errors created by
-[Synchronous Validation](syncValidation).
+[Synchronous Validation](../../syncValidation).
 
 ### How to use the form below:
 

--- a/examples/simple/src/Simple.md
+++ b/examples/simple/src/Simple.md
@@ -16,4 +16,4 @@ The delay between when you click "Submit" and when the alert dialog pops up is i
 simulate server latency.
 
 This form does no validation. To learn about how to do client-side validation, see the 
-[Synchronous Validation](syncValidation) example.
+[Synchronous Validation](../../syncValidation) example.

--- a/examples/submitValidation/src/SubmitValidation.md
+++ b/examples/submitValidation/src/SubmitValidation.md
@@ -12,7 +12,7 @@ decorated component_. In which case, you would use `onClick={this.props.handleSu
 inside your decorated component to cause it to fire when the submit button is clicked.
 
 The errors are displayed in the exact same way as validation errors created by
-[Synchronous Validation](syncValidation), but they are returned from the `onSubmit`
+[Synchronous Validation](../../syncValidation), but they are returned from the `onSubmit`
 function wrapped in a `SubmissionError`. This is to differentiate validation errors from I/O 
 errors, like HTTP `400` or `500` errors, which will also cause the submission promise to be
 rejected.


### PR DESCRIPTION
Came across a few things when reading docs. This pull request fixes:

1. Broken links between validation examples, e.g. try to click the "Submit Validation" link in this example on [Github](https://github.com/erikras/redux-form/blob/v6/examples/asyncValidation/src/AsyncValidation.md) and [redux-form.com](http://redux-form.com/6.0.0-alpha.15/examples/asyncValidation/).
2. A couple of typos

Also noticed two more potential changes in the [`reduxForm()`](http://redux-form.com/6.0.0-alpha.15/docs/api/ReduxForm.md/) docs, which I could add to the PR:

![screenshot 2016-07-01 16 10 53 copy](https://cloud.githubusercontent.com/assets/12738484/16524054/bbd9d616-3fa6-11e6-8fba-fe8ba2157bb8.png)

* **Blue**: This link seems superfluous and the placement would suggest it relates to all options or options in general, which is not the case.
* **Red**: As mentioned in #726, section 12, the ambition is to have docs navigable on both Github and redux-form.com. In the docs for `reduxForm()`, the link to the async validation example works on Github, but not on redux-form.com. Not sure how to resolve that. A quick fix could be to provide two links (sounds ugly, but perhaps better than something broken), if there is no easy way to restructure the files to allow relative links.

Please let me know if there is something you would like me to add or edit. Thanks.