### PR TITLE
Allow Fields to have an "_error" assigned to them

### DIFF
--- a/src/__tests__/hasError.spec.js
+++ b/src/__tests__/hasError.spec.js
@@ -110,6 +110,21 @@ const describeHasError = (name, structure, expect) => {
         expect(hasError(field, null, null, error)).toBe(false)
       }
     })
+
+    it('should return true if a Field that has an object value has an _error', () => {
+      const field = fromJS({ name: 'foo', type: 'Field' })
+      const plainError = {
+        foo: {
+          _error: 'An error'
+        }
+      }
+
+      expect(hasError(field, plainError)).toBe(true)
+
+      const error = fromJS(plainError)
+      expect(hasError(field, null, error)).toBe(true)
+      expect(hasError(field, null, null, error)).toBe(true)
+    })
   })
 }
 

--- a/src/hasError.js
+++ b/src/hasError.js
@@ -1,11 +1,11 @@
 import plainGetIn from './structure/plain/getIn'
 
-const getErrorKey = (name, type) => {
+const getErrorKeys = (name, type) => {
   switch (type) {
     case 'Field':
-      return name
+      return [ name, `${name}._error` ]
     case 'FieldArray':
-      return `${name}._error`
+      return [ `${name}._error` ]
   }
 }
 
@@ -16,17 +16,27 @@ const createHasError = ({ getIn }) => {
     if (!syncErrors && !asyncErrors && !submitErrors) {
       return false
     }
-    const errorKey = getErrorKey(name, type)
-    const syncError = plainGetIn(syncErrors, errorKey)
-    if (syncError && typeof syncError === 'string') {
+    const errorKeys = getErrorKeys(name, type)
+
+    const syncError = errorKeys.reduce((error, errorKey) => {
+      const curError = plainGetIn(syncErrors, errorKey)
+      return curError ? error + curError : error
+    }, null)
+    if (syncError != null) {
       return true
     }
-    const asyncError = getIn(asyncErrors, errorKey)
-    if (asyncError && typeof asyncError === 'string') {
+    const asyncError = errorKeys.reduce((error, errorKey) => {
+      const curError = getIn(asyncErrors, errorKey)
+      return curError ? error + curError : error
+    }, null)
+    if (asyncError != null) {
       return true
     }
-    const submitError = getIn(submitErrors, errorKey)
-    if (submitError && typeof submitError === 'string') {
+    const submitError = errorKeys.reduce((error, errorKey) => {
+      const curError = getIn(submitErrors, errorKey)
+      return curError ? error + curError : error
+    }, null)
+    if (submitError != null) {
       return true
     }
 

--- a/src/reduxForm.js
+++ b/src/reduxForm.js
@@ -10,10 +10,9 @@ import handleSubmit from './handleSubmit'
 import silenceEvent from './events/silenceEvent'
 import silenceEvents from './events/silenceEvents'
 import asyncValidation from './asyncValidation'
-import createHasErrors from './hasErrors'
-import createHasError from './hasError'
 import defaultShouldAsyncValidate from './defaultShouldAsyncValidate'
 import plain from './structure/plain'
+import createIsValid from './selectors/isValid'
 
 const isClassComponent = Component => Boolean(
   Component &&
@@ -75,10 +74,8 @@ const checkSubmit = submit => {
  */
 const createReduxForm =
   structure => {
-    const { deepEqual, empty, getIn, setIn, fromJS, some } = structure
-    const hasErrors = createHasErrors(structure)
-    const hasError = createHasError(structure)
-    const plainHasErrors = createHasErrors(plain)
+    const { deepEqual, empty, getIn, setIn, fromJS } = structure
+    const isValid = createIsValid(structure)
     return initialConfig => {
       const config = {
         touchOnBlur: true,
@@ -405,16 +402,9 @@ const createReduxForm =
             const values = getIn(formState, 'values') || initial
             const pristine = deepEqual(initial, values)
             const asyncErrors = getIn(formState, 'asyncErrors')
-            const submitErrors = getIn(formState, 'submitErrors')
             const syncErrors = getIn(formState, 'syncErrors')
-            const hasSyncErrors = plainHasErrors(syncErrors)
-            const hasAsyncErrors = hasErrors(asyncErrors)
-            const hasSubmitErrors = hasErrors(submitErrors)
             const registeredFields = getIn(formState, 'registeredFields') || []
-            const hasFieldWithError = registeredFields && some(registeredFields,
-              field => hasError(field, syncErrors, asyncErrors, submitErrors))
-            const valid =
-              !hasSyncErrors && !hasAsyncErrors && !hasSubmitErrors && !hasFieldWithError
+            const valid = isValid(form, getFormState)(state)
             const anyTouched = !!getIn(formState, 'anyTouched')
             const submitting = !!getIn(formState, 'submitting')
             const submitFailed = !!getIn(formState, 'submitFailed')


### PR DESCRIPTION
Fields can have object values, in which case we need a way to set an
error at the object level. The library will pass "_error" to the Field as
the "error" prop to be displayed, but isValid wasn't respecting it as an error.

Also reused `isValid` selector in the `reduxForm` `connect` function so that we're not duplicating logic.

Fixes #1107 