### PR TITLE
Update react-redux dependency range to include v5 prereleases

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   },
   "peerDependencies": {
     "react": "^15.0.0",
-    "react-redux": "^4.3.0",
+    "react-redux": "^4.3.0 || ^5.0.0-beta",
     "redux": "^3.0.0"
   },
   "files": [


### PR DESCRIPTION
v5 is centered around the `connect()` rewrite described in this PR: https://github.com/reactjs/react-redux/pull/416

The changes expands the API and rewrites all of the internals but preserves existing functionality, so it’s really non-breaking ([reference](https://github.com/reactjs/react-redux/pull/416#issuecomment-239678590)). It also solves bugs related to nested connected components’ subscriptions getting triggered our of order for our app (which was actually the original motivation for the PR, see https://github.com/reactjs/react-redux/pull/416#issuecomment-250885794 and https://github.com/reactjs/react-redux/pull/416#issuecomment-250892326), so we’re switching over.