### PR TITLE
Fix #1677: Add `name` argument to `parse` & `format` props for Field + Fields

### DIFF
--- a/docs/api/Field.md
+++ b/docs/api/Field.md
@@ -38,10 +38,13 @@ be as simple as `'firstName'` or as complicated as
 A `Component`, stateless function, or string corresponding to a default JSX element.
 See the [Usage](#usage) section below for details.
 
-#### `format : (value) => formattedValue` [optional]
+#### `format : (value, name) => formattedValue` [optional]
 
 Formats the value from the Redux store to be displayed in the field input. Common use cases are 
 to format `Number`s into currencies or `Date`s into a localized date format.
+
+`format` is called with the field `value` and `name` as arguments and should return the
+new formatted value to be displayed in the field input.
 
 #### `normalize : (value, previousValue, allValues, previousAllValues) => nextValue` [optional]
 
@@ -76,11 +79,14 @@ passing props along to your `component` is to give them directly to the `Field` 
 if, for whatever reason, you prefer to bundle them into a separate object, you may do so by 
 passing them into `props`.
 
-#### `parse : (value) => parsedValue` [optional]
+#### `parse : (value, name) => parsedValue` [optional]
 
 Parses the value given from the field input component to the type that you want stored in the 
 Redux store. Common use cases are to parse currencies into `Number`s into currencies or 
 localized date formats into `Date`s.
+
+`parse` is called with the field `value` and `name` as arguments and should return the new
+parsed value to be stored in the Redux store.
 
 #### `withRef : boolean` [optional]
 

--- a/docs/api/Fields.md
+++ b/docs/api/Fields.md
@@ -36,10 +36,13 @@ be as simple as `'firstName'` or as complicated as
 A `Component` or stateless function that will be given all the props necessary to render the 
 field inputs. See the [Usage](#usage) section below for details.
 
-#### `format : (value) => formattedValue` [optional]
+#### `format : (value, name) => formattedValue` [optional]
 
 Formats the value from the Redux store to be displayed in the field input. Common use cases are 
 to format `Number`s into currencies or `Date`s into a localized date format.
+
+`format` is called with the field `value` and `name` as arguments and should return the
+new formatted value to be displayed in the field input.
 
 #### `props : object` [optional]
 
@@ -50,11 +53,14 @@ passing props along to your `component` is to give them directly to the `Fields`
 if, for whatever reason, you prefer to bundle them into a separate object, you may do so by 
 passing them into `props`.
 
-#### `parse : (value) => parsedValue` [optional]
+#### `parse : (value, name) => parsedValue` [optional]
 
 Parses the value given from the field input component to the type that you want stored in the 
 Redux store. Common use cases are to parse currencies into `Number`s into currencies or 
 localized date formats into `Date`s.
+
+`parse` is called with the field `value` and `name` as arguments and should return the new
+parsed value to be stored in the Redux store.
 
 #### `withRef : boolean` [optional]
 

--- a/src/__tests__/Field.spec.js
+++ b/src/__tests__/Field.spec.js
@@ -782,7 +782,7 @@ const describeField = (name, structure, combineReducers, expect) => {
 
       expect(format).toHaveBeenCalled()
       expect(format.calls.length).toBe(1)
-      expect(format.calls[ 0 ].arguments).toEqual([ 'Redux Form' ])
+      expect(format.calls[ 0 ].arguments).toEqual([ 'Redux Form', 'name' ])
 
       expect(input.calls[ 0 ].arguments[ 0 ].input.value).toBe('redux form')
     })
@@ -822,7 +822,7 @@ const describeField = (name, structure, combineReducers, expect) => {
 
       expect(parse).toHaveBeenCalled()
       expect(parse.calls.length).toBe(1)
-      expect(parse.calls[ 0 ].arguments).toEqual([ 'REDUX FORM ROCKS' ])
+      expect(parse.calls[ 0 ].arguments).toEqual([ 'REDUX FORM ROCKS', 'name' ])
 
       expect(input.calls.length).toBe(2)
       expect(input.calls[ 1 ].arguments[ 0 ].input.value).toBe('redux form rocks')
@@ -863,7 +863,7 @@ const describeField = (name, structure, combineReducers, expect) => {
 
       expect(parse).toHaveBeenCalled()
       expect(parse.calls.length).toBe(1)
-      expect(parse.calls[ 0 ].arguments).toEqual([ 'REDUX FORM ROCKS' ])
+      expect(parse.calls[ 0 ].arguments).toEqual([ 'REDUX FORM ROCKS', 'name' ])
 
       expect(input.calls.length).toBe(2)
       expect(input.calls[ 1 ].arguments[ 0 ].input.value).toBe('redux form rocks')
@@ -913,7 +913,7 @@ const describeField = (name, structure, combineReducers, expect) => {
       // parse was called
       expect(parse).toHaveBeenCalled()
       expect(parse.calls.length).toBe(1)
-      expect(parse.calls[ 0 ].arguments).toEqual([ '15' ])
+      expect(parse.calls[ 0 ].arguments).toEqual([ '15', 'age' ])
 
       // value in store is number
       expect(store.getState()).toEqualMap({
@@ -930,7 +930,7 @@ const describeField = (name, structure, combineReducers, expect) => {
       // format called again
       expect(format).toHaveBeenCalled()
       expect(format.calls.length).toBe(2)
-      expect(format.calls[ 1 ].arguments).toEqual([ 15 ])
+      expect(format.calls[ 1 ].arguments).toEqual([ 15, 'age' ])
 
       // input rerendered with string value
       expect(input.calls.length).toBe(2)

--- a/src/__tests__/Fields.spec.js
+++ b/src/__tests__/Fields.spec.js
@@ -737,7 +737,7 @@ const describeFields = (name, structure, combineReducers, expect) => {
 
       expect(format).toHaveBeenCalled()
       expect(format.calls.length).toBe(1)
-      expect(format.calls[ 0 ].arguments).toEqual([ 'Redux Form' ])
+      expect(format.calls[ 0 ].arguments).toEqual([ 'Redux Form', 'name' ])
 
       expect(input.calls[ 0 ].arguments[ 0 ].name.input.value).toBe('redux form')
     })
@@ -777,7 +777,7 @@ const describeFields = (name, structure, combineReducers, expect) => {
 
       expect(parse).toHaveBeenCalled()
       expect(parse.calls.length).toBe(1)
-      expect(parse.calls[ 0 ].arguments).toEqual([ 'REDUX FORM ROCKS' ])
+      expect(parse.calls[ 0 ].arguments).toEqual([ 'REDUX FORM ROCKS', 'name' ])
 
       expect(input.calls.length).toBe(2)
       expect(input.calls[ 1 ].arguments[ 0 ].name.input.value).toBe('redux form rocks')
@@ -818,7 +818,7 @@ const describeFields = (name, structure, combineReducers, expect) => {
 
       expect(parse).toHaveBeenCalled()
       expect(parse.calls.length).toBe(1)
-      expect(parse.calls[ 0 ].arguments).toEqual([ 'REDUX FORM ROCKS' ])
+      expect(parse.calls[ 0 ].arguments).toEqual([ 'REDUX FORM ROCKS', 'name' ])
 
       expect(input.calls.length).toBe(2)
       expect(input.calls[ 1 ].arguments[ 0 ].name.input.value).toBe('redux form rocks')
@@ -868,7 +868,7 @@ const describeFields = (name, structure, combineReducers, expect) => {
       // parse was called
       expect(parse).toHaveBeenCalled()
       expect(parse.calls.length).toBe(1)
-      expect(parse.calls[ 0 ].arguments).toEqual([ '15' ])
+      expect(parse.calls[ 0 ].arguments).toEqual([ '15', 'age' ])
 
       // value in store is number
       expect(store.getState()).toEqualMap({
@@ -885,7 +885,7 @@ const describeFields = (name, structure, combineReducers, expect) => {
       // format called again
       expect(format).toHaveBeenCalled()
       expect(format.calls.length).toBe(2)
-      expect(format.calls[ 1 ].arguments).toEqual([ 15 ])
+      expect(format.calls[ 1 ].arguments).toEqual([ 15, 'age' ])
 
       // input rerendered with string value
       expect(input.calls.length).toBe(2)

--- a/src/createFieldProps.js
+++ b/src/createFieldProps.js
@@ -42,11 +42,12 @@ const createFieldProps = (getIn, name,
     ...custom
   }, asyncValidate = noop) => {
   const error = syncError || asyncError || submitError
+  const boundParse = parse && (value => parse(value, name))
   const boundNormalize = normalize && (value => normalize(name, value))
   const boundChange = value => dispatch(change(name, value))
   const onChange = createOnChange(boundChange, {
     normalize: boundNormalize,
-    parse
+    parse: boundParse
   })
   const fieldValue = value == null ? '' : value
 
@@ -55,14 +56,14 @@ const createFieldProps = (getIn, name,
       name,
       onBlur: createOnBlur(value => dispatch(blur(name, value)), {
         normalize: boundNormalize,
-        parse,
+        parse: boundParse,
         after: asyncValidate.bind(null, name)
       }),
       onChange,
       onDragStart: createOnDragStart(name, fieldValue),
       onDrop: createOnDrop(name, boundChange),
       onFocus: createOnFocus(name, () => dispatch(focus(name))),
-      value: format ? format(fieldValue) : fieldValue
+      value: format ? format(fieldValue, name) : fieldValue
     }, _value),
     meta: {
       ...state,


### PR DESCRIPTION
Description
----

Currently, `parse` and `format` props are called with only the field `value`.:
>`format : (value) => formattedValue` [optional]
>`parse : (value) => parsedValue` [optional]

As described in #1677, there are cases where it would be beneficial for it to be called with the field `name` such that the interface for both would become:
>`format : (value, name) => formattedValue` [optional]
>`parse : (value, name) => parsedValue` [optional]

It would allow for fields of the same component that rely on different types of values to be differentiated by `name` in the value lifecycle through `parse` & `format`.

Changes Proposed
----

- Add field `name` as a second input to `parse` & `format`
- Update tests for `parse` & `format` for both Field & Fields components with new `name` argument
- Update docs for Field & Fields to explain how `parse` & `format` props function with access to the field `name`.

---
Fixes #1677