### PR TITLE
Support for ImmutableJS setIn array paths

### DIFF
--- a/src/structure/immutable/__tests__/setIn.spec.js
+++ b/src/structure/immutable/__tests__/setIn.spec.js
@@ -1,0 +1,121 @@
+import expect from 'expect'
+import { fromJS, Map, List } from 'immutable'
+import setIn from '../setIn'
+
+describe('structure.immutable.setIn', () => {
+  it('should handle undefined', () => {
+    let result = setIn(new Map(), undefined, 'success')
+    expect(result).toEqual('success')
+  })
+  it('should handle dot paths', () => {
+    let result = setIn(new Map(), 'a.b.c', 'success')
+
+    let a = result.get('a')
+    expect(a).toExist('a missing')
+
+    let b = a.get('b')
+    expect(b).toExist('b missing')
+
+    let c = b.get('c')
+    expect(c).toEqual('success')
+  })
+  it('should handle array paths', () => {
+    let result = setIn(new Map(), 'a.b[0]', 'success')
+
+    let a = result.get('a')
+    expect(a).toExist('a missing')
+
+    let b = a.get('b')
+    expect(b)
+      .toExist('b missing')
+      .toBeA(List)
+      .toEqual(fromJS([ 'success' ]))
+  })
+  it('should handle array paths with successive sets', () => {
+    let result = setIn(new Map(), 'a.b[2]', 'success')
+    result = setIn(result, 'a.b[0]', 'success')
+
+    let a = result.get('a')
+    expect(a).toExist('a missing')
+
+    let b = a.get('b')
+    expect(b)
+      .toExist('b missing')
+      .toBeA(List)
+      .toEqual(fromJS([ 'success', undefined, 'success' ]))
+  })
+  it('should handle array paths with existing array', () => {
+    let result = setIn(new Map({
+      a: new Map({
+        b: new List([ 'first' ])
+      })
+    }), 'a.b[1].value', 'success')
+
+    let a = result.get('a')
+    expect(a).toExist('a missing')
+
+    let b = a.get('b')
+    expect(b)
+      .toExist('b missing')
+      .toBeA(List)
+      .toEqual(fromJS([ 'first', { value: 'success' } ]))
+  })
+  it('should handle array paths with existing array with undefined', () => {
+    let result = setIn(new Map({
+      a: new Map({
+        b: new List([ 'first', undefined ])
+      })
+    }), 'a.b[1].value', 'success')
+
+    let a = result.get('a')
+    expect(a).toExist('a missing')
+
+    let b = a.get('b')
+    expect(b)
+      .toExist('b missing')
+      .toBeA(List)
+      .toEqual(fromJS([ 'first', { value: 'success' } ]))
+  })
+  it('should handle multiple array paths', () => {
+    let result = setIn(new Map(), 'a.b[0].c.d[13].e', 'success')
+
+    let a = result.get('a')
+    expect(a).toExist('a missing').toBeA(Map)
+
+    let b = a.get('b')
+    expect(b).toExist('b missing').toBeA(List)
+
+    let b0 = b.get(0)
+    expect(b0).toExist('b[0] missing').toBeA(Map)
+
+    let c = b0.get('c')
+    expect(c).toExist('c missing').toBeA(Map)
+
+    let d = c.get('d')
+    expect(d).toExist('d missing').toBeA(List)
+
+    let d13 = d.get(13)
+    expect(d13).toExist('d[13] missing').toBeA(Map)
+
+    let e = d13.get('e')
+    expect(e).toExist('e missing').toEqual('success')
+  })
+  it('should handle indexer paths', () => {
+    let result = setIn(new Map(), 'a.b[c].d[e]', 'success')
+
+    let a = result.get('a')
+    expect(a).toExist('a missing')
+
+    let b = a.get('b')
+    expect(b).toExist('b missing')
+
+    let c = b.get('c')
+    expect(c).toExist('c missing')
+
+    let d = c.get('d')
+    expect(d).toExist('d missing')
+
+    let e = d.get('e')
+    expect(e).toExist('e missing').toEqual('success')
+  })
+})

--- a/src/structure/immutable/__tests__/setIn.spec.js
+++ b/src/structure/immutable/__tests__/setIn.spec.js
@@ -118,4 +118,148 @@ describe('structure.immutable.setIn', () => {
     let e = d.get('e')
     expect(e).toExist('e missing').toEqual('success')
   })
+  it('should update existing Map', () => {
+    let initial = fromJS({
+      a: {
+        b: { c: 'one' }
+      }
+    })
+
+    let result = setIn(initial, 'a.b.c', 'two')
+    
+    let a = result.get('a')
+    expect(a).toExist('a missing')
+
+    let b = a.get('b')
+    expect(b).toExist('b missing')
+
+    let c = b.get('c')
+    expect(c).toEqual('two')
+  })
+  it('should update existing List', () => {
+    let initial = fromJS({
+      a: {
+        b: [ { c: 'one' } ]
+      }
+    })
+
+    let result = setIn(initial, 'a.b[0].c', 'two')
+    
+    let a = result.get('a')
+    expect(a).toExist('a missing')
+
+    let b = a.get('b')
+    expect(b).toExist('b missing')
+
+    let b0 = b.get(0)
+    expect(b0).toExist()
+
+    let b0c = b0.get('c')
+    expect(b0c).toEqual('two')
+  })
+  it('should not break existing Map', () => {
+    let initial = fromJS({
+      a: {
+        b: { c: 'one' }
+      }
+    })
+
+    let result = setIn(initial, 'a.b.d', 'two')
+    
+    let a = result.get('a')
+    expect(a).toExist('a missing')
+
+    let b = a.get('b')
+    expect(b).toExist('b missing')
+
+    let c = b.get('c')
+    expect(c).toEqual('one')
+
+    let d = b.get('d')
+    expect(d).toEqual('two')
+  })
+  it('should not break existing List', () => {
+    let initial = fromJS({
+      a: {
+        b: [
+          { c: 'one' },
+          { c: 'two' }
+        ]
+      }
+    })
+
+    let result = setIn(initial, 'a.b[0].c', 'changed')
+    
+    let a = result.get('a')
+    expect(a).toExist('a missing')
+
+    let b = a.get('b')
+    expect(b).toExist('b missing')
+
+    let b0 = b.get(0)
+    expect(b0).toExist()
+
+    let b0c = b0.get('c')
+    expect(b0c).toEqual('changed')
+
+    let b1 = b.get(1)
+    expect(b1).toExist()
+
+    let b1c = b1.get('c')
+    expect(b1c).toEqual('two')
+  })
+  it('should add to an existing List', () => {
+    let initial = fromJS({
+      a: {
+        b: [
+          { c: 'one' },
+          { c: 'two' }
+        ]
+      }
+    })
+
+    let result = setIn(initial, 'a.b[2].c', 'three')
+    
+    let a = result.get('a')
+    expect(a).toExist('a missing')
+
+    let b = a.get('b')
+    expect(b).toExist('b missing')
+
+    let b0 = b.get(0)
+    expect(b0).toExist()
+
+    let b0c = b0.get('c')
+    expect(b0c).toEqual('one')
+
+    let b1 = b.get(1)
+    expect(b1).toExist()
+
+    let b1c = b1.get('c')
+    expect(b1c).toEqual('two')
+
+    let b2 = b.get(2)
+    expect(b2).toExist()
+
+    let b2c = b2.get('c')
+    expect(b2c).toEqual('three')
+  })
+  it('should set a value directly on new list', () => {
+    let result = setIn(new Map(), 'a.b[2]', 'three')
+    
+    let a = result.get('a')
+    expect(a).toExist('a missing')
+
+    let b = a.get('b')
+    expect(b).toExist('b missing')
+
+    let b0 = b.get(0)
+    expect(b0).toEqual(undefined)
+
+    let b1 = b.get(1)
+    expect(b1).toEqual(undefined)
+
+    let b2 = b.get(2)
+    expect(b2).toEqual('three')
+  })
 })

--- a/src/structure/immutable/__tests__/setIn.spec.js
+++ b/src/structure/immutable/__tests__/setIn.spec.js
@@ -262,4 +262,32 @@ describe('structure.immutable.setIn', () => {
     let b2 = b.get(2)
     expect(b2).toEqual('three')
   })
+  it('should add to an existing List item', function () {
+    let initial = fromJS({
+      a: {
+        b: [
+          {
+            c: '123'
+          }
+        ]
+      }
+    })
+
+    let result = setIn(initial, 'a.b[0].d', '12')
+
+    let a = result.get('a')
+    expect(a).toExist('a missing')
+
+    let b = a.get('b')
+    expect(b).toExist('b missing')
+
+    let b0 = b.get(0)
+    expect(b0).toExist()
+
+    let b0d = b0.get('d')
+    expect(b0d).toEqual('12')
+
+    let b0c = b0.get('c')
+    expect(b0c).toEqual('123')
+  })
 })

--- a/src/structure/immutable/index.js
+++ b/src/structure/immutable/index.js
@@ -1,6 +1,7 @@
 import { Map, Iterable, List, fromJS } from 'immutable'
 import { toPath } from 'lodash'
 import deepEqual from './deepEqual'
+import setIn from './setIn'
 import splice from './splice'
 import plainGetIn from '../plain/getIn'
 
@@ -9,7 +10,7 @@ const structure = {
   emptyList: List(),
   getIn: (state, field) =>
     Map.isMap(state) || List.isList(state) ? state.getIn(toPath(field)) : plainGetIn(state, field),
-  setIn: (state, field, value) => state.setIn(toPath(field), value),
+  setIn,
   deepEqual,
   deleteIn: (state, field) => state.deleteIn(toPath(field)),
   fromJS: jsValue => fromJS(jsValue, (key, value) =>

--- a/src/structure/immutable/setIn.js
+++ b/src/structure/immutable/setIn.js
@@ -1,0 +1,54 @@
+import { List, Map } from 'immutable'
+import { toPath } from 'lodash'
+
+const arrayPattern = /\[(\d+)\]/
+
+const undefinedArrayMerge = (previous, next) =>  
+  next !== undefined 
+    ? next 
+    : previous
+
+const mergeLists = (original, value) => 
+  original && List.isList(original)
+    ? original.mergeWith(undefinedArrayMerge, value)
+    : value
+
+/*
+ * ImmutableJS' setIn function doesn't support array (List) creation
+ * so we must pre-insert all arrays in the path ahead of time.
+ * 
+ * Additionally we must also pre-set a dummy Map at the location
+ * of an array index if there's parts that come afterwards because 
+ * the setIn function uses `{}` to mark an unset value instead of 
+ * undefined (which is the case for list / arrays).
+ */
+export default function setIn(state, field, value) {
+  if (!field || typeof field !== 'string' || !arrayPattern.test(field)) {
+    return state.setIn(toPath(field), value)
+  }
+
+  return state.withMutations(mutable => {
+    let arraySafePath = field.split('.')
+    let pathSoFar = null
+
+    for (let partIndex in arraySafePath) {
+      let part = arraySafePath[partIndex]
+      let match = arrayPattern.exec(part)
+
+      pathSoFar = pathSoFar === null ? part : `${pathSoFar}.${part}`
+
+      if (!match) continue
+ 
+      let arr = []
+      arr[parseInt(match[1])] = partIndex + 1 >= arraySafePath.length 
+        ? new Map() 
+        : undefined
+
+      mutable = mutable.updateIn(
+        toPath(pathSoFar).slice(0, -1), 
+        value => mergeLists(value, new List(arr)))
+    }
+
+    return mutable.setIn(toPath(field), value)
+  })
+}

--- a/src/structure/immutable/setIn.js
+++ b/src/structure/immutable/setIn.js
@@ -10,7 +10,7 @@ const undefinedArrayMerge = (previous, next) =>
 
 const mergeLists = (original, value) => 
   original && List.isList(original)
-    ? original.mergeWith(undefinedArrayMerge, value)
+    ? original.mergeDeepWith(undefinedArrayMerge, value)
     : value
 
 /*


### PR DESCRIPTION
## Problem

ImmutableJS's `setIn` (and thereby `updateIn` / `deleteIn` / etc...) do not seem architected to work with a mixture of `Map` and `List` objects. The call assumes that an "unset" value can only be one thing, and only has one resolution path for when that value is empty. (Namely, add it as an empty map) [See Immutable-js Source](https://github.com/facebook/immutable-js/blob/master/src/Map.js#L802)

This leads to the issue found in #1574 where we get the infamous error:

    Uncaught TypeError: list.splice is not a function

When using immutable-js with `FieldArray`. The focus / blur events are calling `setIn` on `fields.fieldName[0].touched` etc... which causes the `fieldName` part of the tree to be instantiated as `Map` instead of a `List`.

Actual | Expected
------------ | -------------
```{ "fields": { "fieldName": { "0": { "touched": true } } } }``` | ```{ "fields": { "fieldName": [ { "touched": true } ] } }```

## Solution

We need to pre-seed a mixed type path like `fields.thing[0].visisted` with empty `List` objects at each array breakout point. This allows immutable to simply update the existing `List` with a call to `set()` instead of trying to instantiate it as a `Map`

I have broken the `structure/immutable`'s `setIn` method out [into it's own file](https://github.com/Reanmachine/redux-form/blob/reanmachine/immutable-array-setIn/src/structure/immutable/setIn.js) to allow us to take some liberties with it.

## Extra

Along with this PR I've included regression tests for the `setIn` behaviors I fixed as well as some tests for some of the expected vanilla `setIn` behavior the library depends on.
