### PR TITLE
[v6] Fixed the pristine/dirty state of fields that get reinitialized to an empty value.

### DIFF
--- a/src/ConnectedField.js
+++ b/src/ConnectedField.js
@@ -73,7 +73,8 @@ const createConnectedField = ({
   const connector = connect(
     (state, ownProps) => {
       const formState = getFormState(state)
-      const initial = getIn(formState, `initial.${name}`) || propInitialValue
+      const initialState = getIn(formState, `initial.${name}`)
+      const initial = initialState === undefined ? propInitialValue : initialState
       const value = getIn(formState, `values.${name}`)
       const syncError = getSyncError(getIn(formState, 'syncErrors'))
       const pristine = value === initial

--- a/src/__tests__/Field.spec.js
+++ b/src/__tests__/Field.spec.js
@@ -86,6 +86,29 @@ const describeField = (name, structure, combineReducers, expect) => {
       expect(props2.meta.dirty).toBe(true)
     })
 
+    it('should allow an empty value from Redux state to be pristine', () => {
+      const props1 = testProps({
+        initial: {
+          foo: 'bar'
+        },
+        values: {
+          foo: ''
+        }
+      })
+      expect(props1.meta.pristine).toBe(false)
+      expect(props1.meta.dirty).toBe(true)
+      const props2 = testProps({
+        initial: {
+          foo: ''
+        },
+        values: {
+          foo: ''
+        }
+      })
+      expect(props2.meta.pristine).toBe(true)
+      expect(props2.meta.dirty).toBe(false)
+    })
+
     it('should get asyncValidating from Redux state', () => {
       const props1 = testProps({
         initial: {


### PR DESCRIPTION
Here's a simple fix. I noticed that if a field has a non-empty initial value, then I clear the field and reinitialize the form with an empty string, the field should become pristine, but does not (as of 6.0.0-rc.4). This happens because the code treats an empty string as no value at all and falls back to the original initial value. This pull request fixes the problem by expecting 'undefined' to be the only value that indicates the initial value is missing. Test included.