### PR TITLE
remove the deletion of form level syncError during field CHANGE action.

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -160,7 +160,6 @@ const createReducer = structure => {
         result = deleteInWithCleanUp(result, `submitErrors.${field}`)
       }
       result = deleteInWithCleanUp(result, `fields.${field}.autofilled`)
-      result = deleteInWithCleanUp(result, 'syncError')
       if (touch) {
         result = setIn(result, `fields.${field}.touched`, true)
         result = setIn(result, 'anyTouched', true)


### PR DESCRIPTION
Form level `syncError`doesn't need to be removed during a field `CHANGE` action, and is properly removed during `UPDATE_SYNC_ERRORS`. This fix will correct the following issue:

- Form has form level error, triggered by the validate function returning `{_error: "missing required fields"}`
- The next CHANGE event clears `syncError: true` from the form state, making the form as `valid` when the form level `error: "missing required fields"` still exists in the state.

This was added by @ortex in v6.1.1 (issue #1925, PR #1945)

Hey @ortex, can you double check my logic above? I just want to make sure I'm not undoing something you were trying to fix that I haven't noticed.

Thanks!