### PR TITLE
Add missing documentation on `enableReinitialize` in InitializeFromState example docs

### DIFF
--- a/examples/initializeFromState/src/InitializeFromState.md
+++ b/examples/initializeFromState/src/InitializeFromState.md
@@ -10,9 +10,11 @@ reducer. To get those values into your `redux-form`-decorated component, you wil
 `connect()` to the Redux state yourself and map from the data reducer to the `initialValues`
 prop.
 
-You may only initialize a form component _once_ via `initialValues`. If you wish to change the 
-"pristine" values again, you will need to dispatch the `INITIALIZE` action yourself (using the 
-action creator provided by `redux-form`).
+By default, you may only initialize a form component _once_ via `initialValues`. You can also
+provide a `enableReinitialize` prop set to `true` to allow the form the reinitialize every time
+the `initialValues` prop changes. If you wish to change the "pristine" values again, you will 
+need to dispatch the `INITIALIZE` action yourself (using the action creator provided by 
+`redux-form`).
 
 The following example references an external `account` reducer, which simply takes an object of
 values and saves it in the store under `account.data` when you dispatch the `load` action by

--- a/examples/initializeFromState/src/InitializeFromState.md
+++ b/examples/initializeFromState/src/InitializeFromState.md
@@ -15,8 +15,8 @@ methods to reinitialize the form component with new "pristine" values:
 
 1. Pass a `enableReinitialize` prop or `reduxForm()` config parameter set to `true` to allow the
 form the reinitialize with new "pristine" values every time the `initialValues` prop changes. To
-keep dirty form values when reinitialize, you can set `keepDirtyOnReinitialize` to true. By
-default, reinitialize the form replaces all dirty values.
+keep dirty form values when it reinitializes, you can set `keepDirtyOnReinitialize` to true. By
+default, reinitializing the form replaces all dirty values with "pristine" values.
 
 2. Dispatch the `INITIALIZE` action (using the action creator provided by `redux-form`).
 

--- a/examples/initializeFromState/src/InitializeFromState.md
+++ b/examples/initializeFromState/src/InitializeFromState.md
@@ -10,11 +10,12 @@ reducer. To get those values into your `redux-form`-decorated component, you wil
 `connect()` to the Redux state yourself and map from the data reducer to the `initialValues`
 prop.
 
-By default, you may only initialize a form component _once_ via `initialValues`. You can also
-provide a `enableReinitialize` prop set to `true` to allow the form the reinitialize every time
-the `initialValues` prop changes. If you wish to change the "pristine" values again, you will 
-need to dispatch the `INITIALIZE` action yourself (using the action creator provided by 
-`redux-form`).
+By default, you may only initialize a form component _once_ via `initialValues`. You can provide a 
+`enableReinitialize` prop set to `true` to allow the form the reinitialize with new "pristine" 
+values every time the `initialValues` prop changes. To keep dirty form values when reinitialize, 
+you can set `keepDirtyOnReinitialize` to true. By default, reinitialize the form replaces all
+dirty values. You can also manually dispatch the `INITIALIZE` action (using the action creator
+provided by `redux-form`) as another method of reinitialize the form with new "pristine" values.
 
 The following example references an external `account` reducer, which simply takes an object of
 values and saves it in the store under `account.data` when you dispatch the `load` action by

--- a/examples/initializeFromState/src/InitializeFromState.md
+++ b/examples/initializeFromState/src/InitializeFromState.md
@@ -10,12 +10,15 @@ reducer. To get those values into your `redux-form`-decorated component, you wil
 `connect()` to the Redux state yourself and map from the data reducer to the `initialValues`
 prop.
 
-By default, you may only initialize a form component _once_ via `initialValues`. You can provide a 
-`enableReinitialize` prop set to `true` to allow the form the reinitialize with new "pristine" 
-values every time the `initialValues` prop changes. To keep dirty form values when reinitialize, 
-you can set `keepDirtyOnReinitialize` to true. By default, reinitialize the form replaces all
-dirty values. You can also manually dispatch the `INITIALIZE` action (using the action creator
-provided by `redux-form`) as another method of reinitialize the form with new "pristine" values.
+By default, you may only initialize a form component _once_ via `initialValues`. There are two
+methods to reinitialize the form component with new "pristine" values:
+
+1. Pass a `enableReinitialize` prop or `reduxForm()` config parameter set to `true` to allow the
+form the reinitialize with new "pristine" values every time the `initialValues` prop changes. To
+keep dirty form values when reinitialize, you can set `keepDirtyOnReinitialize` to true. By
+default, reinitialize the form replaces all dirty values.
+
+2. Dispatch the `INITIALIZE` action (using the action creator provided by `redux-form`).
 
 The following example references an external `account` reducer, which simply takes an object of
 values and saves it in the store under `account.data` when you dispatch the `load` action by


### PR DESCRIPTION
This issue is mentioned in https://github.com/erikras/redux-form/issues/1648.

Currently, the example documentation refers to the method of dispatching `INITIALIZE` as if it is the only method to reinitialize the form with new pristine values. `enableReinitialize` & `keepDirtyOnReinitialize` are missing from this section.

This change adds documentation about `enableReinitialize` & `keepDirtyOnReinitialize` to the Initialize From State example as another option.