### PR TITLE
Fix `name` prop not being passed down to children

### DIFF
--- a/src/ConnectedFieldArray.js
+++ b/src/ConnectedFieldArray.js
@@ -54,7 +54,10 @@ const createConnectedFieldArray = ({ deepEqual, getIn, size }) => {
       const props = createFieldArrayProps(
         getIn,
         name,
-        rest
+        {
+          ...rest,
+          name
+        }
       )
       if (withRef) {
         props.ref = 'renderedComponent'


### PR DESCRIPTION
In commit 89e183f, additional properties were extracted from `this.props`, which in turn removed them from the `...rest` variable.

This commit manually adds the `name` prop back into the generated lists of props.

I'm not 100% sure that this fixes all of the things that were changed in that commit, but it does fix the `FieldArray` `component` not getting this property.