### PR TITLE
Maintain cursor position on parse/normalize (#1895)

### DIFF
--- a/src/events/createOnBlur.js
+++ b/src/events/createOnBlur.js
@@ -12,7 +12,7 @@ const createOnBlur =
       let distanceFromEnd = -1
       let validInputTypes = [ 'text', 'search', 'url', 'tel', 'password' ]
       // get distance between caret and end of original value
-      if (isEvent(event) && validInputTypes.includes(event.target.type)) {
+      if (isEvent(event) && validInputTypes.indexOf(event.target.type) !== -1) {
         distanceFromEnd = value.length - event.target.selectionEnd
       }
 

--- a/src/events/createOnBlur.js
+++ b/src/events/createOnBlur.js
@@ -1,4 +1,5 @@
 import getValue from './getValue'
+import isEvent from './isEvent'
 import isReactNative from '../isReactNative'
 
 const createOnBlur =
@@ -6,15 +7,37 @@ const createOnBlur =
     event => {
       // read value from input
       let value = getValue(event, isReactNative)
+      let newValue
+      let changed = false
+      let distanceFromEnd = -1
+      let validInputTypes = [ 'text', 'search', 'url', 'tel', 'password' ]
+      // get distance between caret and end of original value
+      if (isEvent(event) && validInputTypes.includes(event.target.type)) {
+        distanceFromEnd = value.length - event.target.selectionEnd
+      }
 
       // parse value if we have a parser
       if (parse) {
-        value = parse(value)
+        newValue = parse(value)
+        if (newValue !== value) {
+          changed = true
+          value = newValue
+        }
       }
 
       // normalize value
       if (normalize) {
-        value = normalize(value)
+        newValue = normalize(value)
+        if (newValue !== value) {
+          changed = true
+          value = newValue
+        }
+      }
+
+      // move caret to appropriate position if value has changed
+      if (changed && distanceFromEnd !== -1) {
+        event.persist()
+        setTimeout(() => event.target.selectionStart = event.target.selectionEnd = value.length - distanceFromEnd)
       }
 
       // dispatch blur action

--- a/src/events/createOnChange.js
+++ b/src/events/createOnChange.js
@@ -11,7 +11,7 @@ const createOnChange = (change, { parse, normalize } = {}) =>
     let distanceFromEnd = -1
     let validInputTypes = [ 'text', 'search', 'url', 'tel', 'password' ]
     // get distance between caret and end of original value
-    if (isEvent(event) && validInputTypes.includes(event.target.type)) {
+    if (isEvent(event) && validInputTypes.indexOf(event.target.type) !== -1) {
       distanceFromEnd = value.length - event.target.selectionEnd
     }
 

--- a/src/events/createOnChange.js
+++ b/src/events/createOnChange.js
@@ -1,19 +1,42 @@
 import getValue from './getValue'
+import isEvent from './isEvent'
 import isReactNative from '../isReactNative'
 
 const createOnChange = (change, { parse, normalize } = {}) =>
   event => {
     // read value from input
     let value = getValue(event, isReactNative)
+    let newValue
+    let changed = false
+    let distanceFromEnd = -1
+    let validInputTypes = [ 'text', 'search', 'url', 'tel', 'password' ]
+    // get distance between caret and end of original value
+    if (isEvent(event) && validInputTypes.includes(event.target.type)) {
+      distanceFromEnd = value.length - event.target.selectionEnd
+    }
 
     // parse value if we have a parser
     if (parse) {
-      value = parse(value)
+      newValue = parse(value)
+      if (newValue !== value) {
+        changed = true
+        value = newValue
+      }
     }
 
     // normalize value
     if (normalize) {
-      value = normalize(value)
+      newValue = normalize(value)
+      if (newValue !== value) {
+        changed = true
+        value = newValue
+      }
+    }
+
+    // move caret to appropriate position if value has changed
+    if (changed && distanceFromEnd !== -1) {
+      event.persist()
+      setTimeout(() => event.target.selectionStart = event.target.selectionEnd = value.length - distanceFromEnd)
     }
 
     // dispatch change action


### PR DESCRIPTION
References #1895 and #1396.

* Modifies createOnChange() and createOnBlur() to handle
  moving the caret to the appropriate place when the value
  is changed
* Set to only work for input types that support .selection
* Can probably be cleaned up -- this is just a POC for now