### PR TITLE
Create shouldValidate config property

### DIFF
--- a/docs/api/ReduxForm.md
+++ b/docs/api/ReduxForm.md
@@ -126,13 +126,38 @@ prop namespace collisions.
 
 #### `pure : boolean` [optional]
 
-> If true, implements `shouldComponentUpdate` and shallowly compares _only the Redux-connected 
-props_ that are needed to manage the form state, preventing unnecessary 
+> If true, implements `shouldComponentUpdate` and shallowly compares _only the Redux-connected
+props_ that are needed to manage the form state, preventing unnecessary
 updates, assuming that the component is a “pure” component and does not rely on any input or
 state other than its props and the selected Redux store’s state. Defaults to `true`.
 
 > Similar to the `pure` parameter in [`react-redux`'s `connect()`
 API](https://github.com/reactjs/react-redux/blob/master/docs/api.md#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options)
+
+#### `shouldValidate(params) : boolean` [optional]
+
+> An optional function you may provide to have full control over when sync validation happens.
+Your `shouldValidate()` function will be given an object with the following values:
+
+> ##### `values : Object`
+
+> The values in the form of `{ field1: 'value1', field2: 'value2' }`.
+
+> ##### `nextProps : Object`
+
+> The next props.
+
+> ##### `props : Object`
+
+> The current props.
+
+> ##### `initialRender : boolean`
+
+> `true` if the form is being initially rendered.
+
+> ##### `structure : Object`
+
+> The structure object being used internally for values. You may wish to use `deepEqual` from the structure.
 
 #### `shouldAsyncValidate(params) : boolean` [optional]
 

--- a/src/__tests__/defaultShouldValidate.spec.js
+++ b/src/__tests__/defaultShouldValidate.spec.js
@@ -1,0 +1,50 @@
+import expect from 'expect'
+import plain from '../structure/plain'
+import immutable from '../structure/immutable'
+import defaultShouldValidate from '../defaultShouldValidate'
+
+describe('defaultShouldValidate', () => {
+
+  it('should validate when initialRender is true', () => {
+    expect(defaultShouldValidate({
+      initialRender: true
+    })).toBe(true)
+  })
+
+  const itValidateChange = (structure) => {
+    const { fromJS } = structure
+
+    it('should validate if values have changed', () => {
+      expect(defaultShouldValidate({
+        initialRender: false,
+        structure,
+        values: fromJS({
+          foo: 'fooInitial'
+        }),
+        nextProps: {
+          values: fromJS({
+            foo: 'fooChanged'
+          })
+        }
+      }), true)
+    })
+
+    it('should not validate if values have not changed', () => {
+      expect(defaultShouldValidate({
+        initialRender: false,
+        structure,
+        values: fromJS({
+          foo: 'fooInitial'
+        }),
+        nextProps: {
+          values: fromJS({
+            foo: 'fooInitial'
+          })
+        }
+      }), false)
+    })
+  }
+
+  itValidateChange(plain)
+  itValidateChange(immutable)
+})

--- a/src/defaultShouldValidate.js
+++ b/src/defaultShouldValidate.js
@@ -1,0 +1,14 @@
+const defaultShouldValidate = ({
+  values,
+  nextProps,
+  // props,  // not used in default implementation
+  initialRender,
+  structure
+}) => {
+  if (initialRender) {
+    return true
+  }
+  return !structure.deepEqual(values, nextProps.values)
+}
+
+export default defaultShouldValidate


### PR DESCRIPTION
Creates a new config property for `reduxForm` called `shouldValidate` which allows developers to have full control over when sync validation happens.

Provides a solution for #1965.