### PR TITLE
Adds a third argument when calling reducer plugins

### DIFF
--- a/src/__tests__/reducer.plugin.spec.js
+++ b/src/__tests__/reducer.plugin.spec.js
@@ -138,10 +138,10 @@ const describePlugin = (vanillaReducer, expect, { fromJS, deleteIn, getIn, setIn
     
     const plugin = (state, action, startingState) => {
       if (action.type === CHANGE && action.meta.field === 'cat') {
-         let result = state
-         result = setIn(result, 'values.lastCat', getIn(startingState, 'values.cat'))
-         result = setIn(result, 'fields.lastCat.touched', action.meta.touch)
-         return result
+        let result = state
+        result = setIn(result, 'values.lastCat', getIn(startingState, 'values.cat'))
+        result = setIn(result, 'fields.lastCat.touched', action.meta.touch)
+        return result
       }
       return state
     }

--- a/src/__tests__/reducer.plugin.spec.js
+++ b/src/__tests__/reducer.plugin.spec.js
@@ -1,4 +1,7 @@
-const describePlugin = (vanillaReducer, expect, { fromJS, deleteIn }) => () => {
+import { CHANGE } from '../actionTypes'
+import { change } from '../actions'
+
+const describePlugin = (vanillaReducer, expect, { fromJS, deleteIn, getIn, setIn }) => () => {
   it('should initialize state when a plugin is given', () => {
     const reducer = vanillaReducer.plugin({
       foo: state => state
@@ -111,6 +114,53 @@ const describePlugin = (vanillaReducer, expect, { fromJS, deleteIn }) => () => {
           fields: {
             cat: { touched: true },
             rat: { touched: true }
+          }
+        }
+      })
+  })
+  
+  it('should be provided the state from before the vanillaReducer', () => {
+    const state1 = fromJS({
+      foo: {
+        values: {
+          cat: 'beta',
+          lastCat: 'alpha' 
+        },
+        fields: {
+          cat: { touched: false },
+          lastCat: { touched: false }
+        }
+      }
+    })
+
+    // this plugin will change the value we are after so we can confirm we get the real starting state
+    const intermediatePlugin = (state) => setIn(state, 'values.cat', 'zed')
+    
+    const plugin = (state, action, startingState) => {
+      if (action.type === CHANGE && action.meta.field === 'cat') {
+         let result = state
+         result = setIn(result, 'values.lastCat', getIn(startingState, 'values.cat'))
+         result = setIn(result, 'fields.lastCat.touched', action.meta.touch)
+         return result
+      }
+      return state
+    }
+
+    const reducer = vanillaReducer.plugin({ foo: intermediatePlugin }).plugin({ foo: plugin })
+    
+    const state2 = reducer(state1, change('foo', 'cat', 'charlie', true, false))
+    
+    expect(state2)
+      .toEqualMap({
+        foo: {
+          anyTouched: true,
+          values: {
+            cat: 'zed',
+            lastCat: 'beta'
+          },
+          fields: {
+            cat: { touched: true },
+            lastCat: { touched: true }
           }
         }
       })

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -381,7 +381,7 @@ const createReducer = structure => {
           .keys(reducers)
           .reduce((accumulator, key) => {
             const previousState = getIn(accumulator, key)
-            const nextState = reducers[ key ](previousState, action)
+            const nextState = reducers[ key ](previousState, action, getIn(state, key))
             return nextState === previousState ?
               accumulator :
               setIn(accumulator, key, nextState)


### PR DESCRIPTION
This argument is the state before the redux form and other plugins reduce the action to the state provided as the first argument.

This fixes issue #1817