### PR TITLE
Remove duplicate 5.2.3 docs link and upkeep of v6 patch docs links

### DIFF
--- a/docs/DocumentationVersions.md
+++ b/docs/DocumentationVersions.md
@@ -24,7 +24,6 @@
 * [5.2.5](http://redux-form.com/5.2.5/)
 * [5.2.4](http://redux-form.com/5.2.4/)
 * [5.2.3](http://redux-form.com/5.2.3/)
-* [5.2.3](http://redux-form.com/5.2.3/)
 * [5.2.1](http://redux-form.com/5.2.1/)
 * [5.2.0](http://redux-form.com/5.2.0/)
 * [5.1.3](http://redux-form.com/5.1.3/)

--- a/docs/DocumentationVersions.md
+++ b/docs/DocumentationVersions.md
@@ -1,6 +1,9 @@
 # Documentation Versions
 
 * [6.0.5](http://redux-form.com/6.0.5/)
+* [6.0.4](http://redux-form.com/6.0.4/)
+* [6.0.2](http://redux-form.com/6.0.2/)
+* [6.0.1](http://redux-form.com/6.0.1/)
 * [6.0.0-rc.5](http://redux-form.com/6.0.0-rc.5/)
 * [6.0.0-rc.4](http://redux-form.com/6.0.0-rc.4/)
 * [6.0.0-rc.3](http://redux-form.com/6.0.0-rc.3/)
@@ -16,8 +19,6 @@
 * [6.0.0-alpha.6](http://redux-form.com/6.0.0-alpha.6/)
 * [6.0.0-alpha.5](http://redux-form.com/6.0.0-alpha.5/)
 * [6.0.0-alpha.4](http://redux-form.com/6.0.0-alpha.4/)
-
-
 * [5.3.3](http://redux-form.com/5.3.3/)
 * [5.3.1](http://redux-form.com/5.3.1/)
 * [5.3.0](http://redux-form.com/5.3.0/)


### PR DESCRIPTION
Description:
-----
There is a duplicate link for [5.2.3](http://redux-form.com/5.2.3/) in `DocumentationVersions.md`, which displays in the live documentation as:
>- [5.2.3](http://redux-form.com/5.2.3/)
>- [5.2.3](http://redux-form.com/5.2.3/)

Second,`DocumentationVersions.md` is missing links to 6.0.1, 6.0.2, 6.0.4 patch versions. Not sure if this was intentional, but it might be nice to put those here for archival reasons since they're in gh-pages anyway, up to you. Let me know what you think about this.

Lastly, there's a big line break jump between version 6 documentations & the version below it, which cause some fragmented formatting starting at v6.0.0-alpha-4 (https://github.com/kevinzwh/redux-form/blob/master/docs/DocumentationVersions.md)

Changes proposed:
-----

- Removed duplicate [5.2.3](http://redux-form.com/5.2.3/) version link
- Add missing documentation links to 6.0.1, 6.0.2, 6.0.4
- Prune extra line breaks from `DocumentationVersions.md`