### PR TITLE
Improved performance of getIn()

### DIFF
--- a/src/structure/plain/getIn.js
+++ b/src/structure/plain/getIn.js
@@ -1,13 +1,5 @@
 import { toPath } from 'lodash'
 
-const getInWithPath = (state, first, ...rest) => {
-  if(!state) {
-    return state
-  }
-  const next = state[first]
-  return rest.length ? getInWithPath(next, ...rest) : next
-}
-
 const getIn = (state, field) => {
   if (!state) {
     return state
@@ -15,27 +7,14 @@ const getIn = (state, field) => {
 
   const path = toPath(field)
   const length = path.length
-
-  if (length > 3) {
-    return getInWithPath(state, ...path)
-  }
-
-  let result = state
-  if (!length || !result) {
+  if (!length) {
     return undefined
   }
-
-  result = result[path[0]]
-  if (length === 1 || !result) {
-    return result
+  
+  let result = state
+  for (let i = 0; i < length && !!result; ++i) {
+    result = result[path[i]]
   }
-
-  result = result[path[1]]
-  if (length === 2 || !result) {
-    return result
-  }
-
-  result = result[path[2]]
 
   return result
 }


### PR DESCRIPTION
Rewrite recursive rest spread getInPath into simple for loop for 10x and 5x speed improvement in Firefox and Chrome respectively.

I've removed the special case for paths of length 1, 2 and 3 added in https://github.com/erikras/redux-form/pull/1667. That resulted in a 1% and 2% decrease in performance in Firefox and Chrome respectively. If the 1% to 2% is important, I'll add the special cases back.

Benchmark
https://jsfiddle.net/huan086/tbjebaz8/8/

Recursive rest spread is a bad idea, as it is creating a lot of new arrays and putting a strain on garbage collection.