### PR TITLE
Add Source code links to API documentation & Add selectors section to api/README.md

### DIFF
--- a/docs/api/ActionCreators.md
+++ b/docs/api/ActionCreators.md
@@ -1,5 +1,7 @@
 # Action Creators
 
+[`View source on GitHub`](https://github.com/erikras/redux-form/blob/master/src/actions.js)
+
 `redux-form` exports all of its internal action creators, allowing you complete control to
 dispatch any action you wish. However, it is recommended that you use the actions passed as
 props to your component for most of your needs, as they are already bound to `dispatch`, your

--- a/docs/api/Field.md
+++ b/docs/api/Field.md
@@ -1,5 +1,7 @@
 # `Field`
 
+[`View source on GitHub`](https://github.com/erikras/redux-form/blob/master/src/Field.js)
+
 The `Field` component is how you connect each individual input to the Redux store. There are
 three fundamental things that you need to understand in order to use `Field` correctly:
 

--- a/docs/api/FieldArray.md
+++ b/docs/api/FieldArray.md
@@ -1,5 +1,7 @@
 # `FieldArray`
 
+[`View source on GitHub`](https://github.com/erikras/redux-form/blob/master/src/FieldArray.js)
+
 The `FieldArray` component is how you render an array of fields. It works a lot like `Field`.
 With `Field`, you give a `name`, referring to the location of the field in the Redux state, and a
 `component` to render the field, which is given the props to connect the field to the Redux state.

--- a/docs/api/Fields.md
+++ b/docs/api/Fields.md
@@ -1,5 +1,7 @@
 # `Fields`
 
+[`View source on GitHub`](https://github.com/erikras/redux-form/blob/master/src/Fields.js)
+
 The `Fields` component is similar to the
 [`Field`](http://redux-form.com/6.0.1/docs/api/Field.md/) component, but operates on multiple
 fields at a time. Rather than passing a single `name` prop, `Fields` takes an array of names in 

--- a/docs/api/FormValueSelector.md
+++ b/docs/api/FormValueSelector.md
@@ -1,5 +1,7 @@
 # `formValueSelector(form:String, [getFormState:Function])`
 
+[`View source on GitHub`](https://github.com/erikras/redux-form/blob/master/src/formValueSelector.js)
+
 > A "selector" API to make it easier to `connect()` to form values. `formValueSelector` _creates_
 a selector function for your form that can be used with your field names.
 

--- a/docs/api/Props.md
+++ b/docs/api/Props.md
@@ -1,5 +1,7 @@
 # `props`
 
+[`View source on GitHub`](https://github.com/erikras/redux-form/blob/master/src/reduxForm.js#L347)
+
 > The `props` listed on this page are are the `props` that `redux-form` generates to give
 to your decorated form component. The `props` that _you pass into your wrapped component_ are
 listed [here](#/api/reduxForm).

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -5,8 +5,7 @@
 > The decorator you use to connect your form component to Redux.
 [See details](ReduxForm.md).
 
-> [`View source on
-> GitHub`](https://github.com/erikras/redux-form/blob/master/src/reduxForm.js)
+> [`View source on GitHub`](https://github.com/erikras/redux-form/blob/master/src/reduxForm.js)
 
 ---
 
@@ -18,8 +17,7 @@
 
 > Returns a form reducer that will also pass each action through additional reducers specified.
 
-> [`View source on
-> GitHub`](https://github.com/erikras/redux-form/blob/master/src/reducer.js)
+> [`View source on GitHub`](https://github.com/erikras/redux-form/blob/master/src/reducer.js)
 
 ---
 
@@ -27,8 +25,7 @@
 
 > The props passed into your decorated form component.
 
-> [`View source on
-> GitHub`](https://github.com/erikras/redux-form/blob/master/src/reduxForm.js#L347)
+> [`View source on GitHub`](https://github.com/erikras/redux-form/blob/master/src/reduxForm.js#L347)
 
 ---
 
@@ -36,8 +33,7 @@
 
 > The component needed to connect any input to `redux-form`.
 
-> [`View source on
-> GitHub`](https://github.com/erikras/redux-form/blob/master/src/Field.js)
+> [`View source on GitHub`](https://github.com/erikras/redux-form/blob/master/src/Field.js)
 
 ---
 
@@ -45,8 +41,7 @@
 
 > The component that can to connect multiple inputs to `redux-form`.
 
-> [`View source on
-> GitHub`](https://github.com/erikras/redux-form/blob/master/src/Fields.js)
+> [`View source on GitHub`](https://github.com/erikras/redux-form/blob/master/src/Fields.js)
 
 ---
 
@@ -54,8 +49,7 @@
 
 > The component needed to render an array of fields
 
-> [`View source on
-> GitHub`](https://github.com/erikras/redux-form/blob/master/src/FieldArray.js)
+> [`View source on GitHub`](https://github.com/erikras/redux-form/blob/master/src/FieldArray.js)
 
 ---
 
@@ -63,8 +57,7 @@
 
 > Creates a selector for use in `connect()`ing to form values in the Redux store.
 
-> [`View source on
-> GitHub`](https://github.com/erikras/redux-form/blob/master/src/formValueSelector.js)
+> [`View source on GitHub`](https://github.com/erikras/redux-form/blob/master/src/formValueSelector.js)
 
 ---
 
@@ -72,8 +65,7 @@
 
 > A special error type for returning submit validation errors
 
-> [`View source on
-> GitHub`](https://github.com/erikras/redux-form/blob/master/src/SubmissionError.js)
+> [`View source on GitHub`](https://github.com/erikras/redux-form/blob/master/src/SubmissionError.js)
 
 ---
 
@@ -81,7 +73,14 @@
 
 > `redux-form` exports all of its internal action creators.
 
-> [`View source on
-> GitHub`](https://github.com/erikras/redux-form/blob/master/src/actions.js)
+> [`View source on GitHub`](https://github.com/erikras/redux-form/blob/master/src/actions.js)
+
+---
+
+## [Selectors](Selectors.md)
+
+> `redux-form` provides Redux state selectors that may be used to query the state of your forms.
+
+> [`View source on GitHub`](https://github.com/erikras/redux-form/tree/master/src/selectors)
 
 ---

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -9,7 +9,7 @@
 > GitHub`](https://github.com/erikras/redux-form/blob/master/src/reduxForm.js)
 
 ---
-  
+
 ## [`reducer`](Reducer.md)
 
 > The form reducer. Should be given to mounted to your Redux state at `form`.
@@ -22,7 +22,7 @@
 > GitHub`](https://github.com/erikras/redux-form/blob/master/src/reducer.js)
 
 ---
-  
+
 ## [`props`](Props.md)
 
 > The props passed into your decorated form component.
@@ -31,7 +31,7 @@
 > GitHub`](https://github.com/erikras/redux-form/blob/master/src/reduxForm.js#L347)
 
 ---
-  
+
 ## [`Field`](Field.md)
 
 > The component needed to connect any input to `redux-form`.
@@ -40,7 +40,7 @@
 > GitHub`](https://github.com/erikras/redux-form/blob/master/src/Field.js)
 
 ---
-  
+
 ## [`Fields`](Fields.md)
 
 > The component that can to connect multiple inputs to `redux-form`.
@@ -49,7 +49,7 @@
 > GitHub`](https://github.com/erikras/redux-form/blob/master/src/Fields.js)
 
 ---
-  
+
 ## [`FieldArray`](FieldArray.md)
 
 > The component needed to render an array of fields
@@ -58,7 +58,7 @@
 > GitHub`](https://github.com/erikras/redux-form/blob/master/src/FieldArray.js)
 
 ---
-  
+
 ## [`formValueSelector(form:String, [getFormState:Function])`](FormValueSelector.md)
 
 > Creates a selector for use in `connect()`ing to form values in the Redux store.
@@ -67,7 +67,7 @@
 > GitHub`](https://github.com/erikras/redux-form/blob/master/src/formValueSelector.js)
 
 ---
-  
+
 ## [`SubmissionError`](SubmissionError.md)
 
 > A special error type for returning submit validation errors
@@ -76,7 +76,7 @@
 > GitHub`](https://github.com/erikras/redux-form/blob/master/src/SubmissionError.js)
 
 ---
-  
+
 ## [Action Creators](ActionCreators.md)
 
 > `redux-form` exports all of its internal action creators.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -19,7 +19,7 @@
 
 > Returns a form reducer that will also pass each action through additional reducers specified.
 
-[`View source on GitHub`](https://github.com/erikras/redux-form/blob/master/src/reducer.js#L369)
+> [`View source on GitHub`](https://github.com/erikras/redux-form/blob/master/src/reducer.js#L369)
 
 ---
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -13,11 +13,13 @@
 
 > The form reducer. Should be given to mounted to your Redux state at `form`.
 
+> [`View source on GitHub`](https://github.com/erikras/redux-form/blob/master/src/reducer.js)
+
 > ### [`reducer.plugin(Object<String, Function>)`](ReducerPlugin.md)
 
 > Returns a form reducer that will also pass each action through additional reducers specified.
 
-> [`View source on GitHub`](https://github.com/erikras/redux-form/blob/master/src/reducer.js)
+[`View source on GitHub`](https://github.com/erikras/redux-form/blob/master/src/reducer.js#L369)
 
 ---
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -5,6 +5,9 @@
 > The decorator you use to connect your form component to Redux.
 [See details](ReduxForm.md).
 
+> [`View source on
+> GitHub`](https://github.com/erikras/redux-form/blob/master/src/reduxForm.js)
+
 ---
   
 ## [`reducer`](Reducer.md)
@@ -15,11 +18,17 @@
 
 > Returns a form reducer that will also pass each action through additional reducers specified.
 
+> [`View source on
+> GitHub`](https://github.com/erikras/redux-form/blob/master/src/reducer.js)
+
 ---
   
 ## [`props`](Props.md)
 
 > The props passed into your decorated form component.
+
+> [`View source on
+> GitHub`](https://github.com/erikras/redux-form/blob/master/src/reduxForm.js#L347)
 
 ---
   
@@ -27,11 +36,17 @@
 
 > The component needed to connect any input to `redux-form`.
 
+> [`View source on
+> GitHub`](https://github.com/erikras/redux-form/blob/master/src/Field.js)
+
 ---
   
 ## [`Fields`](Fields.md)
 
 > The component that can to connect multiple inputs to `redux-form`.
+
+> [`View source on
+> GitHub`](https://github.com/erikras/redux-form/blob/master/src/Fields.js)
 
 ---
   
@@ -39,11 +54,17 @@
 
 > The component needed to render an array of fields
 
+> [`View source on
+> GitHub`](https://github.com/erikras/redux-form/blob/master/src/FieldArray.js)
+
 ---
   
 ## [`formValueSelector(form:String, [getFormState:Function])`](FormValueSelector.md)
 
 > Creates a selector for use in `connect()`ing to form values in the Redux store.
+
+> [`View source on
+> GitHub`](https://github.com/erikras/redux-form/blob/master/src/formValueSelector.js)
 
 ---
   
@@ -51,10 +72,16 @@
 
 > A special error type for returning submit validation errors
 
+> [`View source on
+> GitHub`](https://github.com/erikras/redux-form/blob/master/src/SubmissionError.js)
+
 ---
   
 ## [Action Creators](ActionCreators.md)
 
 > `redux-form` exports all of its internal action creators.
+
+> [`View source on
+> GitHub`](https://github.com/erikras/redux-form/blob/master/src/actions.js)
 
 ---

--- a/docs/api/Reducer.md
+++ b/docs/api/Reducer.md
@@ -1,5 +1,7 @@
 # `reducer`
 
+[`View source on GitHub`](https://github.com/erikras/redux-form/blob/master/src/reducer.js)
+
 > The form reducer. Should be given to mounted to your Redux state at `form`.
 
 > If you absolutely must mount it somewhere other than `form`, you may provide a

--- a/docs/api/ReducerPlugin.md
+++ b/docs/api/ReducerPlugin.md
@@ -1,5 +1,7 @@
 # `reducer.plugin(Object<String, Function>)`
 
+[`View source on GitHub`](https://github.com/erikras/redux-form/blob/master/src/reducer.js#L369)
+
 > Returns a form reducer that will also pass each action through additional reducers specified.
 The parameter should be an object mapping from `formName` to a `(state, action) => nextState`
 reducer. **The `state` passed to each reducer will only be the slice that pertains to that form.**

--- a/docs/api/ReduxForm.md
+++ b/docs/api/ReduxForm.md
@@ -1,5 +1,7 @@
 # `reduxForm(config:Object)`
 
+[`View source on GitHub`](https://github.com/erikras/redux-form/blob/master/src/reduxForm.js)
+
 Creates a decorator with which you use `redux-form` to connect your form component to Redux.
 It takes a `config` parameter which lets you configure your form.
 

--- a/docs/api/Selectors.md
+++ b/docs/api/Selectors.md
@@ -1,5 +1,7 @@
 # Selectors
 
+[`View source on GitHub`](https://github.com/erikras/redux-form/tree/master/src/selectors)
+
 `redux-form` provides a set of useful Redux state
 [**selectors**](http://redux.js.org/docs/recipes/ComputingDerivedData.html) that may be used in 
 any part of your application to query the state of any of your forms.

--- a/docs/api/SubmissionError.md
+++ b/docs/api/SubmissionError.md
@@ -1,5 +1,7 @@
 # `SubmissionError`
 
+[`View source on GitHub`](https://github.com/erikras/redux-form/blob/master/src/SubmissionError.js)
+
 A throwable error that is used to return submit validation errors from `onSubmit`. The purpose
 being to distinguish promise rejection because of validation errors from promise rejection because
 of AJAX I/O problems or other server errors.


### PR DESCRIPTION
Addresses #1214 

Changes proposed:

- Add source code links on the api/README.md for each section block.

- Add source code links on each api documentation page to its respective github source. For `props` & `reducer.plugin`, I referred to their inline references in reduxForm.js & reducer.js

- Add Selectors section block to bottom of api/README.md to reflect the new Selectors.md documentation

