### PR TITLE
arrayPush should handle a null leaf value

### DIFF
--- a/src/__tests__/reducer.arrayPush.spec.js
+++ b/src/__tests__/reducer.arrayPush.spec.js
@@ -83,6 +83,26 @@ const describeArrayPush = (reducer, expect, { fromJS }) => () => {
         }
       })
   })
+
+  it('should handle a null leaf value', () => {
+    const state = reducer(fromJS({
+      foo: {
+        values: {
+          steps: null
+        }
+      }
+    }), arrayPush('foo', 'steps', 'value'))
+    expect(state)
+      .toEqualMap({
+        foo: {
+          values: {
+            steps: [
+              'value'
+            ]
+          }
+        }
+      })
+  })
 }
 
 export default describeArrayPush

--- a/src/structure/immutable/splice.js
+++ b/src/structure/immutable/splice.js
@@ -1,6 +1,8 @@
 import { List } from 'immutable'
 
-export default (list = List.isList(list) || List(), index, removeNum, value) => {
+export default (list, index, removeNum, value) => {
+  list = List.isList(list) ? list : List()
+
   if (index < list.count()) {
     if (value === undefined && !removeNum) { // inserting undefined
       // first insert null and then re-set it to undefined

--- a/src/structure/plain/splice.js
+++ b/src/structure/plain/splice.js
@@ -1,4 +1,6 @@
-const splice = (array = [], index, removeNum, value) => {
+const splice = (array, index, removeNum, value) => {
+  array = array || []
+
   if (index < array.length) {
     if (value === undefined && !removeNum) { // inserting undefined
       const copy = [ ...array ]


### PR DESCRIPTION
The constructs being used in argument assignment only account for undefined values, for example the array property below:

```
const splice = (array = [], index, removeNum, value) => {
```

If the array value is null, it will not be assigned to be an empty array. This causes any code that assumes array will be an actual array (and not null) to break.

I've added a test to demonstrate the bug, and a simple fix. Basically, do the assignment outside of the arguments, so that null values are handled properly, and list.count() and array.length don't fail.

This might affect other areas of the codebase. If the foo = bar arg assignment construct is being used anywhere, the code in that function has to be protected against null values (or don't use that arg construct, just do default arg assignment in the function itself). 

Thanks for redux-form, loving it :).