### PR TITLE
Store number input value as string to fix #1383

### DIFF
--- a/src/events/__tests__/getValue.spec.js
+++ b/src/events/__tests__/getValue.spec.js
@@ -109,7 +109,7 @@ describe('getValue', () => {
         type: 'number',
         value: '3.1415'
       }
-    }, true)).toBe(3.1415)
+    }, true)).toBe('3.1415')
     expect(getValue({
       preventDefault: noop,
       stopPropagation: noop,
@@ -117,7 +117,7 @@ describe('getValue', () => {
         type: 'range',
         value: '2.71828'
       }
-    }, true)).toBe(2.71828)
+    }, true)).toBe('2.71828')
     expect(getValue({
       preventDefault: noop,
       stopPropagation: noop,
@@ -125,7 +125,7 @@ describe('getValue', () => {
         type: 'number',
         value: '3'
       }
-    }, false)).toBe(3)
+    }, false)).toBe('3')
     expect(getValue({
       preventDefault: noop,
       stopPropagation: noop,
@@ -133,7 +133,7 @@ describe('getValue', () => {
         type: 'range',
         value: '3.1415'
       }
-    }, false)).toBe(3.1415)
+    }, false)).toBe('3.1415')
 
     expect(getValue({
       preventDefault: noop,

--- a/src/events/getValue.js
+++ b/src/events/getValue.js
@@ -31,9 +31,6 @@ const getValue = (event, isReactNative) => {
     if (type === 'select-multiple') {
       return getSelectedValues(event.target.options)
     }
-    if (value !== '' && (type === 'number' || type === 'range')) {
-      return parseFloat(value)
-    }
     return value
   }
   return event


### PR DESCRIPTION
Removes the `parseFloat` for number and range types so that decimals can be entered. Fixes #1383.