### PR TITLE
Change 'homepage' schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "bugs": {
     "url": "https://github.com/erikras/redux-form/issues"
   },
-  "homepage": "https://redux-form.com/",
+  "homepage": "http://redux-form.com/",
   "dependencies": {
     "array-findindex-polyfill": "^0.1.0",
     "deep-equal": "^1.0.1",


### PR DESCRIPTION
Package.json contains wrong schema for homepage option. This option is used by npm-check utility for example and when you click on link in console you got security warning in your browser.

If you don't have plans to move site to https, then it will be nice to unify site links.