### PR TITLE
Use redux-validate for examples

### DIFF
--- a/examples/asyncValidation/package.json
+++ b/examples/asyncValidation/package.json
@@ -12,6 +12,7 @@
     "babel-polyfill": "^6.6.1",
     "html-loader": "^0.4.3",
     "json-loader": "^0.5.4",
+    "lodash": "4.14.1",
     "markdown-loader": "^0.1.7",
     "raw-loader": "^0.5.1",
     "react": "^15.0.0-rc.2",
@@ -19,7 +20,8 @@
     "react-redux": "^4.4.1",
     "redux": "^3.3.1",
     "redux-form": "file:../../",
-    "redux-form-website-template": "0.0.34"
+    "redux-form-website-template": "0.0.34",
+    "redux-validate": "0.2.0"
   },
   "devDependencies": {
     "babel-core": "^6.3.15",

--- a/examples/asyncValidation/src/asyncValidate.js
+++ b/examples/asyncValidation/src/asyncValidate.js
@@ -1,13 +1,14 @@
+import validate from 'redux-validate'
+
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
 
-const asyncValidate = (values/*, dispatch */) => {
-  return sleep(1000) // simulate server latency
-    .then(() => {
-      if ([ 'john', 'paul', 'george', 'ringo' ].includes(values.username)) {
-        throw { username: 'That username is taken' }
-      }
-    })
-}
+const asyncValidate = validate({
+  username: username =>
+    sleep(1000) // simulate server latency
+      .then(() =>
+        [ 'john', 'paul', 'george', 'ringo' ].includes(username) &&
+          'That username is taken'
+      )
+})
 
 export default asyncValidate
-

--- a/examples/asyncValidation/src/validate.js
+++ b/examples/asyncValidation/src/validate.js
@@ -1,13 +1,5 @@
-const validate = values => {
-  const errors = {}
-  if (!values.username) {
-    errors.username = 'Required'
-  }
-  if (!values.password) {
-    errors.password = 'Required'
-  }
-  return errors
-}
+import _validate from 'redux-validate'
+
+const validate = _validate([ 'username', 'password' ], 'Required')
 
 export default validate
-

--- a/examples/fieldArrays/package.json
+++ b/examples/fieldArrays/package.json
@@ -12,6 +12,7 @@
     "babel-polyfill": "^6.6.1",
     "html-loader": "^0.4.3",
     "json-loader": "^0.5.4",
+    "lodash": "4.14.1",
     "markdown-loader": "^0.1.7",
     "raw-loader": "^0.5.1",
     "react": "^15.0.0-rc.2",
@@ -19,7 +20,8 @@
     "react-redux": "^4.4.1",
     "redux": "^3.3.1",
     "redux-form": "file:../../",
-    "redux-form-website-template": "0.0.34"
+    "redux-form-website-template": "0.0.34",
+    "redux-validate": "0.2.0"
   },
   "devDependencies": {
     "babel-core": "^6.3.15",

--- a/examples/fieldArrays/src/validate.js
+++ b/examples/fieldArrays/src/validate.js
@@ -1,48 +1,14 @@
-const validate = values => {
-  const errors = {}
-  if(!values.clubName) {
-    errors.clubName = 'Required'
-  }
-  if (!values.members || !values.members.length) {
-    errors.members = { _error: 'At least one member must be entered' }
-  } else {
-    const membersArrayErrors = []
-    values.members.forEach((member, memberIndex) => {
-      const memberErrors = {}
-      if (!member || !member.firstName) {
-        memberErrors.firstName = 'Required'
-        membersArrayErrors[memberIndex] = memberErrors
-      }
-      if (!member || !member.lastName) {
-        memberErrors.lastName = 'Required'
-        membersArrayErrors[memberIndex] = memberErrors
-      }
-      if (member && member.hobbies && member.hobbies.length) {
-        const hobbyArrayErrors = []
-        member.hobbies.forEach((hobby, hobbyIndex) => {
-          if (!hobby || !hobby.length) {
-            hobbyArrayErrors[hobbyIndex] =  'Required'
-          }
-        })
-        if(hobbyArrayErrors.length) {
-          memberErrors.hobbies = hobbyArrayErrors
-          membersArrayErrors[memberIndex] = memberErrors
-        }
-        if (member.hobbies.length > 5) {
-          if(!memberErrors.hobbies) {
-            memberErrors.hobbies = []
-          }
-          memberErrors.hobbies._error = 'No more than five hobbies allowed'
-          membersArrayErrors[memberIndex] = memberErrors
-        }
-      }
-      return memberErrors
-    })
-    if(membersArrayErrors.length) {
-      errors.members = membersArrayErrors
-    }
-  }
-  return errors
-}
+import _validate from 'redux-validate'
+
+const validate =
+  _validate(
+    [ 'clubName', 'members[].firstName','members[].lastName', 'members[].hobbies[]' ],
+    'Required')
+  .then(
+    'members<._error>',
+    members => (!members || !members.length) && 'At least one member must be entered')
+  .then(
+    'members[].hobbies<._error>',
+    hobbies => hobbies && hobbies.length > 5 && 'No more than five hobbies allowed')
 
 export default validate

--- a/examples/immutable/package.json
+++ b/examples/immutable/package.json
@@ -13,6 +13,7 @@
     "html-loader": "^0.4.3",
     "immutable": "^3.8.1",
     "json-loader": "^0.5.4",
+    "lodash": "4.14.1",
     "markdown-loader": "^0.1.7",
     "raw-loader": "^0.5.1",
     "react": "^15.0.1",
@@ -21,7 +22,8 @@
     "redux": "^3.4.0",
     "redux-form": "file:../../",
     "redux-form-website-template": "0.0.34",
-    "redux-immutablejs": "0.0.8"
+    "redux-immutablejs": "0.0.8",
+    "redux-validate": "0.2.0"
   },
   "devDependencies": {
     "babel-core": "^6.7.6",

--- a/examples/immutable/src/validate.js
+++ b/examples/immutable/src/validate.js
@@ -1,24 +1,16 @@
+import _validate from 'redux-validate'
+
 const validate = values => {
-  // IMPORTANT: values is an Immutable.Map here!
-  const errors = {}
-  if (!values.get('username')) {
-    errors.username = 'Required'
-  } else if (values.get('username').length > 15) {
-    errors.username = 'Must be 15 characters or less'
-  }
-  if (!values.get('email')) {
-    errors.email = 'Required'
-  } else if (!/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i.test(values.get('email'))) {
-    errors.email = 'Invalid email address'
-  }
-  if (!values.get('age')) {
-    errors.age = 'Required'
-  } else if (isNaN(Number(values.get('age')))) {
-    errors.age = 'Must be a number'
-  } else if (Number(values.get('age')) < 18) {
-    errors.age = 'Sorry, you must be at least 18 years old'
-  }
-  return errors
+  values = values.toJS()
+  return _validate([ 'username', 'email', 'age' ], 'Required')
+    .then({
+      username: username => username && username.length > 15 && 'Must be 15 characters or less',
+      email: email => !/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i.test(email) &&
+        'Invalid email address',
+      age: age => isNaN(Number(age)) && 'Must be a number'
+    })
+    .then('age', age => Number(age) < 18 && 'Sorry, you must be at least 18 years old')(
+    values)
 }
 
 export default validate

--- a/examples/syncValidation/package.json
+++ b/examples/syncValidation/package.json
@@ -12,6 +12,7 @@
     "babel-polyfill": "^6.6.1",
     "html-loader": "^0.4.3",
     "json-loader": "^0.5.4",
+    "lodash": "4.14.1",
     "markdown-loader": "^0.1.7",
     "raw-loader": "^0.5.1",
     "react": "^15.0.0-rc.2",
@@ -19,7 +20,8 @@
     "react-redux": "^4.4.1",
     "redux": "^3.3.1",
     "redux-form": "file:../../",
-    "redux-form-website-template": "0.0.34"
+    "redux-form-website-template": "0.0.34",
+    "redux-validate": "0.2.0"
   },
   "devDependencies": {
     "babel-core": "^6.3.15",

--- a/examples/syncValidation/src/SyncValidationForm.js
+++ b/examples/syncValidation/src/SyncValidationForm.js
@@ -1,27 +1,16 @@
 import React from 'react'
 import { Field, reduxForm } from 'redux-form'
+import _validate from 'redux-validate'
 
-const validate = values => {
-  const errors = {}
-  if (!values.username) {
-    errors.username = 'Required'
-  } else if (values.username.length > 15) {
-    errors.username = 'Must be 15 characters or less'
-  }
-  if (!values.email) {
-    errors.email = 'Required'
-  } else if (!/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i.test(values.email)) {
-    errors.email = 'Invalid email address'
-  }
-  if (!values.age) {
-    errors.age = 'Required'
-  } else if (isNaN(Number(values.age))) {
-    errors.age = 'Must be a number'
-  } else if (Number(values.age) < 18) {
-    errors.age = 'Sorry, you must be at least 18 years old'
-  }
-  return errors
-}
+const validate =
+  _validate([ 'username', 'email', 'age' ], 'Required')
+    .then({
+      username: username => username && username.length > 15 && 'Must be 15 characters or less',
+      email: email => !/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i.test(email) &&
+        'Invalid email address',
+      age: age => isNaN(Number(age)) && 'Must be a number'
+    })
+    .then('age', age => Number(age) < 18 && 'Sorry, you must be at least 18 years old')
 
 const renderField = ({ input, label, type, meta: { touched, error } }) => (
   <div>

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "babel-plugin-transform-es2015-modules-commonjs": "^6.8.0",
     "babel-plugin-transform-regenerator": "^6.6.5",
     "babel-polyfill": "^6.7.4",
-    "babel-preset-es2015": "^6.1.18",
+    "babel-preset-es2015": "6.9.0",
     "babel-preset-es2015-webpack": "^6.4.1",
     "babel-preset-react": "^6.1.18",
     "babel-preset-stage-2": "^6.1.18",


### PR DESCRIPTION
This is **not** a serious pull request. I wanted to:

* Draw attention to a recent rewrite of [redux-validate](https://github.com/ashtonwar/redux-validate), it adds several features including async & deep key support.
* Make sure redux-validate works well with redux-form.

I think the changes to the `fieldArrays` example are particularly interesting, the code seems a lot easier to understand with the addition of redux-validate.