### PR TITLE
Add ability to use function in enableReinitialize

### DIFF
--- a/src/reduxForm.js
+++ b/src/reduxForm.js
@@ -116,7 +116,12 @@ const createReduxForm =
           }
 
           initIfNeeded(nextProps) {
-            const { enableReinitialize } = this.props
+            let { enableReinitialize } = this.props
+
+            if (typeof enableReinitialize === 'function') {
+              enableReinitialize = enableReinitialize(this.props, nextProps)
+            }
+
             if (nextProps) {
               if ((enableReinitialize || !nextProps.initialized) && !deepEqual(this.props.initialValues, nextProps.initialValues)) {
                 const keepDirty = nextProps.initialized && this.props.keepDirtyOnReinitialize


### PR DESCRIPTION
This is not final yet.

Just want to know what you guys think.

The use case for this is:

I've a, b, c field in the form, I only want to reload the form if initialValues for c changed. If a or b changed. 
Don't reload.

I'm aware of `keepDirtyData`, but still if we went for re-init, we lost all the meta data and error too.
