### PR TITLE
Improve dirty handling for checkboxes

### DIFF
--- a/src/structure/immutable/__tests__/deepEqual.spec.js
+++ b/src/structure/immutable/__tests__/deepEqual.spec.js
@@ -275,5 +275,17 @@ describe('structure.immutable.deepEqual', () => {
       }
     }), true)
   })
+
+  it('should treat false and undefined as equal', () => {
+    testBothWays(fromJS({
+      a: {
+        b: false
+      }
+    }), fromJS({
+      a: {
+        b: undefined
+      }
+    }), true)
+  })
 })
 

--- a/src/structure/immutable/deepEqual.js
+++ b/src/structure/immutable/deepEqual.js
@@ -4,8 +4,8 @@ import { isEqualWith } from 'lodash'
 
 const customizer = (obj, other) => {
   if (obj == other) return true
-  if (obj == null && other === '') return true
-  if (obj === '' && other == null) return true
+  if ((obj == null || obj === '' || obj === false) &&
+    (other == null || other === '' || other === false)) return true
 
   if (Iterable.isIterable(obj) && Iterable.isIterable(other)) {
     return obj.count() === other.count() && obj.every((value, key) => {

--- a/src/structure/plain/__tests__/deepEqual.spec.js
+++ b/src/structure/plain/__tests__/deepEqual.spec.js
@@ -188,5 +188,17 @@ describe('structure.plain.deepEqual', () => {
     testBothWays(a, b, false)
     testBothWays(b, c, true)
   })
+
+  it('should treat false and undefined as equal', () => {
+    testBothWays({
+      a: {
+        b: false
+      }
+    }, {
+      a: {
+        b: undefined
+      }
+    }, true)
+  })
 })
 

--- a/src/structure/plain/deepEqual.js
+++ b/src/structure/plain/deepEqual.js
@@ -2,8 +2,9 @@ import { isEqualWith } from 'lodash'
 
 const customizer = (obj, other) => {
   if (obj == other) return true
-  if (obj == null && other === '') return true
-  if (obj === '' && other == null) return true
+  if ((obj == null || obj === '' || obj === false) &&
+    (other == null || other === '' || other === false)) return true
+
   if (obj && other && obj._error !== other._error) return false
 }
 


### PR DESCRIPTION
`dirty(undefined, false)` should be `false`. It was `true`.

Intuitively, clicking twice on a check-box should return it to
pristine, which is false atm (unless the checkbox is initialized with
`false`).

Same behavior as `empty` and `undefined` for a string.

Also decreases code complexity. If both `value` and `initial` are falsey,
return “equal true”.

Comes with tests, both `immutable` and `plain` structures are covered.

I would be very pleased to see it shipped. :hatching_chick: