### PR TITLE
Add meta.touched to FieldArrays

### DIFF
--- a/examples/fieldArrays/src/FieldArraysForm.js
+++ b/examples/fieldArrays/src/FieldArraysForm.js
@@ -12,10 +12,11 @@ const renderField = ({ input, label, type, meta: { touched, error } }) => (
   </div>
 )
 
-const renderMembers = ({ fields }) => (
+const renderMembers = ({ fields, meta: { touched, error } }) => (
   <ul>
     <li>
       <button type="button" onClick={() => fields.push({})}>Add Member</button>
+      {touched && error && <span>{error}</span>}
     </li>
     {fields.map((member, index) =>
       <li key={index}>

--- a/src/ConnectedFieldArray.js
+++ b/src/ConnectedFieldArray.js
@@ -110,6 +110,7 @@ const createConnectedFieldArray = ({
         asyncError: getIn(formState, `asyncErrors.${name}._error`),
         dirty: !pristine,
         pristine,
+        state: getIn(formState, `fields.${name}`),
         submitError: getIn(formState, `submitErrors.${name}._error`),
         submitting,
         syncError,

--- a/src/__tests__/FieldArray.spec.js
+++ b/src/__tests__/FieldArray.spec.js
@@ -104,6 +104,27 @@ const describeFieldArray = (name, structure, combineReducers, expect) => {
       expect(props2.meta.dirty).toBe(true)
     })
 
+    it('should get touched from Redux state', () => {
+      const props1 = testProps({
+        values: {
+          foo: 'bar'
+        }
+      })
+      expect(props1.meta.touched).toBe(false)
+      const props2 = testProps({
+        values: {
+          foo: 'bar'
+        },
+        fields: {
+          foo: {
+            touched: true
+          }
+        }
+      })
+      expect(props2.meta.touched).toBe(true)
+    })
+
+
     it('should provide forEach', () => {
       const props = testProps({
         values: {

--- a/src/createFieldArrayProps.js
+++ b/src/createFieldArrayProps.js
@@ -2,7 +2,7 @@ const createFieldArrayProps = (getIn, name,
   {
     arrayInsert, arrayMove, arrayPop, arrayPush, arrayRemove, arrayRemoveAll, arrayShift,
     arraySplice, arraySwap, arrayUnshift, asyncError, // eslint-disable-line no-unused-vars
-    dirty, length, pristine, submitError,
+    dirty, length, pristine, submitError, state,
     submitFailed, submitting, // eslint-disable-line no-unused-vars
     syncError, value, props, ...rest
   }) => {
@@ -37,6 +37,7 @@ const createFieldArrayProps = (getIn, name,
       invalid: !!error,
       pristine,
       submitting,
+      touched: !!(state && getIn(state, 'touched')),
       valid: !error
     },
     ...props,


### PR DESCRIPTION
With this PR, if you view the `fieldArrays` example and submit before doing anything, it will display the error for not adding any members.

![selection_037](https://cloud.githubusercontent.com/assets/324999/18295244/b615453e-7454-11e6-8f96-0932b4db157a.png)

I can't fix the CSS for this because even when running a local example it links out to http://redux-form.com/6.0.2/bundle.css. 

In fixing this it exposed another bug. If you add any members, then you remove all members you can't get the `.touched` property, so the error never shows up again. Once you add a member `form.fieldArrays.fields.members` is converted from an object to an array. Later when the `TOUCH` action happens it can't add the `.touched` property because it's still an array even after the last member is gone. I spent about an hour tracking this down and trying to figure out how to fix it, but I don't know if I can fix it without potentially breaking other things. 

What do you think the right approach is for fixing that? Some things that seem like the could work:

1. `ARRAY_REMOVE` deletes `form.fieldArrays.fields.members` when the last member is removed.
2. `ARRAY_REMOVE` converts `form.fieldArrays.fields.members` to an object when the last member is removed.
3. `TOUCH` should be smarter and check for the empty array and convert it to `{ touched: true }` when it encounters it.