### PR TITLE
Fix sync validation -> _error should trigger a form level error prop

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -295,7 +295,7 @@ const createReducer = structure => {
     [UPDATE_SYNC_ERRORS](state, { payload }) {
       let result = state
       if (payload && Object.keys(payload).length) {
-        const { _error, ...fieldErrors } = payload
+        const { _error } = payload
         if (_error) {
           result = setIn(result, 'error', _error)
         } else {

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -205,6 +205,8 @@ const createReducer = structure => {
         const { _error, ...fieldErrors } = payload
         if (_error) {
           result = setIn(result, 'error', _error)
+        } else {
+          result = deleteIn(result, 'error')
         }
         if (Object.keys(fieldErrors).length) {
           result = setIn(result, 'asyncErrors', fromJS(fieldErrors))
@@ -226,6 +228,8 @@ const createReducer = structure => {
         const { _error, ...fieldErrors } = payload
         if (_error) {
           result = setIn(result, 'error', _error)
+        } else {
+          result = deleteIn(result, 'error')
         }
         if (Object.keys(fieldErrors).length) {
           result = setIn(result, 'submitErrors', fromJS(fieldErrors))
@@ -289,9 +293,24 @@ const createReducer = structure => {
       return result
     },
     [UPDATE_SYNC_ERRORS](state, { payload }) {
-      return Object.keys(payload).length ?
-        setIn(state, 'syncErrors', payload) :
-        deleteIn(state, 'syncErrors')
+      let result = state
+      if (payload && Object.keys(payload).length) {
+        const { _error, ...fieldErrors } = payload
+        if (_error) {
+          result = setIn(result, 'error', _error)
+        } else {
+          result = deleteIn(result, 'error')
+        }
+        if (Object.keys(payload).length) {
+          result = setIn(result, 'syncErrors', payload)
+        } else {
+          result = deleteIn(result, 'syncErrors')
+        }
+      } else {
+        result = deleteIn(result, 'error')
+        result = deleteIn(result, 'syncErrors')
+      }
+      return result
     }
   }
 


### PR DESCRIPTION
Hey @erikras 

I noticed when running sync validation in the below example
```javascript
const FormComponent = ({error}) => {
    console.log(error) // undefined
    return (
        <form>
        ...form fields
        </form>
    )
}

reduxForm({
    name: 'myForm',
    validate => ({ _error: 'the form is bad' })
})(FormComponent)
```
The `error` prop will always come in to the form as undefined. When I took a look a the reducer, the `STOP_SUBMIT` and `STOP_ASYNC_VALIDATION` action handlers both assign the `_error` key to the `error` key in the form's state, but the `UPDATE_SYNC_ERRORS` action handler didn't.

This pull request updates `UPDATE_SYNC_ERRORS` to process the `_error` key just like the other action handlers.

The other two changes are small, updating the `STOP_SUBMIT` and `STOP_ASYNC_VALIDATION` action handlers to delete the form level `error` key from the state if `_error` isn't in the error payload, but other field errors exist.

Please let me know if you have any questions.
Thanks for all your hard work on redux-form!