### PR TITLE
Added propNamespace functionality

### DIFF
--- a/docs/api/ReduxForm.md
+++ b/docs/api/ReduxForm.md
@@ -112,9 +112,7 @@ following parameters:
 
 > The Redux `dispatch` function.
 
-#### `propNamespace : string` [optional]
-
-**UNIMPLEMENTED SO FAR IN V6**
+#### `propNamespace : String` [optional]
 
 > If specified, all the props normally passed into your decorated component directly will be passed
 under the key specified. Useful if using other decorator libraries on the same component to avoid

--- a/src/__tests__/reduxForm.spec.js
+++ b/src/__tests__/reduxForm.spec.js
@@ -169,6 +169,24 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(propChecker({ submitting: false }).submitting).toBe(false)
     })
 
+    it('should put props under prop namespace if specified', () => {
+      const props = propChecker({}, noop, {
+        propNamespace: 'fooProps',
+        someOtherProp: 'whatever'
+      })
+      expect(props.fooProps).toExist().toBeA('object')
+      expect(props.dispatch).toNotExist()
+      expect(props.dirty).toNotExist()
+      expect(props.pristine).toNotExist()
+      expect(props.submitting).toNotExist()
+      expect(props.someOtherProp).toExist()
+      expect(props.fooProps.dispatch).toBeA('function')
+      expect(props.fooProps.dirty).toBeA('boolean')
+      expect(props.fooProps.pristine).toBeA('boolean')
+      expect(props.fooProps.submitting).toBeA('boolean')
+      expect(props.fooProps.someOtherProp).toNotExist()
+    })
+
     it('should provide bound array action creators', () => {
       const arrayProp = propChecker({}).array
       expect(arrayProp).toExist()

--- a/src/reduxForm.js
+++ b/src/reduxForm.js
@@ -255,6 +255,7 @@ const createReduxForm =
             // remove some redux-form config-only props
             /* eslint-disable no-unused-vars */
             const {
+              anyTouched,
               arrayInsert,
               arrayPop,
               arrayPush,
@@ -264,25 +265,63 @@ const createReduxForm =
               arraySwap,
               arrayUnshift,
               asyncErrors,
+              asyncValidate,
+              asyncValidating,
+              destroy,
               destroyOnUnmount,
+              dirty,
+              dispatch,
               enableReinitialize,
+              error,
+              form,
               getFormState,
+              initialize,
+              invalid,
+              pristine,
+              propNamespace,
               registerField,
+              reset,
+              submitting,
+              submitFailed,
+              touch,
               touchOnBlur,
               touchOnChange,
               syncErrors,
               unregisterField,
+              untouch,
+              valid,
               values,
-              ...passableProps
+              ...rest
             } = this.props
             /* eslint-enable no-unused-vars */
-            if (isClassComponent(WrappedComponent)) {
-              passableProps.ref = 'wrapped'
+            const reduxFormProps = {
+              anyTouched,
+              asyncValidate,
+              asyncValidating,
+              destroy,
+              dirty,
+              dispatch,
+              error,
+              form,
+              handleSubmit: this.submit,
+              initialize,
+              invalid,
+              pristine,
+              reset,
+              submitting,
+              submitFailed,
+              touch,
+              untouch,
+              valid
             }
-            return createElement(WrappedComponent, {
-              ...passableProps,
-              handleSubmit: this.submit
-            })
+            const propsToPass = {
+              ...(propNamespace ? { [propNamespace]: reduxFormProps } : reduxFormProps),
+              ...rest
+            }
+            if (isClassComponent(WrappedComponent)) {
+              propsToPass.ref = 'wrapped'
+            }
+            return createElement(WrappedComponent, propsToPass)
           }
         }
         Form.displayName = `Form(${getDisplayName(WrappedComponent)})`
@@ -297,6 +336,7 @@ const createReduxForm =
           getFormState: PropTypes.func,
           onSubmitFail: PropTypes.func,
           onSubmitSuccess: PropTypes.func,
+          propNameSpace: PropTypes.string,
           validate: PropTypes.func,
           touchOnBlur: PropTypes.bool,
           touchOnChange: PropTypes.bool,


### PR DESCRIPTION
Rarely (?) used functionality from `v5`.

Also specifically whitelisted the props that `redux-form` provides to the wrapped component.