### PR TITLE
Implemented custom meta props. Fixes #1634

### DIFF
--- a/src/__tests__/createFieldProps.spec.js
+++ b/src/__tests__/createFieldProps.spec.js
@@ -107,6 +107,35 @@ const describeCreateFieldProps = (name, structure, expect) => {
       expect(submittingResult.meta.submitting).toBe(true)
     })
 
+    it('should pass along all custom state props', () => {
+      const pristineResult = createFieldProps(getIn, 'foo', {
+        value: 'bar'
+      })
+      expect(pristineResult.meta.customProp).toBe(undefined)
+      const customResult = createFieldProps(getIn, 'foo', {
+        value: 'bar',
+        state: {
+          customProp: 'my-custom-prop'
+        }
+      })
+      expect(customResult.meta.customProp).toBe('my-custom-prop')
+    })
+
+    it('should not override canonical props with custom props', () => {
+      const pristineResult = createFieldProps(getIn, 'foo', {
+        value: 'bar'
+      })
+      expect(pristineResult.meta.customProp).toBe(undefined)
+      const customResult = createFieldProps(getIn, 'foo', {
+        value: 'bar',
+        submitting: true,
+        state: {
+          submitting: false
+        }
+      })
+      expect(customResult.meta.submitting).toBe(true)
+    })
+
     it('should read touched from state', () => {
       const untouchedResult = createFieldProps(getIn, 'foo', {
         value: 'bar',

--- a/src/createFieldProps.js
+++ b/src/createFieldProps.js
@@ -65,6 +65,7 @@ const createFieldProps = (getIn, name,
       value: format ? format(fieldValue) : fieldValue
     }, _value),
     meta: {
+      ...state,
       active: !!(state && getIn(state, 'active')),
       asyncValidating,
       autofilled: !!(state && getIn(state, 'autofilled')),


### PR DESCRIPTION
Ref: https://github.com/erikras/redux-form/issues/1634

This allow creating own meta properties for fields via the reducer:

```js
combineReducers({
    form: form.plugin((state, action) => {
        if (action.type !== 'redux-form/CHANGE') return state;
        return setIn(state, 'fields.' + action.meta.field + '.myCustomProp', true);
    })
});
```

results are passed to the `meta` object:

```jsx
<Field name='foo' component={renderFancy} />

const renderFancy = ({input, meta: {myCustomProp}}) => 
    <input type="text" {...input} style={myCustomProp ? {color: 'red'} : null} />
```