### PR TITLE
Add link to rc.4 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
 * [6.0.0-rc.1](http://redux-form.com/6.0.0-rc.1/)
 * [6.0.0-rc.2](http://redux-form.com/6.0.0-rc.2/)
 * [6.0.0-rc.3](http://redux-form.com/6.0.0-rc.3/)
+* [6.0.0-rc.4](http://redux-form.com/6.0.0-rc.4/)
 
 ## Community
 [Adding A Robust Form Validation To React Redux Apps - Blog](https://medium.com/@rajaraodv/adding-a-robust-form-validation-to-react-redux-apps-616ca240c124#.1iyuelj2e)


### PR DESCRIPTION
Looks like this got missed in the initial rc.4 release?