### PR TITLE
Fix ConnectedField withRef/getRenderedComponent() regression for text components

### DIFF
--- a/src/ConnectedField.js
+++ b/src/ConnectedField.js
@@ -52,7 +52,7 @@ const createConnectedField = ({ deepEqual, getIn }) => {
         asyncValidate
       )
       if (withRef) {
-        props.ref = 'renderedComponent'
+        custom.ref = 'renderedComponent'
       }
       if (typeof component === 'string') {
         const { input, meta } = props // eslint-disable-line no-unused-vars


### PR DESCRIPTION
Regression caused by src/ConnectedField.js changes in PR #1589, partly breaking feature added for #927 

`custom` is now initialized before props.ref is assigned. This means that the ref prop will not reach a text-based component like `input`.

The fix is trivial, just need to assign ref as a property to `custom` instead of to `props`.
Being in `custom`, it will end up in both text and React components.

Testing the change locally seems to indicate that getRenderedComponent() works properly again.
