### PR TITLE
Put custom props in proper place in Fields

### DIFF
--- a/src/ConnectedField.js
+++ b/src/ConnectedField.js
@@ -40,7 +40,7 @@ const createConnectedField = ({
 
     render() {
       const { component, withRef, ...rest } = this.props
-      const props = createFieldProps(getIn,
+      const { custom, ...props } = createFieldProps(getIn,
         name,
         {
           ...rest,
@@ -54,11 +54,11 @@ const createConnectedField = ({
         props.ref = 'renderedComponent'
       }
       if (typeof component === 'string') {
-        const { input, meta, ...custom } = props // eslint-disable-line no-unused-vars
+        const { input, meta } = props // eslint-disable-line no-unused-vars
         // flatten input into other props
         return createElement(component, { ...input, ...custom })
       } else {
-        return createElement(component, props)
+        return createElement(component, { ...props, ...custom })
       }
     }
   }

--- a/src/ConnectedFields.js
+++ b/src/ConnectedFields.js
@@ -42,9 +42,9 @@ const createConnectedFields = ({
     render() {
       const { component, withRef, _fields, ...rest } = this.props
 
-      const props = Object.keys(_fields).reduce((accumulator, name) => {
+      const { custom, ...props } = Object.keys(_fields).reduce((accumulator, name) => {
         const connectedProps = _fields[ name ]
-        const fieldProps = createFieldProps(getIn,
+        const { custom, ...fieldProps } = createFieldProps(getIn,
           name,
           {
             ...connectedProps,
@@ -55,13 +55,14 @@ const createConnectedFields = ({
           },
           asyncValidate
         )
+        accumulator.custom = custom
         return plain.setIn(accumulator, name, fieldProps)
       }, {})
       if (withRef) {
         props.ref = 'renderedComponent'
       }
 
-      return createElement(component, props)
+      return createElement(component, { ...props, ...custom })
     }
   }
 

--- a/src/__tests__/createFieldProps.spec.js
+++ b/src/__tests__/createFieldProps.spec.js
@@ -219,8 +219,8 @@ const describeCreateFieldProps = (name, structure, expect) => {
       })
       expect(result.initial).toNotExist()
       expect(result.state).toNotExist()
-      expect(result.someOtherProp).toBe('dog')
-      expect(result.className).toBe('my-class')
+      expect(result.custom.someOtherProp).toBe('dog')
+      expect(result.custom.className).toBe('my-class')
     })
 
     it('should pass through other props using props prop', () => {
@@ -234,8 +234,8 @@ const describeCreateFieldProps = (name, structure, expect) => {
       })
       expect(result.initial).toNotExist()
       expect(result.state).toNotExist()
-      expect(result.someOtherProp).toBe('dog')
-      expect(result.className).toBe('my-class')
+      expect(result.custom.someOtherProp).toBe('dog')
+      expect(result.custom.className).toBe('my-class')
     })
 
     it('should set checked for checkboxes', () => {

--- a/src/createFieldProps.js
+++ b/src/createFieldProps.js
@@ -77,8 +77,7 @@ const createFieldProps = (getIn, name,
       valid: !error,
       visited: state && !!getIn(state, 'visited')
     },
-    ...props,
-    ...custom
+    custom: { ...custom, ...props }
   }
 }
 


### PR DESCRIPTION
The custom props weren't going into the right place in the props passed to `component`. Fixes #1583.