### PR TITLE
pure option

### DIFF
--- a/src/__tests__/reduxForm.spec.js
+++ b/src/__tests__/reduxForm.spec.js
@@ -88,6 +88,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
         'initialized',
         'invalid',
         'pristine',
+        'pure',
         'reset',
         'submitFailed',
         'submitSucceeded',

--- a/src/reduxForm.js
+++ b/src/reduxForm.js
@@ -164,7 +164,7 @@ const createReduxForm =
           }
 
           shouldComponentUpdate(nextProps) {
-            if (!config.pure) return true;
+            if (!config.pure) return true
             return Object.keys(nextProps).some(prop => {
               // useful to debug rerenders
               // if (!plain.deepEqual(this.props[ prop ], nextProps[ prop ])) {

--- a/src/reduxForm.js
+++ b/src/reduxForm.js
@@ -87,6 +87,7 @@ const createReduxForm =
         shouldAsyncValidate: defaultShouldAsyncValidate,
         enableReinitialize: false,
         getFormState: state => getIn(state, 'form'),
+        pure: true,
         ...initialConfig
       }
       return WrappedComponent => {
@@ -163,6 +164,7 @@ const createReduxForm =
           }
 
           shouldComponentUpdate(nextProps) {
+            if (!config.pure) return true;
             return Object.keys(nextProps).some(prop => {
               // useful to debug rerenders
               // if (!plain.deepEqual(this.props[ prop ], nextProps[ prop ])) {


### PR DESCRIPTION
Adds `pure` option.

Needed if a parent component re-renders and a child component fetches state from context / any other source that isn't checked in the `shouldComponentUpdate`.