### PR TITLE
Fix broken links & image in documentation

### DIFF
--- a/docs/ValueLifecycle.md
+++ b/docs/ValueLifecycle.md
@@ -27,7 +27,6 @@ have provided a parser, the value given to `normalize()` will already be parsed.
 ## Value Lifecycle
 
 <div style="text-align: center;">
-<img align="center" src="https://github.com/erikras/redux-form/raw/v6/docs/valueLifecycle
-.png"/>
+<img align="center" src="https://github.com/erikras/redux-form/blob/master/docs/valueLifecycle.png"/>
 </div>
 

--- a/docs/ValueLifecycle.md
+++ b/docs/ValueLifecycle.md
@@ -27,6 +27,6 @@ have provided a parser, the value given to `normalize()` will already be parsed.
 ## Value Lifecycle
 
 <div style="text-align: center;">
-<img align="center" src="https://github.com/erikras/redux-form/blob/master/docs/valueLifecycle.png"/>
+<img align="center" src="https://github.com/erikras/redux-form/raw/master/docs/valueLifecycle.png"/>
 </div>
 

--- a/docs/api/Props.md
+++ b/docs/api/Props.md
@@ -5,7 +5,7 @@ to your decorated form component. The `props` that _you pass into your wrapped c
 listed [here](#/api/reduxForm).
 
 > If you are a strict `PropTypes` completionist, `redux-form` exports all of these
-[`propTypes`](https://github.com/erikras/redux-form/blob/v6/src/createPropTypes.js), 
+[`propTypes`](https://github.com/erikras/redux-form/blob/master/src/propTypes.js), 
 so you may import them, like so:
 
 ```javascript

--- a/docs/api/Props.md
+++ b/docs/api/Props.md
@@ -2,7 +2,7 @@
 
 > The `props` listed on this page are are the `props` that `redux-form` generates to give
 to your decorated form component. The `props` that _you pass into your wrapped component_ are
-listed [here](#/api/reduxForm).
+listed [here](http://redux-form.com/6.0.1/docs/api/ReduxForm.md/).
 
 > If you are a strict `PropTypes` completionist, `redux-form` exports all of these
 [`propTypes`](https://github.com/erikras/redux-form/blob/master/src/propTypes.js), 


### PR DESCRIPTION
- The [Value Lifecycle](http://redux-form.com/6.0.1/docs/ValueLifecycle.md/) page has a broken image due to its src url pointing to a nonexistant image. It has been corrected to point to `https://github.com/erikras/redux-form/blob/master/docs/valueLifecycle.png`

- The [Props](http://redux-form.com/6.0.1/docs/api/Props.md/) page has two broken links, one to the reduxForm() api docs & the other to `/propTypes.js`. Those two links have been corrected as well.