### PR TITLE
Improved performance of getIn()

### DIFF
--- a/src/structure/plain/__tests__/getIn.spec.js
+++ b/src/structure/plain/__tests__/getIn.spec.js
@@ -33,6 +33,31 @@ describe('structure.plain.getIn', () => {
     expect(getIn(state, 'foo.bar[1].dog')).toBe(42)
   })
 
+  it('should get a value nested 1 level', () => {
+    expect(getIn({ foo: { bar: 42 } }, 'foo.bar')).toBe(42)
+  })
+
+  it('should get a value nested 2 levels', () => {
+    expect(getIn({ foo: { bar: { baz: 42 } } }, 'foo.bar.baz')).toBe(42)
+  })
+
+  it('should get a value nested 3 levels', () => {
+    expect(getIn({ foo: { bar: { baz: { yolanda: 42 } } } }, 'foo.bar.baz.yolanda')).toBe(42)
+  })
+
+  it('should return undefined if the requested level does not exist', () => {
+    expect(getIn({}, 'foo')).toBe(undefined)
+    expect(getIn({}, 'foo.bar')).toBe(undefined)
+    expect(getIn({}, 'foo.bar.baz')).toBe(undefined)
+    expect(getIn({}, 'foo.bar.baz.yolanda')).toBe(undefined)
+  })
+
+  it('should return undefined for invalid/empty path', () => {
+    expect(getIn({ foo: 42 }, undefined)).toBe(undefined)
+    expect(getIn({ foo: 42 }, null)).toBe(undefined)
+    expect(getIn({ foo: 42 }, '')).toBe(undefined)
+  })
+
   it('should get string keys on arrays', () => {
     const array = [ 1, 2, 3 ]
     array.stringKey = 'hello'

--- a/src/structure/plain/getIn.js
+++ b/src/structure/plain/getIn.js
@@ -8,6 +8,36 @@ const getInWithPath = (state, first, ...rest) => {
   return rest.length ? getInWithPath(next, ...rest) : next
 }
 
-const getIn = (state, field) => getInWithPath(state, ...toPath(field))
+const getIn = (state, field) => {
+  if (!state) {
+    return state
+  }
+
+  const path = toPath(field)
+  const length = path.length
+
+  if (length > 3) {
+    return getInWithPath(state, ...path)
+  }
+
+  let result = state
+  if (!length || !result) {
+    return undefined
+  }
+
+  result = result[path[0]]
+  if (length === 1 || !result) {
+    return result
+  }
+
+  result = result[path[1]]
+  if (length === 2 || !result) {
+    return result
+  }
+
+  result = result[path[2]]
+
+  return result
+}
 
 export default getIn


### PR DESCRIPTION
`getIn` seems to be the highest low hanging fruit when it comes to performance

Optimized for the most common use-case: path length of 1, 2 or 3 items

On my chrome it shows ~5x improvement

jsPerf is down, so here's a benchmarkJS fiddle:
https://jsfiddle.net/9vqm86eu/1/