### PR TITLE
Add explanation on how custom props are given in Field & clarify props given by Field

### DIFF
--- a/docs/api/Field.md
+++ b/docs/api/Field.md
@@ -193,8 +193,9 @@ The following properties and methods are available on an instance of a `Field` c
 ## Props
 
 These are props that `Field` will pass to your wrapped component. **The props provided by `redux-form`
-are divided into `input` and `meta` objects. Any custom props passed to `Field` will be merged into
-the props object on the same level as the `input` and `meta` objects.**
+are divided into `input` and `meta` objects.**
+
+**Any custom props passed to `Field` will be merged into the props object on the same level as the `input` and `meta` objects.**
  
 ### Input Props
 

--- a/docs/api/Field.md
+++ b/docs/api/Field.md
@@ -192,8 +192,9 @@ The following properties and methods are available on an instance of a `Field` c
 
 ## Props
 
-These are props that `Field` will pass to your wrapped component. **All the props provided to your 
-component by `redux-form` are divided into `input` and `meta` objects.**
+These are props that `Field` will pass to your wrapped component. **The props provided by `redux-form`
+are divided into `input` and `meta` objects. Any custom props passed to `Field` will be merged into
+the props object on the same level as the `input` and `meta` objects.**
  
 ### Input Props
 


### PR DESCRIPTION
Currently in the documentation in Field.md, it says that 

> ## Props

>These are props that Field will pass to your wrapped component. **All the props provided to your component by redux-form are divided into input and meta objects.**

Unfortunately, for a newcomer to V6, this might be confusing since there is no explanation of where custom props come into play - only that there are props are divided into input & meta objects. 

(Also the use of the phrasing _`All the props provided to your component...are divided into input and meta objects`_ makes it sound like there is no other props available to Field besides input & meta).

**Change Proposed:**
I'd like to propose to add a sentence after the input & meta objects explanation, to explain that custom props are merged into the props that Field provides. Also to rephrase the input/meta explaination to be softer.

>## Props

>These are props that `Field` will pass to your wrapped component. **The props provided by `redux-form` are divided into `input` and `meta` objects.**

>**Any custom props passed to `Field` will be merged into the props object on the same level as the `input` and `meta` objects.**
 