### PR TITLE
Fix build:es output by replacing babel-preset es2015 with es2015-no-commonjs

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-  "presets": ["es2015", "react", "stage-2"],
+  "presets": ["es2015-no-commonjs", "react", "stage-2"],
   "env": {
     "development": {
       "plugins": ["lodash", "transform-es2015-modules-commonjs"]

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "babel-plugin-syntax-async-functions": "^6.5.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.8.0",
     "babel-plugin-transform-regenerator": "^6.6.5",
-    "babel-preset-es2015": "^6.13.2",
+    "babel-preset-es2015-no-commonjs": "0.0.2",
     "babel-preset-react": "^6.1.18",
     "babel-preset-stage-2": "^6.1.18",
     "babel-register": "^6.3.13",


### PR DESCRIPTION
Currently the jsnext:main build of redux-form contains CommonJS code instead of ES module code.  
Removing the `transform-es2015-modules-commonjs` babel plugin fixes the issue and outputs the correct format. 