### PR TITLE
Pass "submitting" as prop to ConnectedField and ConnectedFieldArray

### DIFF
--- a/src/ConnectedField.js
+++ b/src/ConnectedField.js
@@ -76,6 +76,7 @@ const createConnectedField = ({
       const initialState = getIn(formState, `initial.${name}`)
       const initial = initialState === undefined ? propInitialValue : initialState
       const value = getIn(formState, `values.${name}`)
+      const submitting = getSyncError(getIn(formState, 'submitting'))
       const syncError = getSyncError(getIn(formState, 'syncErrors'))
       const pristine = value === initial
       return {
@@ -85,6 +86,7 @@ const createConnectedField = ({
         pristine,
         state: getIn(formState, `fields.${name}`),
         submitError: getIn(formState, `submitErrors.${name}`),
+        submitting,
         syncError,
         value,
         _value: ownProps.value // save value passed in (for checkboxes)

--- a/src/ConnectedFieldArray.js
+++ b/src/ConnectedFieldArray.js
@@ -96,6 +96,7 @@ const createConnectedFieldArray = ({
       const formState = getFormState(state)
       const initial = getIn(formState, `initial.${name}`) || propInitialValue
       const value = getIn(formState, `values.${name}`)
+      const submitting = getSyncError(getIn(formState, 'submitting'))
       const syncError = getSyncError(getIn(formState, 'syncErrors'))
       const pristine = deepEqual(value, initial)
       return {
@@ -103,6 +104,7 @@ const createConnectedFieldArray = ({
         dirty: !pristine,
         pristine,
         submitError: getIn(formState, `submitErrors.${name}._error`),
+        submitting,
         syncError,
         value
       }


### PR DESCRIPTION
This will force the component to re-render when submitting so that we
can disabled / enable components based on submit state.

Fixes #1122