### PR TITLE
Fix errors getting lost

### DIFF
--- a/src/handleSubmit.js
+++ b/src/handleSubmit.js
@@ -15,7 +15,10 @@ const handleSubmit = (submit, props, valid, asyncValidate, fields) => {
       try {
         result = submit(values, dispatch)
       } catch (submitError) {
-        const error = submitError instanceof SubmissionError ? submitError.errors : undefined
+        if (!submitError instanceof SubmissionError) {
+          throw submitError
+        }
+        const error = submitError.errors
         if(onSubmitFail) {
           onSubmitFail(error, dispatch)
         }
@@ -32,6 +35,9 @@ const handleSubmit = (submit, props, valid, asyncValidate, fields) => {
             return submitResult
           }, submitError => {
             const error = submitError instanceof SubmissionError ? submitError.errors : undefined
+            if (!error) {
+              setTimeout(() => throw submitError)
+            }
             stopSubmit(error)
             if(onSubmitFail) {
               onSubmitFail(error, dispatch)


### PR DESCRIPTION
Why:

* Non `SubmissionError` errors like `ReferenceError` are silenced and
  makes debugging difficult inside submission logic.

This change addresses the need by:

* Throw the error again if it's not a `SubmissionError`.
* The error is thrown in `setTimeout` for a `Promise` so we get the real
  error as opposed to an uncaught rejection.