### PR TITLE
UNREGISTER_FIELD should not remove fields that don't exist

### DIFF
--- a/src/__tests__/reducer.unregisterField.spec.js
+++ b/src/__tests__/reducer.unregisterField.spec.js
@@ -21,6 +21,22 @@ const describeUnregisterField = (reducer, expect, { fromJS }) => () => {
     expect(state)
       .toEqual(initialState)
   })
+  
+  it('should do nothing if the field is not registered', () => {
+    const state = reducer(fromJS({
+      foo: {
+        registeredFields: [ 
+          { name: 'bar', type: 'field' }
+        ]
+      }
+    }), unregisterField('foo', 'baz'))
+    expect(state)
+      .toEqualMap({
+        foo: {
+          registeredFields: [ { name: 'bar', type: 'field' } ]
+        }
+      })
+  })
 }
 
 export default describeUnregisterField

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -250,6 +250,9 @@ const createReducer = structure => {
       if (size(registeredFields) <= 1 && fieldIndex >= 0) {
         return deleteInWithCleanUp(state, 'registeredFields')
       }
+      if (fieldIndex < 0) {
+        return state
+      }
       return setIn(state, 'registeredFields', splice(registeredFields, fieldIndex, 1))
     },
     [UNTOUCH](state, { meta: { fields } }) {

--- a/src/structure/immutable/expectations.js
+++ b/src/structure/immutable/expectations.js
@@ -35,8 +35,8 @@ const api = {
     expect.assert(
       deepEqualValues(this.actual, fromJS(expected)),
       'expected...\n%s\n...but found...\n%s',
-      this.actual,
-      fromJS(expected)
+      fromJS(expected),
+      this.actual
     )
     return this
   }


### PR DESCRIPTION
`findIndex()` returns -1 for non existing values. When feeding -1 to
the `splice()` method, the first value of the `registeredFields` array
is erroneously removed.

Fixes #1460.