### PR TITLE
Created a selector for synchronous errors

### DIFF
--- a/docs/api/Selectors.md
+++ b/docs/api/Selectors.md
@@ -3,15 +3,16 @@
 [`View source on GitHub`](https://github.com/erikras/redux-form/tree/master/src/selectors)
 
 `redux-form` provides a set of useful Redux state
-[**selectors**](http://redux.js.org/docs/recipes/ComputingDerivedData.html) that may be used in 
+[**selectors**](http://redux.js.org/docs/recipes/ComputingDerivedData.html) that may be used in
 any part of your application to query the state of any of your forms.
 
-All of the selectors listed below have the same usage pattern: they all take the name of the 
+All of the selectors listed below have the same usage pattern: they all take the name of the
 form, and create a selector for whatever form state the selector is for.
 
 ```js
 import {
   getFormValues,
+  getFormSyncErrors,
   isDirty,
   isPristine,
   isValid,
@@ -21,6 +22,7 @@ import {
 MyComponent = connect(
   state => ({
     values: getFormValues('myForm')(state),
+    syncErrors: getFormSyncErrors('myForm')(state),
     dirty: isDirty('myForm')(state),
     pristine: isPristine('myForm')(state),
     valid: isValid('myForm')(state),
@@ -35,22 +37,26 @@ MyComponent = connect(
 
 > Gets the form values. Shocking, right?
 
+### `getFormSyncErrors(formName:String)` returns `(state) => formSyncErrors:Object`
+
+> Returns the form synchronous validation errors.
+
 ### `isDirty(formName:String)` returns `(state) => dirty:boolean`
 
-> Returns `true` if the form is dirty, i.e. the values have been altered from the original 
+> Returns `true` if the form is dirty, i.e. the values have been altered from the original
 `initialValues` provided. The opposite of `isPristine`.
 
 ### `isPristine(formName:String)` returns `(state) => pristine:boolean`
 
-> Returns `true` if the form is pristine, i.e. the values have NOT been altered from the original 
+> Returns `true` if the form is pristine, i.e. the values have NOT been altered from the original
 `initialValues` provided. The opposite of `isDirty`.
 
 ### `isValid(formName:String)` returns `(state) => valid:boolean`
 
-> Returns `true` if the form is valid, i.e. has no sync, async, or submission errors. The opposite 
+> Returns `true` if the form is valid, i.e. has no sync, async, or submission errors. The opposite
 of `isInvalid`.
 
 ### `isInvalid(formName:String)` returns `(state) => invalid:boolean`
 
-> Returns `true` if the form is invalid, i.e. has sync, async, or submission errors. The opposite 
+> Returns `true` if the form is invalid, i.e. has sync, async, or submission errors. The opposite
 of `isValid`.

--- a/src/createAll.js
+++ b/src/createAll.js
@@ -6,6 +6,7 @@ import createFieldArray from './FieldArray'
 import createFormValueSelector from './formValueSelector'
 import createValues from './values'
 import createGetFormValues from './selectors/getFormValues'
+import createGetFormSyncErrors from './selectors/getFormSyncErrors'
 import createIsDirty from './selectors/isDirty'
 import createIsInvalid from './selectors/isInvalid'
 import createIsPristine from './selectors/isPristine'
@@ -24,6 +25,7 @@ const createAll = structure => ({
   FieldArray: createFieldArray(structure),
   formValueSelector: createFormValueSelector(structure),
   getFormValues: createGetFormValues(structure),
+  getFormSyncErrors: createGetFormSyncErrors(structure),
   isDirty: createIsDirty(structure),
   isInvalid: createIsInvalid(structure),
   isPristine: createIsPristine(structure),

--- a/src/selectors/__tests__/getFormSyncErrors.spec.js
+++ b/src/selectors/__tests__/getFormSyncErrors.spec.js
@@ -1,0 +1,61 @@
+import createGetFormSyncErrors from '../getFormSyncErrors'
+import plain from '../../structure/plain'
+import plainExpectations from '../../structure/plain/expectations'
+import immutable from '../../structure/immutable'
+import immutableExpectations from '../../structure/immutable/expectations'
+import addExpectations from '../../__tests__/addExpectations'
+
+const describeGetFormSyncErrors = (name, structure, expect) => {
+  const getFormSyncErrors = createGetFormSyncErrors(structure)
+
+  const { fromJS, getIn } = structure
+
+  describe(name, () => {
+    it('should return a function', () => {
+      expect(createGetFormSyncErrors('foo')).toBeA('function')
+    })
+
+    it('should get the form values from state', () => {
+      expect(getFormSyncErrors('foo')(fromJS({
+        form: {
+          foo: {
+            syncErrors: {
+              dog: 'Snoopy',
+              cat: 'Garfield'
+            }
+          }
+        }
+      }))).toEqualMap({
+        dog: 'Snoopy',
+        cat: 'Garfield'
+      })
+    })
+
+    it('should return undefined if there are no syncErrors', () => {
+      expect(getFormSyncErrors('foo')(fromJS({
+        form: {
+          foo: {}
+        }
+      }))).toEqual(undefined)
+    })
+
+    it('should use getFormState if provided', () => {
+      expect(getFormSyncErrors('foo', state => getIn(state, 'someOtherSlice'))(fromJS({
+        someOtherSlice: {
+          foo: {
+            syncErrors: {
+              dog: 'Snoopy',
+              cat: 'Garfield'
+            }
+          }
+        }
+      }))).toEqualMap({
+        dog: 'Snoopy',
+        cat: 'Garfield'
+      })
+    })
+  })
+}
+
+describeGetFormSyncErrors('getFormSyncErrors.plain', plain, addExpectations(plainExpectations))
+describeGetFormSyncErrors('getFormSyncErrors.immutable', immutable, addExpectations(immutableExpectations))

--- a/src/selectors/getFormSyncErrors.js
+++ b/src/selectors/getFormSyncErrors.js
@@ -1,0 +1,5 @@
+const createGetFormSyncErrors = ({ getIn }) =>
+  (form, getFormState = state => getIn(state, 'form')) =>
+    state => getIn(getFormState(state), `${form}.syncErrors`)
+
+export default createGetFormSyncErrors


### PR DESCRIPTION
I found myself needing to display all errors in a single location, as an unordered list, outside of the fields components. This adds a simple selector to return synchronous validation errors.

Also refers to https://github.com/erikras/redux-form/issues/1923