### PR TITLE
Add custom props to material-ui select field

### DIFF
--- a/examples/material-ui/src/MaterialUiForm.js
+++ b/examples/material-ui/src/MaterialUiForm.js
@@ -42,13 +42,14 @@ const renderRadioGroup = ({ input, ...rest }) => (
     onChange={(event, value) => input.onChange(value)}/>
 )
 
-const renderSelectField = ({ input, label, meta: { touched, error }, children }) => (
+const renderSelectField = ({ input, label, meta: { touched, error }, children, ...custom }) => (
   <SelectField
     floatingLabelText={label}
     errorText={touched && error}
     {...input}
     onChange={(event, index, value) => input.onChange(value)}
-    children={children}/>
+    children={children}
+    {...custom}/>
 )
 
 const MaterialUiForm = props => {


### PR DESCRIPTION
I spent a while trying to figure out why my `disabled` prop wasn't being passed to the SelectField, where it was working elsewhere.

I'd copied the function from here, and just figured out the issue that we were losing any other props passed in to the component.