### PR TITLE
Use the `for` attribute for label elements

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -47,15 +47,15 @@ class ContactForm extends Component {
     return (
       <form onSubmit={handleSubmit}>
         <div>
-          <label>First Name</label>
+          <label htmlFor="firstName">First Name</label>
           <Field name="firstName" component="input" type="text"/>
         </div>
         <div>
-          <label>Last Name</label>
+          <label htmlFor="lastName">Last Name</label>
           <Field name="lastName" component="input" type="text"/>
         </div>
         <div>
-          <label>Email</label>
+          <label htmlFor="email">Email</label>
           <Field name="email" component="input" type="email"/>
         </div>
         <button type="submit">Submit</button>

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -36,14 +36,14 @@ import { reduxForm } from 'redux-form'
 
 class MyForm extends Component {
   render() {
-  
+
     const { fields: { username, password }, handleSubmit } = this.props
-    
+
     return (
       <form onSubmit={handleSubmit}>
-      
+
         <div>
-          <label>Username</label>
+          <label htmlFor="username">Username</label>
           <div>
             <input type="text" {...username}/>
             {username.touched &&
@@ -51,9 +51,9 @@ class MyForm extends Component {
              <span className="error">{username.error}</span>}
           </div>
         </div>
-        
+
         <div>
-          <label>Password</label>
+          <label htmlFor="password">Password</label>
           <div>
             <input type="password" {...password}/>  // Duplicating same code as above
             {password.touched &&                    // except for "type" prop
@@ -87,31 +87,31 @@ const renderInput = field =>   // Define stateless component to render input and
      field.error &&
      <span className="error">{field.error}</span>}
   </div>
-            
+
 class MyForm extends Component {
   render() {
-  
+
     const { handleSubmit } = this.props       // No fields prop
-    
+
     return (
       <form onSubmit={handleSubmit}>
-      
+
         <div>
-          <label>Username</label>
+          <label htmlFor="username">Username</label>
           <Field
             name="username"                   // Specify field name
             component={renderInput}           // Specify render component above
             type="text"/>                     // "type" prop will get forwarded to <input>
         </div>
-        
+
         <div>
-          <label>Username</label>
+          <label htmlFor="username">Username</label>
           <Field
             name="username"                   // Specify field name
             component={renderInput}           // Reuse same render component
             type="password"/>                 // type prop will get forwarded to <input>
         </div>
-        
+
         <button type="submit">Submit</button>
       </form>
     )
@@ -237,7 +237,7 @@ render() {
     <div>
       <ul>
         {awards.map((award, index) => <li key={index}>
-          <label>Award #{index + 1}</label>
+          <label htmlFor="award">Award #{index + 1}</label>
           <input type="text" {...award.input}/>
         </li>)}
       </ul>
@@ -257,7 +257,7 @@ render() {
         <div>
           <ul>
             {awards.map((name, index) => <li key={index}>
-              <label>Award #{index + 1}</label>
+              <label htmlFor="award">Award #{index + 1}</label>
               <Field name={name} type="text" component="input"/>
             </li>)}
           </ul>

--- a/docs/faq/EnterToSubmit.md
+++ b/docs/faq/EnterToSubmit.md
@@ -10,13 +10,13 @@ render() {
     <form onSubmit={handleSubmit}>
       <button type="button">Load Data</button>
       <button type="button">Delete Record</button>
-      
-      <label>First Name</label>
+
+      <label htmlFor="firstName">First Name</label>
       <input type="text" {...firstName}/>
-      
-      <label>Last Name</label>
+
+      <label htmlFor="lastName">Last Name</label>
       <input type="text" {...lastName}/>
-      
+
       <button type="submit">Submit</button>
       <button type="button">Do Something Else</button>
     </form>


### PR DESCRIPTION
Assistive technologies makes good use of `for` in order
to help people who depend on screenreaders.

I believe in making the web an inclusive place and I think libraries like this promoting best practices is a good place to start. Including the `for` attribute in the examples increases the chance that developers who copy and paste from the docs will include it in their own markup.

Your PR, should you choose to accept it, will add the `htmlFor` attribute to `<label>` elements in the examples, increasing the chance that other developers will include it in their codebase.