### PR TITLE
Don't unregister fields on unmount when a single form is concurrently mounted

### DIFF
--- a/src/reduxForm.js
+++ b/src/reduxForm.js
@@ -92,7 +92,10 @@ const createReduxForm =
         pure: true,
         ...initialConfig
       }
+
       return WrappedComponent => {
+        let instances = 0;
+
         class Form extends Component {
           constructor(props) {
             super(props)
@@ -103,6 +106,8 @@ const createReduxForm =
             this.register = this.register.bind(this)
             this.unregister = this.unregister.bind(this)
             this.submitCompleted = this.submitCompleted.bind(this)
+
+            instances++;
           }
 
           getChildContext() {
@@ -219,6 +224,10 @@ const createReduxForm =
               this.destroyed = true
               destroy()
             }
+
+            this.unmounted = true;
+
+            instances--;
           }
 
           getValues() {
@@ -238,7 +247,7 @@ const createReduxForm =
           }
 
           unregister(name) {
-            if (!this.destroyed) {
+            if (!this.destroyed && (!this.unmounted || !instances)) {
               this.props.unregisterField(name)
             }
           }

--- a/src/reduxForm.js
+++ b/src/reduxForm.js
@@ -94,7 +94,7 @@ const createReduxForm =
       }
 
       return WrappedComponent => {
-        let instances = 0;
+        let instances = 0
 
         class Form extends Component {
           constructor(props) {
@@ -107,7 +107,7 @@ const createReduxForm =
             this.unregister = this.unregister.bind(this)
             this.submitCompleted = this.submitCompleted.bind(this)
 
-            instances++;
+            instances++
           }
 
           getChildContext() {
@@ -225,9 +225,9 @@ const createReduxForm =
               destroy()
             }
 
-            this.unmounted = true;
+            this.unmounted = true
 
-            instances--;
+            instances--
           }
 
           getValues() {


### PR DESCRIPTION
This relates to #1990  and #2016. This patch suppresses unregister() for a field if the containing form is still mounted elsewhere, and the containing form itself is being unmounted, rather than just the field itself.

This is useful in conjunction with destroyOnUnmount: false when you have small, self-contained sub-forms embedded in larger forms, or different parts of the UI.
