### PR TITLE
[v6] Replace react-addons-shallow-compare with local implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "is-promise": "^2.1.0",
     "lodash": "^4.12.0",
     "lodash-es": "^4.12.0",
-    "react-addons-shallow-compare": "^15.2.0"
+    "shallowequal": "^0.2.2"
   },
   "devDependencies": {
     "babel-cli": "^6.3.17",

--- a/src/ConnectedFieldArray.js
+++ b/src/ConnectedFieldArray.js
@@ -2,7 +2,7 @@ import { Component, PropTypes, createElement } from 'react'
 import { connect } from 'react-redux'
 import createFieldArrayProps from './createFieldArrayProps'
 import { mapValues } from 'lodash'
-import shallowCompare from 'react-addons-shallow-compare'
+import shallowCompare from './util/shallowCompare'
 import plain from './structure/plain'
 
 const createConnectedFieldArray = ({

--- a/src/Field.js
+++ b/src/Field.js
@@ -1,7 +1,7 @@
 import { Component, PropTypes, createElement } from 'react'
 import invariant from 'invariant'
 import createConnectedField from './ConnectedField'
-import shallowCompare from 'react-addons-shallow-compare'
+import shallowCompare from './util/shallowCompare'
 
 
 const createField = ({ deepEqual, getIn, setIn }) => {

--- a/src/FieldArray.js
+++ b/src/FieldArray.js
@@ -1,7 +1,7 @@
 import { Component, PropTypes, createElement } from 'react'
 import invariant from 'invariant'
 import createConnectedFieldArray from './ConnectedFieldArray'
-import shallowCompare from 'react-addons-shallow-compare'
+import shallowCompare from './util/shallowCompare'
 
 const createFieldArray = ({ deepEqual, getIn, size }) => {
 

--- a/src/util/shallowCompare.js
+++ b/src/util/shallowCompare.js
@@ -1,0 +1,10 @@
+import shallowEqual from 'shallowequal'
+
+const shallowCompare = (instance, nextProps, nextState) => {
+  return (
+    !shallowEqual(instance.props, nextProps) ||
+    !shallowEqual(instance.state, nextState)
+  )
+}
+
+export default shallowCompare


### PR DESCRIPTION
This replaces the `react-addons-shallow-compare` dependency with a small local implementation of the same behavior, to avoid introducing a peer dependency on a specific minor version of React 15. See #1319 for the original discussion around this. Copying the description here for ease of viewing:

> Currently there is a dependency on `"react-addons-shallow-compare": "^15.2.0"` in the [package.json for rc.3](https://github.com/erikras/redux-form/blob/v6.0.0-rc.3/package.json#L50). This causes a problem for those of us still using React 15.1 or lower with NPM 2, since that package has a peer dependency on React 15.2.
> 
> Since the functionality provided by that package is super minimal, might it be possible to replace it with a simple local implementation to prevent weird dependency issues with older React versions? If that's something that sounds reasonable I'd be happy to tackle opening a PR for it if you don't have bandwidth for such a change.

Thanks for all your hard work on this library!