### PR TITLE
Remove deprecated reducer.normalize details from Reducer.md in documentation

### DIFF
--- a/docs/api/Reducer.md
+++ b/docs/api/Reducer.md
@@ -33,14 +33,3 @@ const reducers = {
 const reducer = combineReducers(reducers);
 const store = createStore(reducer);
 ```
-
----
-
-### Additional Functionality
-
-### [`reducer.normalize(Object<String, Object<String, Function>>)`](ReducerNormalize.md)
-
-> Returns a form reducer that will also pass each form value through the normalizing functions
-provided. The parameter is an object mapping from `formName` to an object mapping from
-`fieldName` to a normalizer function. The normalizer function is given four parameters and
-expected to return the normalized value of the field. [See details](ReducerNormalize.md).


### PR DESCRIPTION
Remove old details from V6 documentation about the normalizer function which no longer exists in reducer.js

The details also included a broken link to the old ReducerNormalize.md which no longer exists as well. Since this information is deprecated now and there is a new way to normalize form values ([normalizing functions](http://redux-form.com/6.0.1/examples/normalizing/)), it's worth removing from the docs now.