### PR TITLE
isPristine now differentiates between null, 0 and NaN 

### DIFF
--- a/src/__tests__/isPristine.spec.js
+++ b/src/__tests__/isPristine.spec.js
@@ -76,4 +76,16 @@ describe('isPristine', () => {
     tryBothWays(null, 0, false);
   });
 
+  it('should return false when one value is null the other is NaN', () => {
+    tryBothWays(NaN, null, false);
+  });
+
+  it('should return false when one value is 0 the other is NaN', () => {
+    tryBothWays(NaN, 0, false);
+  });
+
+  it('should return true when both values are NaN', () => {
+    expect(isPristine(NaN, NaN)).toBe(true);
+  });
+
 });

--- a/src/isPristine.js
+++ b/src/isPristine.js
@@ -23,8 +23,11 @@ export default function isPristine(initial, data) {
     }
   } else if (initial || data) { // allow '' to equate to undefined or null
     return initial === data;
-  } else if (initial === null && data === 0 || initial === 0 && data === null) {
-    return false;
+  } else if (Number.isNaN(initial) && Number.isNaN(data)) {
+    // Equality for NaN always results in false, thus the special case
+    return true;
+  } else if ((initial === 0 || initial === null || Number.isNaN(initial)) && (data === null || data === 0 || Number.isNaN(data))) {
+    return initial === data;
   }
   return true;
 }


### PR DESCRIPTION
I realise I just submitted #1673 for something very similar just a few days ago but I've found another edge case.

This PR addresses issues where a HTML5 number field is left empty which is fed through as `NaN`.

I could have modified the condition on line 24 of isPristine.js but I felt that it would be easier to read as is.