### PR TITLE
Fix submit promise error if form is not valid

### DIFF
--- a/src/reduxForm.js
+++ b/src/reduxForm.js
@@ -225,7 +225,6 @@ const createReduxForm =
             this.submitPromise = promise
             return promise.then(this.submitCompleted, err => {
               this.submitCompleted()
-              return Promise.reject(err)
             })
           }
 


### PR DESCRIPTION
@erikras not 100% sure about this one, but I believe that returning rejected promise in `listenToSubmit()` is unnecessary and only results in an error. This PR fixes that.