### PR TITLE
Fix re-initializing when using Immutable

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -200,7 +200,7 @@ const createReducer = structure => {
         const previousValues = getIn(state, 'values')
         const previousInitialValues = getIn(state, 'initial')
         registeredFields.forEach(field => {
-          const name = field.name
+          const name = getIn(field, 'name')
           const previousInitialValue = getIn(previousInitialValues, name)
           const previousValue = getIn(previousValues, name)
           if (!deepEqual(previousValue, previousInitialValue)) {


### PR DESCRIPTION
I found that when using Immutable in my Redux store, and using the `enableReinitialize` and `keepDirtyOnReinitialize` options everything would work fine until I changed one of the values in my form, and then changed the `initialValues`. All other fields then wouldn't update their value to the new initial value. They were getting considered as `dirty`.

`name` in the reducer was evaluating to `undefined`, so when used with `getIn()` below, it was getting the entire form `values` + `initialValues` as the values for the specific field. Then the equality check on the entire values map shows that one of the fields changed, so it considers the field dirty. But of course as it's the entire values map it will always consider every field in the form dirty even if only one is.

Wasn't sure how to add tests for this one, but the bug fix certainly fixes my issue 😃 