### PR TITLE
Create a initial form state before creating fields

### DIFF
--- a/src/__tests__/createReduxForm.spec.js
+++ b/src/__tests__/createReduxForm.spec.js
@@ -2804,4 +2804,43 @@ describe('createReduxForm', () => {
     // FAILS
     //expect(lastPrevBarValue).toNotEqual(lastNextBarValue);
   });
+
+  // Test to show bug https://github.com/erikras/redux-form/issues/1241
+  it('pass correct initial values to validate when initialValues not given', () => {
+    const store = makeStore();
+    const form = 'testForm';
+    const validate = values => {
+      expect(values.name).toBe(undefined);
+      expect(values.company.name).toBe('Foo');
+    };
+
+    class ValidateTestForm extends Component {
+      render() {
+        const {fields: {name}} = this.props;
+        return (<div>
+          <input {...name}/>
+        </div>);
+      }
+    }
+
+    ValidateTestForm.propTypes = {
+      fields: PropTypes.object.isRequired
+    };
+
+    const Decorated = reduxForm({
+      form,
+      fields: ['name', 'company.name'],
+      validate,
+    })(ValidateTestForm);
+
+    const initialValues = {
+      company: { name: 'Foo' }
+    };
+
+    TestUtils.renderIntoDocument(
+      <Provider store={store}>
+        <Decorated initialValues={initialValues} />
+      </Provider>
+    );
+  });
 });

--- a/src/createHigherOrderComponent.js
+++ b/src/createHigherOrderComponent.js
@@ -12,6 +12,7 @@ import silenceEvents from './events/silenceEvents';
 import silenceEvent from './events/silenceEvent';
 import wrapMapDispatchToProps from './wrapMapDispatchToProps';
 import wrapMapStateToProps from './wrapMapStateToProps';
+import createInitialState from './createInitialState';
 
 /**
  * Creates a HOC that knows how to create redux-connected sub-components.
@@ -33,8 +34,11 @@ const createHigherOrderComponent = (config,
         // bind functions
         this.asyncValidate = this.asyncValidate.bind(this);
         this.handleSubmit = this.handleSubmit.bind(this);
-        this.fields = readFields(props, {}, {}, this.asyncValidate, isReactNative);
-        const {submitPassback} = this.props;
+        const { initialValues, submitPassback } = this.props;
+        // Check if form state was initialized, if not, initialize it.
+        const form = deepEqual(props.form, initialState) ?
+          createInitialState(initialValues, config.fields, {}, true, false) : props.form;
+        this.fields = readFields({ ...props, form }, {}, {}, this.asyncValidate, isReactNative);
         submitPassback(() => this.handleSubmit());  // wrapped in function to disallow params
       }
 

--- a/src/createInitialState.js
+++ b/src/createInitialState.js
@@ -1,0 +1,16 @@
+import { globalErrorKey } from './reducer';
+import initializeState from './initializeState';
+
+const createInitialState = (data, fields, state, overwriteValues = true, markInitialized = true) => {
+  return {
+    ...initializeState(data, fields, state, overwriteValues),
+    _asyncValidating: false,
+    _active: undefined,
+    [globalErrorKey]: undefined,
+    _initialized: markInitialized,
+    _submitting: false,
+    _submitFailed: false
+  };
+};
+
+export default createInitialState;

--- a/src/readField.js
+++ b/src/readField.js
@@ -141,12 +141,7 @@ const readField = (state, fieldName, pathToHere = '', fields, syncErrors, asyncV
     Object.defineProperty(field, '_isField', {value: true});
   }
 
-  const defaultFieldState = {
-    initial: field.value,
-    value: field.value,
-  };
-
-  const fieldState = (fieldName ? state[fieldName] : state) || defaultFieldState;
+  const fieldState = (fieldName ? state[fieldName] : state) || {};
   const syncError = read(name, syncErrors);
   const updated = updateField(field, fieldState, name === form._active, syncError);
   if (fieldName || fields[fieldName] !== updated) {

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -9,6 +9,7 @@ import resetState from './resetState';
 import setErrors from './setErrors';
 import {makeFieldValue} from './fieldValue';
 import normalizeFields from './normalizeFields';
+import createInitialState from './createInitialState';
 
 export const globalErrorKey = '_error';
 
@@ -76,15 +77,7 @@ const behaviors = {
     return stateCopy;
   },
   [INITIALIZE](state, {data, fields, overwriteValues}) {
-    return {
-      ...initializeState(data, fields, state, overwriteValues),
-      _asyncValidating: false,
-      _active: undefined,
-      [globalErrorKey]: undefined,
-      _initialized: true,
-      _submitting: false,
-      _submitFailed: false
-    };
+    return createInitialState(data, fields, state, overwriteValues);
   },
   [REMOVE_ARRAY_VALUE](state, {path, index}) {
     const array = read(path, state);


### PR DESCRIPTION
This should fix the long living bug #621.

First round
===========

My first try was #1025, I tried pass a default field state to [updateField](https://github.com/erikras/redux-form/blob/v5.3.1/src/updateField.js#L8) so that updateField can read initial value from given state.

But I forgot the the validate function which causes validate function cann't read initial values at first render.

Second round
============

My second try was #1061, I tried pass initial values to validate function. But I forgot a form may have no initial values or only have partial initial values which causes #1241.

Third round
=====================

I thought I can create a initial form state before creating fields, so that updateField and validate function can both read initial values.