### PR TITLE
Fix drag and drop on IE

### DIFF
--- a/src/events/__tests__/createOnDrop.spec.js
+++ b/src/events/__tests__/createOnDrop.spec.js
@@ -12,15 +12,19 @@ describe('createOnDrop', () => {
   it('should return a function that calls change with result from getData', () => {
     const change = createSpy()
     const getData = createSpy().andReturn('bar')
+    const preventDefault = createSpy()
     createOnDrop('foo', change)({
-      dataTransfer: { getData }
+      dataTransfer: { getData },
+      preventDefault
     })
     expect(getData)
       .toHaveBeenCalled()
       .toHaveBeenCalledWith(dataKey)
     expect(change)
       .toHaveBeenCalled()
-      .toHaveBeenCalledWith('foo', 'bar')
+      .toHaveBeenCalledWith('bar')
+    expect(preventDefault)
+      .toHaveBeenCalled()
   })
 
 })

--- a/src/events/createOnDragStart.js
+++ b/src/events/createOnDragStart.js
@@ -1,4 +1,4 @@
-export const dataKey = 'value'
+export const dataKey = 'text'
 const createOnDragStart =
   (name, value) =>
     event => {

--- a/src/events/createOnDrop.js
+++ b/src/events/createOnDrop.js
@@ -2,6 +2,7 @@ import { dataKey } from './createOnDragStart'
 const createOnDrop =
   (name, change) =>
     event => {
-      change(name, event.dataTransfer.getData(dataKey))
+      change(event.dataTransfer.getData(dataKey))
+      event.preventDefault()
     }
 export default createOnDrop


### PR DESCRIPTION
Bumped into https://github.com/erikras/redux-form/issues/1088 and the solution to stop these errors (and to unbreak drag and drop on IE) is to just change the dataKey to 'text. 

The [stack overflow question](http://stackoverflow.com/questions/26213011/html5-dragdrop-issue-in-internet-explorer-datatransfer-property-access-not-pos) mentioned in the referenced issue suggests this as well FWIW.