### PR TITLE
Reuse connected ConnectedField, ConnectedFields and ConnectedFieldArray

### DIFF
--- a/src/ConnectedField.js
+++ b/src/ConnectedField.js
@@ -3,18 +3,13 @@ import { connect } from 'react-redux'
 import createFieldProps from './createFieldProps'
 import plain from './structure/plain'
 
-const createConnectedField = ({
-  asyncValidate,
-  blur,
-  change,
-  focus,
-  getFormState,
-  initialValues
-}, { deepEqual, getIn }, name) => {
+const propsToNotUpdateFor = [
+  '_reduxForm'
+]
 
-  const propInitialValue = initialValues && getIn(initialValues, name)
+const createConnectedField = ({ deepEqual, getIn }) => {
 
-  const getSyncError = syncErrors => {
+  const getSyncError = (syncErrors, name) => {
     const error = plain.getIn(syncErrors, name)
     // Because the error for this field might not be at a level in the error structure where
     // it can be set directly, it might need to be unwrapped from the _error property
@@ -23,7 +18,11 @@ const createConnectedField = ({
 
   class ConnectedField extends Component {
     shouldComponentUpdate(nextProps) {
-      return !deepEqual(this.props, nextProps)
+      const nextPropsKeys = Object.keys(nextProps)
+      const thisPropsKeys = Object.keys(this.props)
+      return nextPropsKeys.length == thisPropsKeys.length && nextPropsKeys.some(prop => {
+        return !~propsToNotUpdateFor.indexOf(prop) && !deepEqual(this.props[ prop ], nextProps[ prop ])
+      })
     }
 
     isPristine() {
@@ -39,11 +38,13 @@ const createConnectedField = ({
     }
 
     render() {
-      const { component, withRef, ...rest } = this.props
+      const { component, withRef, name, _reduxForm, ...rest } = this.props
+      const { asyncValidate, blur, change, focus } = _reduxForm
       const { custom, ...props } = createFieldProps(getIn,
         name,
         {
           ...rest,
+          name,
           blur,
           change,
           focus
@@ -70,12 +71,13 @@ const createConnectedField = ({
 
   const connector = connect(
     (state, ownProps) => {
+      const { name, _reduxForm: { initialValues, getFormState } } = ownProps
       const formState = getFormState(state)
       const initialState = getIn(formState, `initial.${name}`)
-      const initial = initialState === undefined ? propInitialValue : initialState
+      const initial = initialState !== undefined ? initialState : (initialValues && getIn(initialValues, name))
       const value = getIn(formState, `values.${name}`)
       const submitting = getIn(formState, 'submitting')
-      const syncError = getSyncError(getIn(formState, 'syncErrors'))
+      const syncError = getSyncError(getIn(formState, 'syncErrors'), name)
       const pristine = value === initial
       return {
         asyncError: getIn(formState, `asyncErrors.${name}`),

--- a/src/ConnectedFieldArray.js
+++ b/src/ConnectedFieldArray.js
@@ -1,35 +1,18 @@
 import { Component, PropTypes, createElement } from 'react'
 import { connect } from 'react-redux'
+import { bindActionCreators } from 'redux'
 import createFieldArrayProps from './createFieldArrayProps'
 import { mapValues } from 'lodash'
 import plain from './structure/plain'
 
 const propsToNotUpdateFor = [
+  '_reduxForm',
   'value'
 ]
 
-const createConnectedFieldArray = ({
-  arrayInsert,
-  arrayMove,
-  arrayPop,
-  arrayPush,
-  arrayRemove,
-  arrayRemoveAll,
-  arrayShift,
-  arraySplice,
-  arraySwap,
-  arrayUnshift,
-  asyncValidate,
-  blur,
-  change,
-  focus,
-  getFormState,
-  initialValues
-}, { deepEqual, getIn, size }, name) => {
+const createConnectedFieldArray = ({ deepEqual, getIn, size }) => {
 
-  const propInitialValue = initialValues && getIn(initialValues, name)
-
-  const getSyncError = syncErrors => {
+  const getSyncError = (syncErrors, name) => {
     // For an array, the error can _ONLY_ be under _error.
     // This is why this getSyncError is not the same as the
     // one in Field.
@@ -38,7 +21,9 @@ const createConnectedFieldArray = ({
 
   class ConnectedFieldArray extends Component {
     shouldComponentUpdate(nextProps) {
-      return Object.keys(nextProps).some(prop => {
+      const nextPropsKeys = Object.keys(nextProps)
+      const thisPropsKeys = Object.keys(this.props)
+      return nextPropsKeys.length == thisPropsKeys.length && nextPropsKeys.some(prop => {
         // useful to debug rerenders
         // if (!plain.deepEqual(this.props[ prop ], nextProps[ prop ])) {
         //   console.info(prop, 'changed', this.props[ prop ], '==>', nextProps[ prop ])
@@ -64,7 +49,8 @@ const createConnectedFieldArray = ({
     }
 
     render() {
-      const { component, withRef, ...rest } = this.props
+      /*eslint no-unused-vars: ["error", { "varsIgnorePattern": "^_reduxForm$" }]*/
+      const { component, withRef, name, _reduxForm, ...rest } = this.props
       const props = createFieldArrayProps(
         getIn,
         name,
@@ -86,25 +72,14 @@ const createConnectedFieldArray = ({
     _reduxForm: PropTypes.object
   }
 
-  const actions = mapValues({
-    arrayInsert,
-    arrayMove,
-    arrayPop,
-    arrayPush,
-    arrayRemove,
-    arrayRemoveAll,
-    arrayShift,
-    arraySplice,
-    arraySwap,
-    arrayUnshift
-  }, actionCreator => actionCreator.bind(null, name))
   const connector = connect(
-    state => {
+    (state, ownProps) => {
+      const { name, _reduxForm: { initialValues, getFormState } } = ownProps
       const formState = getFormState(state)
-      const initial = getIn(formState, `initial.${name}`) || propInitialValue
+      const initial = getIn(formState, `initial.${name}`) || (initialValues && getIn(initialValues, name))
       const value = getIn(formState, `values.${name}`)
       const submitting = getIn(formState, 'submitting')
-      const syncError = getSyncError(getIn(formState, 'syncErrors'))
+      const syncError = getSyncError(getIn(formState, 'syncErrors'), name)
       const pristine = deepEqual(value, initial)
       return {
         asyncError: getIn(formState, `asyncErrors.${name}._error`),
@@ -117,7 +92,33 @@ const createConnectedFieldArray = ({
         length: size(value)
       }
     },
-    actions,
+    (dispatch, ownProps) => {
+      const { name, _reduxForm } = ownProps
+      const {
+        arrayInsert,
+        arrayMove,
+        arrayPop,
+        arrayPush,
+        arrayRemove,
+        arrayRemoveAll,
+        arrayShift,
+        arraySplice,
+        arraySwap,
+        arrayUnshift
+      } = _reduxForm
+      return mapValues({
+        arrayInsert,
+        arrayMove,
+        arrayPop,
+        arrayPush,
+        arrayRemove,
+        arrayRemoveAll,
+        arrayShift,
+        arraySplice,
+        arraySwap,
+        arrayUnshift
+      }, actionCreator => bindActionCreators(actionCreator.bind(null, name), dispatch))
+    },
     undefined,
     { withRef: true }
   )

--- a/src/Field.js
+++ b/src/Field.js
@@ -6,16 +6,18 @@ import shallowCompare from './util/shallowCompare'
 
 const createField = ({ deepEqual, getIn, setIn }) => {
 
+  const ConnectedField = createConnectedField({
+    deepEqual,
+    getIn
+  })
+
   class Field extends Component {
     constructor(props, context) {
       super(props, context)
       if (!context._reduxForm) {
         throw new Error('Field must be inside a component decorated with reduxForm()')
       }
-      this.ConnectedField = createConnectedField(context._reduxForm, {
-        deepEqual,
-        getIn
-      }, props.name)
+
       this.normalize = this.normalize.bind(this)
     }
 
@@ -29,9 +31,6 @@ const createField = ({ deepEqual, getIn, setIn }) => {
 
     componentWillReceiveProps(nextProps) {
       if (this.props.name !== nextProps.name) {
-        // name changed, regenerate connected field
-        this.ConnectedField =
-          createConnectedField(this.context._reduxForm, { deepEqual, getIn }, nextProps.name)
         // unregister old name
         this.context._reduxForm.unregister(this.props.name)
         // register new name
@@ -83,9 +82,10 @@ const createField = ({ deepEqual, getIn, setIn }) => {
     }
 
     render() {
-      return createElement(this.ConnectedField, {
+      return createElement(ConnectedField, {
         ...this.props,
         normalize: this.normalize,
+        _reduxForm: this.context._reduxForm,
         ref: 'connected'
       })
     }

--- a/src/FieldArray.js
+++ b/src/FieldArray.js
@@ -5,14 +5,14 @@ import shallowCompare from './util/shallowCompare'
 
 const createFieldArray = ({ deepEqual, getIn, size }) => {
 
+  const ConnectedFieldArray = createConnectedFieldArray({ deepEqual, getIn, size })
+
   class FieldArray extends Component {
     constructor(props, context) {
       super(props, context)
       if (!context._reduxForm) {
         throw new Error('FieldArray must be inside a component decorated with reduxForm()')
       }
-      this.ConnectedFieldArray =
-        createConnectedFieldArray(context._reduxForm, { deepEqual, getIn, size }, props.name)
     }
 
     shouldComponentUpdate(nextProps, nextState) {
@@ -25,13 +25,10 @@ const createFieldArray = ({ deepEqual, getIn, size }) => {
 
     componentWillReceiveProps(nextProps) {
       if (this.props.name !== nextProps.name) {
-        // name changed, regenerate connected field
-        this.ConnectedFieldArray =
-          createConnectedFieldArray(this.context._reduxForm, {
-            deepEqual,
-            getIn,
-            size
-          }, nextProps.name)
+        // unregister old name
+        this.context._reduxForm.unregister(this.props.name)
+        // register new name
+        this.context._reduxForm.register(nextProps.name, 'FieldArray')
       }
     }
 
@@ -63,9 +60,10 @@ const createFieldArray = ({ deepEqual, getIn, size }) => {
     }
 
     render() {
-      return createElement(this.ConnectedFieldArray, {
+      return createElement(ConnectedFieldArray, {
         ...this.props,
         syncError: this.syncError,
+        _reduxForm: this.context._reduxForm,
         ref: 'connected'
       })
     }

--- a/src/Fields.js
+++ b/src/Fields.js
@@ -15,16 +15,17 @@ const validateNameProp = prop => {
 
 const createFields = ({ deepEqual, getIn }) => {
 
+  const ConnectedFields = createConnectedFields({
+    deepEqual,
+    getIn
+  })
+  
   class Fields extends Component {
     constructor(props, context) {
       super(props, context)
       if (!context._reduxForm) {
         throw new Error('Fields must be inside a component decorated with reduxForm()')
       }
-      this.ConnectedFields = createConnectedFields(context._reduxForm, {
-        deepEqual,
-        getIn
-      }, this.names)
     }
 
     shouldComponentUpdate(nextProps, nextState) {
@@ -42,9 +43,11 @@ const createFields = ({ deepEqual, getIn }) => {
 
     componentWillReceiveProps(nextProps) {
       if (!plain.deepEqual(this.props.names, nextProps.names)) {
-        // names changed, regenerate connected field
-        this.ConnectedFields =
-          createConnectedFields(this.context._reduxForm, { deepEqual, getIn }, nextProps.names)
+        const { register, unregister } = this.context._reduxForm
+        // unregister old name
+        this.props.names.forEach(unregister)
+        // register new name
+        nextProps.names.forEach(name => register(name, 'Field'))
       }
     }
 
@@ -76,8 +79,9 @@ const createFields = ({ deepEqual, getIn }) => {
     }
 
     render() {
-      return createElement(this.ConnectedFields, {
+      return createElement(ConnectedFields, {
         ...this.props,
+        _reduxForm: this.context._reduxForm,
         ref: 'connected'
       })
     }


### PR DESCRIPTION
Redux `connect()` returns a new class. Currently, each `ConnectedField`, `ConnectedFields` and `ConnectedFieldArray` is connected to redux, thus creating many classes. This change connects `ConnectedField`, `ConnectedFields` and `ConnectedFieldArray` only once.

In a field array, if we would like to preserve state of our component, we need to use a key that identifies the element, instead of array index. However, doing so, `Field`, `Fields` and `FieldArray` detects that it is now bound to a new field name and discards the old connected class and `connect` again. React sees that the class is different, thus discards the old virtual DOM, along with the `component` and its state.

By using `mapStateToProps(state, ownProps)` and `mapDispatchToProps(dispatch, ownProps)`, we can [dynamically map according to the current ownProps.name or ownProps.names](https://github.com/reactjs/react-redux/issues/265#issuecomment-174344345), thus `ConnectedField`, `ConnectedFields` and `ConnectedFieldArray` only needs to be connected once. React will see the same class and reuse the virtual DOM, preserving our `component` and its state.