### PR TITLE
Don't overwrite user input on fields not present in initialValues when  `overwriteOnInitialValuesChange: false`

### DIFF
--- a/src/__tests__/createReduxForm.spec.js
+++ b/src/__tests__/createReduxForm.spec.js
@@ -2255,7 +2255,7 @@ describe('createReduxForm', () => {
 
     const Decorated = reduxForm({
       form,
-      fields: [ 'firstName', 'lastName' ],
+      fields: [ 'firstName', 'lastName', 'instrument' ],
       overwriteOnInitialValuesChange: false
     })(Form);
 
@@ -2301,12 +2301,15 @@ describe('createReduxForm', () => {
     // users changes to George Harrison
     stub.props.fields.firstName.onChange('George');
     stub.props.fields.lastName.onChange('Harrison');
+    stub.props.fields.instrument.onChange('guitar');
 
-    // values are now George Harrison
+    // values are now George Harrison (guitar)
     expect(stub.props.fields.firstName.value).toBe('George');
     expect(stub.props.fields.firstName.pristine).toBe(false);
     expect(stub.props.fields.lastName.value).toBe('Harrison');
     expect(stub.props.fields.lastName.pristine).toBe(false);
+    expect(stub.props.fields.instrument.value).toBe('guitar');
+    expect(stub.props.fields.instrument.pristine).toBe(false);
 
     // change initialValues to Ringo Starr
     const button = TestUtils.findRenderedDOMComponentWithTag(dom, 'button');
@@ -2317,6 +2320,8 @@ describe('createReduxForm', () => {
     expect(stub.props.fields.firstName.pristine).toBe(false);
     expect(stub.props.fields.lastName.value).toBe('Harrison');
     expect(stub.props.fields.lastName.pristine).toBe(false);
+    expect(stub.props.fields.instrument.value).toBe('guitar');
+    expect(stub.props.fields.instrument.pristine).toBe(false);
 
     // but, if we reset form
     stub.props.resetForm();
@@ -2326,6 +2331,8 @@ describe('createReduxForm', () => {
     expect(stub.props.fields.firstName.pristine).toBe(true);
     expect(stub.props.fields.lastName.value).toBe('Starr');
     expect(stub.props.fields.lastName.pristine).toBe(true);
+    expect(stub.props.fields.instrument.value).toBe('');
+    expect(stub.props.fields.instrument.pristine).toBe(true);
   });
 
   it('should replace existing values when initialValues changes', () => {

--- a/src/initializeState.js
+++ b/src/initializeState.js
@@ -1,7 +1,8 @@
 import {makeFieldValue} from './fieldValue';
 
 const makeEntry = (value, previousValue, overwriteValues) => {
-  return makeFieldValue(value === undefined ? {} : {
+  if (value === undefined && previousValue === undefined) return makeFieldValue({});
+  return makeFieldValue({
     initial: value,
     value: overwriteValues ? value : previousValue
   });


### PR DESCRIPTION
Fixes #1112