### PR TITLE
Example docs, run main npm install first

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@ Below are a list of examples that demonstrate the capabilities of `redux-form` f
 learning purposes.
 
 Each example is its own standalone web app with hot reloading. To run them locally, clone the 
-`redux-form` repository, `cd` into an example folder, and run `npm install` and `npm start`. Then
+`redux-form` repository, run `npm install`, `cd` into an example folder, and run `npm install` and `npm start`. Then
 open [`localhost:3030`](http://localhost:3030) in your browser.
 
 


### PR DESCRIPTION
I tried to follow the [general example instructions](http://redux-form.com/6.0.0-rc.1/examples/) to get them running on my local machine, but I ran into missing dependencies like Mocha, babel-register etc. 
I noticed that this wasn't an issue when I first did a `npm install` of the main project.