### PR TITLE
isPristine does not differentiate between null and 0

### DIFF
--- a/src/__tests__/isPristine.spec.js
+++ b/src/__tests__/isPristine.spec.js
@@ -72,4 +72,8 @@ describe('isPristine', () => {
     tryBothWays({foo: 7, bar: 9, when: date}, {foo: 7, bar: 9, when: date}, true);
   });
 
+  it('should return false when one value is null the other is 0 (number)', () => {
+    tryBothWays(null, 0, false);
+  });
+
 });

--- a/src/isPristine.js
+++ b/src/isPristine.js
@@ -23,6 +23,8 @@ export default function isPristine(initial, data) {
     }
   } else if (initial || data) { // allow '' to equate to undefined or null
     return initial === data;
+  } else if (initial === null && data === 0 || initial === 0 && data === null) {
+    return false;
   }
   return true;
 }


### PR DESCRIPTION
I have a situation where a number field gets set to `0` with an initial value of `null` and the form and field don't get marked as dirty.

Note that because it's a number field `0` in this case is of type `number` not `string` which `isPristine` doesn't seem to accommodate for.

In the case of `'0'` (ie.. string) `isPristine` behaves as expected already.

If this is the desired behaviour are there any suggestions for a work around?