### PR TITLE
Add "module" entry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "6.1.1",
   "description": "A higher order component decorator for forms using Redux and React",
   "main": "./lib/index.js",
+  "module": "./es/index.js",
   "jsnext:main": "./es/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Add "module" entry to package.json in order to support ES modules with the latest Webpack.

See: https://github.com/webpack/webpack/issues/1979#issuecomment-234873209
