### PR TITLE
Option to keep submit errors on change

### DIFF
--- a/docs/api/ReduxForm.md
+++ b/docs/api/ReduxForm.md
@@ -192,6 +192,10 @@ form has triggered it, respectively.
 
 > marks fields as `touched` when the change action is fired. Defaults to `false`.
 
+#### `clearErrorsOnChange : boolean` [optional]
+
+> removes existing submit errors from the field when the change action is fired. Defaults to `true`.
+
 #### `validate : (values:Object, props:Object) => errors:Object` [optional]
 
 > a synchronous validation function that takes the form values and props passed into your component.

--- a/docs/api/ReduxForm.md
+++ b/docs/api/ReduxForm.md
@@ -192,9 +192,9 @@ form has triggered it, respectively.
 
 > marks fields as `touched` when the change action is fired. Defaults to `false`.
 
-#### `clearErrorsOnChange : boolean` [optional]
+#### `persistentSubmitErrors : boolean` [optional]
 
-> removes existing submit errors from the field when the change action is fired. Defaults to `true`.
+> do not remove submit errors when the change action is fired. Defaults to `false`.
 
 #### `validate : (values:Object, props:Object) => errors:Object` [optional]
 

--- a/src/__tests__/actions.spec.js
+++ b/src/__tests__/actions.spec.js
@@ -282,7 +282,7 @@ describe('actions', () => {
           form: 'myForm',
           field: 'myField',
           touch: false,
-          clearErrors: true
+          persistentSubmitErrors: true
         },
         payload: 'bar'
       })
@@ -294,7 +294,7 @@ describe('actions', () => {
           form: 'myForm',
           field: 'myField',
           touch: true,
-          clearErrors: false
+          persistentSubmitErrors: false
         },
         payload: 7
       })

--- a/src/__tests__/actions.spec.js
+++ b/src/__tests__/actions.spec.js
@@ -275,24 +275,26 @@ describe('actions', () => {
   })
 
   it('should create change action', () => {
-    expect(change('myForm', 'myField', 'bar', false))
+    expect(change('myForm', 'myField', 'bar', false, true))
       .toEqual({
         type: CHANGE,
         meta: {
           form: 'myForm',
           field: 'myField',
-          touch: false
+          touch: false,
+          clearErrors: true
         },
         payload: 'bar'
       })
       .toPass(isFSA)
-    expect(change('myForm', 'myField', 7, true))
+    expect(change('myForm', 'myField', 7, true, false))
       .toEqual({
         type: CHANGE,
         meta: {
           form: 'myForm',
           field: 'myField',
-          touch: true
+          touch: true,
+          clearErrors: false
         },
         payload: 7
       })

--- a/src/__tests__/handleSubmit.spec.js
+++ b/src/__tests__/handleSubmit.spec.js
@@ -333,4 +333,20 @@ describe('handleSubmit', () => {
         expect(setSubmitSucceeded).toNotHaveBeenCalled()
       })
   })
+
+  it('should submit when there are old submit errors and persistentSubmitErrors is enabled', () => {
+    const values = { foo: 'bar', baz: 42 }
+    const submit = createSpy().andReturn(69)
+    const startSubmit = createSpy()
+    const stopSubmit = createSpy()
+    const touch = createSpy()
+    const setSubmitFailed = createSpy()
+    const setSubmitSucceeded = createSpy()
+    const asyncValidate = createSpy()
+    const props = { startSubmit, stopSubmit, touch, setSubmitFailed, setSubmitSucceeded, values, persistentSubmitErrors: true }
+
+    handleSubmit(submit, props, true, asyncValidate, [ 'foo', 'baz' ])
+
+    expect(submit).toHaveBeenCalled()
+  })
 })

--- a/src/__tests__/reducer.change.spec.js
+++ b/src/__tests__/reducer.change.spec.js
@@ -201,12 +201,40 @@ const describeChange = (reducer, expect, { fromJS }) => () => {
         },
         error: 'some global error'
       }
-    }), change('foo', 'myField', 'different', false))
+    }), change('foo', 'myField', 'different', false, true))
     expect(state)
       .toEqualMap({
         foo: {
           values: {
             myField: 'different'
+          }
+        }
+      })
+  })
+
+  it('should set value on change and NOT remove field-level submit errors', () => {
+    const state = reducer(fromJS({
+      foo: {
+        values: {
+          myField: 'initial'
+        },
+        asyncErrors: {
+          myField: 'async error'
+        },
+        submitErrors: {
+          myField: 'submit error'
+        },
+        error: 'some global error'
+      }
+    }), change('foo', 'myField', 'different', false, false))
+    expect(state)
+      .toEqualMap({
+        foo: {
+          values: {
+            myField: 'different'
+          },
+          submitErrors: {
+            myField: 'submit error'
           }
         }
       })

--- a/src/__tests__/reducer.change.spec.js
+++ b/src/__tests__/reducer.change.spec.js
@@ -201,7 +201,7 @@ const describeChange = (reducer, expect, { fromJS }) => () => {
         },
         error: 'some global error'
       }
-    }), change('foo', 'myField', 'different', false, true))
+    }), change('foo', 'myField', 'different', false))
     expect(state)
       .toEqualMap({
         foo: {
@@ -212,7 +212,7 @@ const describeChange = (reducer, expect, { fromJS }) => () => {
       })
   })
 
-  it('should NOT remove field-level submit errors and global errors if clearErrorsOnChange is disabled', () => {
+  it('should NOT remove field-level submit errors and global errors if persistentSubmitErrors is enabled', () => {
     const state = reducer(fromJS({
       foo: {
         values: {
@@ -226,7 +226,7 @@ const describeChange = (reducer, expect, { fromJS }) => () => {
         },
         error: 'some global error'
       }
-    }), change('foo', 'myField', 'different', false, false))
+    }), change('foo', 'myField', 'different', false, true))
     expect(state)
       .toEqualMap({
         foo: {

--- a/src/__tests__/reducer.change.spec.js
+++ b/src/__tests__/reducer.change.spec.js
@@ -212,14 +212,14 @@ const describeChange = (reducer, expect, { fromJS }) => () => {
       })
   })
 
-  it('should set value on change and NOT remove field-level submit errors', () => {
+  it('should NOT remove field-level submit errors and global errors if clearErrorsOnChange is disabled', () => {
     const state = reducer(fromJS({
       foo: {
         values: {
           myField: 'initial'
         },
         asyncErrors: {
-          myField: 'async error'
+          myField: 'async error' // only this will be removed
         },
         submitErrors: {
           myField: 'submit error'
@@ -235,7 +235,8 @@ const describeChange = (reducer, expect, { fromJS }) => () => {
           },
           submitErrors: {
             myField: 'submit error'
-          }
+          },
+          error: 'some global error'
         }
       })
   })

--- a/src/__tests__/reducer.stopSubmit.spec.js
+++ b/src/__tests__/reducer.stopSubmit.spec.js
@@ -270,7 +270,7 @@ const describeStopSubmit = (reducer, expect, { fromJS }) => () => {
         },
         submitting: true
       }
-    }), stopSubmit('foo', {_error: 'some global error'}))
+    }), stopSubmit('foo', { _error: 'some global error' }))
     expect(state)
       .toEqualMap({
         foo: {
@@ -333,7 +333,7 @@ const describeStopSubmit = (reducer, expect, { fromJS }) => () => {
         submitting: true,
         error: 'some global error'
       }
-    }), stopSubmit('foo', {myField: 'some submit error'}))
+    }), stopSubmit('foo', { myField: 'some submit error' }))
     expect(state)
       .toEqualMap({
         foo: {

--- a/src/__tests__/reducer.stopSubmit.spec.js
+++ b/src/__tests__/reducer.stopSubmit.spec.js
@@ -202,7 +202,7 @@ const describeStopSubmit = (reducer, expect, { fromJS }) => () => {
       })
   })
 
-  it('should unset field submit errors on stopSubmit', () => {
+  it('should unset field submit errors on stopSubmit with no errors', () => {
     const state = reducer(fromJS({
       foo: {
         values: {
@@ -254,7 +254,41 @@ const describeStopSubmit = (reducer, expect, { fromJS }) => () => {
       })
   })
 
-  it('should unset global errors on stopSubmit', () => {
+  it('should unset field submit errors on stopSubmit with global errors', () => {
+    const state = reducer(fromJS({
+      foo: {
+        values: {
+          myField: 'myValue'
+        },
+        submitErrors: {
+          myField: 'some submit error'
+        },
+        fields: {
+          myField: {
+            touched: true
+          }
+        },
+        submitting: true
+      }
+    }), stopSubmit('foo', {_error: 'some global error'}))
+    expect(state)
+      .toEqualMap({
+        foo: {
+          values: {
+            myField: 'myValue'
+          },
+          fields: {
+            myField: {
+              touched: true
+            }
+          },
+          error: 'some global error',
+          submitFailed: true
+        }
+      })
+  })
+
+  it('should unset global errors on stopSubmit with no errors', () => {
     const state = reducer(fromJS({
       foo: {
         values: {
@@ -281,6 +315,40 @@ const describeStopSubmit = (reducer, expect, { fromJS }) => () => {
             }
           },
           submitSucceeded: true
+        }
+      })
+  })
+
+  it('should unset global errors on stopSubmit with field errors', () => {
+    const state = reducer(fromJS({
+      foo: {
+        values: {
+          myField: 'myValue'
+        },
+        fields: {
+          myField: {
+            touched: true
+          }
+        },
+        submitting: true,
+        error: 'some global error'
+      }
+    }), stopSubmit('foo', {myField: 'some submit error'}))
+    expect(state)
+      .toEqualMap({
+        foo: {
+          values: {
+            myField: 'myValue'
+          },
+          submitErrors: {
+            myField: 'some submit error'
+          },
+          fields: {
+            myField: {
+              touched: true
+            }
+          },
+          submitFailed: true
         }
       })
   })

--- a/src/actions.js
+++ b/src/actions.js
@@ -56,8 +56,8 @@ export const autofill = (form, field, value) =>
 export const blur = (form, field, value, touch) =>
   ({ type: BLUR, meta: { form, field, touch }, payload: value })
 
-export const change = (form, field, value, touch) =>
-  ({ type: CHANGE, meta: { form, field, touch }, payload: value })
+export const change = (form, field, value, touch, clearErrors) =>
+  ({ type: CHANGE, meta: { form, field, touch, clearErrors }, payload: value })
 
 export const destroy = (form) =>
   ({ type: DESTROY, meta: { form } })

--- a/src/actions.js
+++ b/src/actions.js
@@ -56,8 +56,8 @@ export const autofill = (form, field, value) =>
 export const blur = (form, field, value, touch) =>
   ({ type: BLUR, meta: { form, field, touch }, payload: value })
 
-export const change = (form, field, value, touch, clearErrors) =>
-  ({ type: CHANGE, meta: { form, field, touch, clearErrors }, payload: value })
+export const change = (form, field, value, touch, persistentSubmitErrors) =>
+  ({ type: CHANGE, meta: { form, field, touch, persistentSubmitErrors }, payload: value })
 
 export const destroy = (form) =>
   ({ type: DESTROY, meta: { form } })

--- a/src/handleSubmit.js
+++ b/src/handleSubmit.js
@@ -4,12 +4,17 @@ import SubmissionError from './SubmissionError'
 const handleSubmit = (submit, props, valid, asyncValidate, fields) => {
   const {
     dispatch, onSubmitFail, onSubmitSuccess, startSubmit, stopSubmit, setSubmitFailed,
-    setSubmitSucceeded, syncErrors, touch, values
+    setSubmitSucceeded, syncErrors, touch, values, persistentSubmitErrors
   } = props
 
   touch(...fields) // mark all fields as touched
 
-  if (valid) {
+  // XXX: Always submitting when persistentSubmitErrors is enabled ignores sync errors. 
+  // It would be better to check whether the form as any other errors except submit errors.
+  // This would either require changing the meaning of `valid` (maybe breaking change),
+  // having a more complex conditional in here, or executing sync validation in here
+  // the same way as async validation is executed.
+  if (valid || persistentSubmitErrors) {
     const doSubmit = () => {
       let result
       try {

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -146,7 +146,7 @@ const createReducer = structure => {
       }
       return result
     },
-    [CHANGE](state, { meta: { field, touch, clearErrors }, payload }) {
+    [CHANGE](state, { meta: { field, touch, persistentSubmitErrors }, payload }) {
       let result = state
       const initial = getIn(result, `initial.${field}`)
       if (initial === undefined && payload === '') {
@@ -155,11 +155,11 @@ const createReducer = structure => {
         result = setIn(result, `values.${field}`, payload)
       }
       result = deleteInWithCleanUp(result, `asyncErrors.${field}`)
-      if (clearErrors) {
+      if (!persistentSubmitErrors) {
         result = deleteInWithCleanUp(result, `submitErrors.${field}`)
       }
       result = deleteInWithCleanUp(result, `fields.${field}.autofilled`)
-      if (clearErrors) {
+      if (!persistentSubmitErrors) {
         result = deleteInWithCleanUp(result, 'error')
       }
       if (touch) {

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -159,7 +159,9 @@ const createReducer = structure => {
         result = deleteInWithCleanUp(result, `submitErrors.${field}`)
       }
       result = deleteInWithCleanUp(result, `fields.${field}.autofilled`)
-      result = deleteInWithCleanUp(result, 'error')
+      if (clearErrors) {
+        result = deleteInWithCleanUp(result, 'error')
+      }
       if (touch) {
         result = setIn(result, `fields.${field}.touched`, true)
         result = setIn(result, 'anyTouched', true)

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -273,6 +273,8 @@ const createReducer = structure => {
         const { _error, ...fieldErrors } = payload
         if (_error) {
           result = setIn(result, 'error', _error)
+        } else {
+          result = deleteIn(result, 'error')
         }
         if (Object.keys(fieldErrors).length) {
           result = setIn(result, 'submitErrors', fromJS(fieldErrors))

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -146,7 +146,7 @@ const createReducer = structure => {
       }
       return result
     },
-    [CHANGE](state, { meta: { field, touch }, payload }) {
+    [CHANGE](state, { meta: { field, touch, clearErrors }, payload }) {
       let result = state
       const initial = getIn(result, `initial.${field}`)
       if (initial === undefined && payload === '') {
@@ -155,7 +155,9 @@ const createReducer = structure => {
         result = setIn(result, `values.${field}`, payload)
       }
       result = deleteInWithCleanUp(result, `asyncErrors.${field}`)
-      result = deleteInWithCleanUp(result, `submitErrors.${field}`)
+      if (clearErrors) {
+        result = deleteInWithCleanUp(result, `submitErrors.${field}`)
+      }
       result = deleteInWithCleanUp(result, `fields.${field}.autofilled`)
       result = deleteInWithCleanUp(result, 'error')
       if (touch) {

--- a/src/reduxForm.js
+++ b/src/reduxForm.js
@@ -80,7 +80,7 @@ const createReduxForm =
       const config = {
         touchOnBlur: true,
         touchOnChange: false,
-        clearErrorsOnChange: true,
+        persistentSubmitErrors: false,
         destroyOnUnmount: true,
         shouldAsyncValidate: defaultShouldAsyncValidate,
         enableReinitialize: false,
@@ -336,7 +336,7 @@ const createReduxForm =
               touch,
               touchOnBlur,
               touchOnChange,
-              clearErrorsOnChange,
+              persistentSubmitErrors,
               syncErrors,
               unregisterField,
               untouch,
@@ -397,7 +397,7 @@ const createReduxForm =
           validate: PropTypes.func,
           touchOnBlur: PropTypes.bool,
           touchOnChange: PropTypes.bool,
-          clearErrorsOnChange: PropTypes.bool, 
+          persistentSubmitErrors: PropTypes.bool, 
           registeredFields: PropTypes.any
         }
 
@@ -443,7 +443,7 @@ const createReduxForm =
             const boundFormACs = mapValues(formActions, bindForm)
             const boundArrayACs = mapValues(arrayActions, bindForm)
             const boundBlur = (field, value) => blur(initialProps.form, field, value, !!initialProps.touchOnBlur)
-            const boundChange = (field, value) => change(initialProps.form, field, value, !!initialProps.touchOnChange, !!initialProps.clearErrorsOnChange)
+            const boundChange = (field, value) => change(initialProps.form, field, value, !!initialProps.touchOnChange, !!initialProps.persistentSubmitErrors)
             const boundFocus = bindForm(focus)
 
             // Wrap action creators with `dispatch`

--- a/src/reduxForm.js
+++ b/src/reduxForm.js
@@ -80,6 +80,7 @@ const createReduxForm =
       const config = {
         touchOnBlur: true,
         touchOnChange: false,
+        clearErrorsOnChange: true,
         destroyOnUnmount: true,
         shouldAsyncValidate: defaultShouldAsyncValidate,
         enableReinitialize: false,
@@ -335,6 +336,7 @@ const createReduxForm =
               touch,
               touchOnBlur,
               touchOnChange,
+              clearErrorsOnChange,
               syncErrors,
               unregisterField,
               untouch,
@@ -395,6 +397,7 @@ const createReduxForm =
           validate: PropTypes.func,
           touchOnBlur: PropTypes.bool,
           touchOnChange: PropTypes.bool,
+          clearErrorsOnChange: PropTypes.bool, 
           registeredFields: PropTypes.any
         }
 
@@ -440,7 +443,7 @@ const createReduxForm =
             const boundFormACs = mapValues(formActions, bindForm)
             const boundArrayACs = mapValues(arrayActions, bindForm)
             const boundBlur = (field, value) => blur(initialProps.form, field, value, !!initialProps.touchOnBlur)
-            const boundChange = (field, value) => change(initialProps.form, field, value, !!initialProps.touchOnChange)
+            const boundChange = (field, value) => change(initialProps.form, field, value, !!initialProps.touchOnChange, !!initialProps.clearErrorsOnChange)
             const boundFocus = bindForm(focus)
 
             // Wrap action creators with `dispatch`


### PR DESCRIPTION
See #1708

The change to the `if (valid)` check in handleSubmit.js is still a bit of an hack. I think the cleanest solution would be to call `validate` there, similar to `asyncValidate`.