### PR TITLE
Don't swallow errors in `onSubmit`

### DIFF
--- a/src/__tests__/handleSubmit.spec.js
+++ b/src/__tests__/handleSubmit.spec.js
@@ -317,9 +317,14 @@ describe('handleSubmit', () => {
     const asyncValidate = createSpy().andReturn(Promise.resolve())
     const props = { dispatch, startSubmit, stopSubmit, touch, setSubmitFailed, setSubmitSucceeded, values }
 
+    const resolveSpy = createSpy()
+    const errorSpy = createSpy()
+
     return handleSubmit(submit, props, true, asyncValidate, [ 'foo', 'baz' ])
-      .then(result => {
-        expect(result).toBe(undefined)
+      .then(resolveSpy, errorSpy)
+      .then(() => {
+        expect(resolveSpy).toNotHaveBeenCalled()
+        expect(errorSpy).toHaveBeenCalledWith(submitErrors)
         expect(asyncValidate)
           .toHaveBeenCalled()
           .toHaveBeenCalledWith()
@@ -409,5 +414,30 @@ describe('handleSubmit', () => {
       () => handleSubmit(submit, props, true, asyncValidate, [ 'foo', 'baz' ])
     ).toThrow('spline reticulation failed')
     expect(submit).toHaveBeenCalled()
+  })
+
+  it('should not swallow async errors', () => {
+    const values = { foo: 'bar', baz: 42 }
+    const submit = createSpy().andReturn(
+      Promise.reject(new Error('spline reticulation failed'))
+    )
+    const startSubmit = createSpy()
+    const stopSubmit = createSpy()
+    const touch = createSpy()
+    const setSubmitFailed = createSpy()
+    const setSubmitSucceeded = createSpy()
+    const asyncValidate = createSpy()
+    const props = { startSubmit, stopSubmit, touch, setSubmitFailed, setSubmitSucceeded, values }
+
+    const resultSpy = createSpy()
+    const errorSpy = createSpy()
+
+    return handleSubmit(submit, props, true, asyncValidate, [ 'foo', 'baz' ])
+      .then(resultSpy, errorSpy)
+      .then(() => {
+        expect(submit).toHaveBeenCalled()
+        expect(resultSpy).toNotHaveBeenCalled('promise should not have resolved')
+        expect(errorSpy).toHaveBeenCalled('promise should have rejected')
+      })
   })
 })

--- a/src/__tests__/handleSubmit.spec.js
+++ b/src/__tests__/handleSubmit.spec.js
@@ -393,4 +393,21 @@ describe('handleSubmit', () => {
 
     expect(submit).toHaveBeenCalled()
   })
+
+  it('should not swallow errors', () => {
+    const values = { foo: 'bar', baz: 42 }
+    const submit = createSpy().andThrow(new Error('spline reticulation failed'))
+    const startSubmit = createSpy()
+    const stopSubmit = createSpy()
+    const touch = createSpy()
+    const setSubmitFailed = createSpy()
+    const setSubmitSucceeded = createSpy()
+    const asyncValidate = createSpy()
+    const props = { startSubmit, stopSubmit, touch, setSubmitFailed, setSubmitSucceeded, values }
+
+    expect(
+      () => handleSubmit(submit, props, true, asyncValidate, [ 'foo', 'baz' ])
+    ).toThrow('spline reticulation failed')
+    expect(submit).toHaveBeenCalled()
+  })
 })

--- a/src/handleSubmit.js
+++ b/src/handleSubmit.js
@@ -49,7 +49,12 @@ const handleSubmit = (submit, props, valid, asyncValidate, fields) => {
             if (onSubmitFail) {
               onSubmitFail(error, dispatch)
             }
-            return error
+            if (error || onSubmitFail) {
+              // if you've provided an onSubmitFail callback, don't re-throw the error
+              return error
+            } else {
+              throw submitError
+            }
           })
       } else {
         setSubmitSucceeded()

--- a/src/handleSubmit.js
+++ b/src/handleSubmit.js
@@ -25,8 +25,9 @@ const handleSubmit = (submit, props, valid, asyncValidate, fields) => {
         if (onSubmitFail) {
           onSubmitFail(error, dispatch)
         }
-        if (error) {
-          return error  
+        if (error || onSubmitFail) {
+          // if you've provided an onSubmitFail callback, don't re-throw the error
+          return error
         } else {
           throw submitError
         }

--- a/src/handleSubmit.js
+++ b/src/handleSubmit.js
@@ -25,7 +25,11 @@ const handleSubmit = (submit, props, valid, asyncValidate, fields) => {
         if (onSubmitFail) {
           onSubmitFail(error, dispatch)
         }
-        return error
+        if (error) {
+          return error  
+        } else {
+          throw submitError
+        }
       }
       if (isPromise(result)) {
         startSubmit()


### PR DESCRIPTION
If an error is thrown by the onSubmit function that is not a SubmissionError, it will now be re-thrown instead of silently ignored. It will retain the previous behavior if you pass an onSubmitFailed prop - personally I don't like that too much, but it would be a breaking change according to the test suite.

Should fix #1859.

Would appreciate feedback!