### PR TITLE
Prevent wrapping brand name

### DIFF
--- a/src/components/Nav.scss
+++ b/src/components/Nav.scss
@@ -72,6 +72,7 @@
       height: 60px;
       font-size: 25px;
       line-height: 38px;
+      white-space: nowrap;
       padding-left: 80px;
       &:hover {
         background: url('./brand.png') no-repeat 8px 8px;


### PR DESCRIPTION
I use MacOs with changed settings of scrollbar behaviour, they always shown. And with this setup brand name is wrapped into two lines. This small styles change fixes it.

Before:
![image](https://cloud.githubusercontent.com/assets/430023/18630744/1836a98e-7e77-11e6-9bdb-20cdf0f6a729.png)

After:
![image](https://cloud.githubusercontent.com/assets/430023/18630768/2f8a6aa8-7e77-11e6-8331-9daabe743ddf.png)
