### PR TITLE
added missing export for getFormSyncErrors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ export const {
   focus,
   formValueSelector,
   getFormValues,
+  getFormSyncErrors,
   initialize,
   isDirty,
   isInvalid,


### PR DESCRIPTION
One-line fix to enable getFormSyncSelector. Needed it to make a feature