### PR TITLE
Add original error as 3rd argument to onSubmitFail

### DIFF
--- a/docs/api/ReduxForm.md
+++ b/docs/api/ReduxForm.md
@@ -105,6 +105,10 @@ called with the following parameters:
 
 > The Redux `dispatch` function.
 
+> ##### `submitError : Error`
+
+> The error object that caused the submission to fail. If `errors` is set this will be a `SubmissionError`, otherwise it can be any error. 
+
 #### `onSubmitSuccess : Function` [optional]
 
 > A callback function that will be called when a submission succeeds.  It will be called with the

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "is-promise": "^2.1.0",
     "lodash": "^4.12.0",
     "lodash-es": "^4.12.0",
+    "promise": "^7.1.1",
     "shallowequal": "^0.2.2"
   },
   "devDependencies": {

--- a/src/__tests__/handleSubmit.spec.js
+++ b/src/__tests__/handleSubmit.spec.js
@@ -16,18 +16,19 @@ describe('handleSubmit', () => {
     const props = { startSubmit, stopSubmit, touch, setSubmitFailed, setSubmitSucceeded, values }
 
     handleSubmit(submit, props, false, asyncValidate, [ 'foo', 'baz' ])
-
-    expect(submit).toNotHaveBeenCalled()
-    expect(startSubmit).toNotHaveBeenCalled()
-    expect(stopSubmit).toNotHaveBeenCalled()
-    expect(touch)
-      .toHaveBeenCalled()
-      .toHaveBeenCalledWith('foo', 'baz')
-    expect(asyncValidate).toNotHaveBeenCalled()
-    expect(setSubmitSucceeded).toNotHaveBeenCalled()
-    expect(setSubmitFailed)
-      .toHaveBeenCalled()
-      .toHaveBeenCalledWith('foo', 'baz')
+      .then(() => {
+        expect(submit).toNotHaveBeenCalled()
+        expect(startSubmit).toNotHaveBeenCalled()
+        expect(stopSubmit).toNotHaveBeenCalled()
+        expect(touch)
+          .toHaveBeenCalled()
+          .toHaveBeenCalledWith('foo', 'baz')
+        expect(asyncValidate).toNotHaveBeenCalled()
+        expect(setSubmitSucceeded).toNotHaveBeenCalled()
+        expect(setSubmitFailed)
+          .toHaveBeenCalled()
+          .toHaveBeenCalledWith('foo', 'baz')
+      })
   })
 
   it('should stop and return errors if sync validation fails', () => {
@@ -49,20 +50,21 @@ describe('handleSubmit', () => {
       values
     }
 
-    const result = handleSubmit(submit, props, false, asyncValidate, [ 'foo', 'baz' ])
-
-    expect(asyncValidate).toNotHaveBeenCalled()
-    expect(submit).toNotHaveBeenCalled()
-    expect(startSubmit).toNotHaveBeenCalled()
-    expect(stopSubmit).toNotHaveBeenCalled()
-    expect(touch)
-      .toHaveBeenCalled()
-      .toHaveBeenCalledWith('foo', 'baz')
-    expect(setSubmitSucceeded).toNotHaveBeenCalled()
-    expect(setSubmitFailed)
-      .toHaveBeenCalled()
-      .toHaveBeenCalledWith('foo', 'baz')
-    expect(result).toBe(syncErrors)
+    handleSubmit(submit, props, false, asyncValidate, [ 'foo', 'baz' ])
+      .then(result => {
+        expect(asyncValidate).toNotHaveBeenCalled()
+        expect(submit).toNotHaveBeenCalled()
+        expect(startSubmit).toNotHaveBeenCalled()
+        expect(stopSubmit).toNotHaveBeenCalled()
+        expect(touch)
+          .toHaveBeenCalled()
+          .toHaveBeenCalledWith('foo', 'baz')
+        expect(setSubmitSucceeded).toNotHaveBeenCalled()
+        expect(setSubmitFailed)
+          .toHaveBeenCalled()
+          .toHaveBeenCalledWith('foo', 'baz')
+        expect(result).toBe(syncErrors)
+      })
   })
 
   it('should return result of sync submit', () => {
@@ -77,18 +79,20 @@ describe('handleSubmit', () => {
     const asyncValidate = undefined
     const props = { dispatch, startSubmit, stopSubmit, touch, setSubmitFailed, setSubmitSucceeded, values }
 
-    expect(handleSubmit(submit, props, true, asyncValidate, [ 'foo', 'baz' ])).toBe(69)
-
-    expect(submit)
-      .toHaveBeenCalled()
-      .toHaveBeenCalledWith(values, dispatch, props)
-    expect(startSubmit).toNotHaveBeenCalled()
-    expect(stopSubmit).toNotHaveBeenCalled()
-    expect(touch)
-      .toHaveBeenCalled()
-      .toHaveBeenCalledWith('foo', 'baz')
-    expect(setSubmitFailed).toNotHaveBeenCalled()
-    expect(setSubmitSucceeded).toHaveBeenCalled()
+    handleSubmit(submit, props, true, asyncValidate, [ 'foo', 'baz' ])
+      .then(result => {
+        expect(result).toBe(69)
+        expect(submit)
+          .toHaveBeenCalled()
+          .toHaveBeenCalledWith(values, dispatch, props)
+        expect(startSubmit).toNotHaveBeenCalled()
+        expect(stopSubmit).toNotHaveBeenCalled()
+        expect(touch)
+          .toHaveBeenCalled()
+          .toHaveBeenCalledWith('foo', 'baz')
+        expect(setSubmitFailed).toNotHaveBeenCalled()
+        expect(setSubmitSucceeded).toHaveBeenCalled()
+      })
   })
 
   it('should not submit if async validation fails', () => {
@@ -152,7 +156,9 @@ describe('handleSubmit', () => {
         expect(stopSubmit).toNotHaveBeenCalled()
         expect(onSubmitFail)
           .toHaveBeenCalled()
-          .toHaveBeenCalledWith(values, dispatch)
+        expect(onSubmitFail.calls[0].arguments[0]).toEqual(values)
+        expect(onSubmitFail.calls[0].arguments[1]).toEqual(dispatch)
+        expect(onSubmitFail.calls[0].arguments[2]).toBeA(SubmissionError)
         expect(touch)
           .toHaveBeenCalled()
           .toHaveBeenCalledWith('foo', 'baz')
@@ -385,7 +391,7 @@ describe('handleSubmit', () => {
 
   it('should submit when there are old submit errors and persistentSubmitErrors is enabled', () => {
     const values = { foo: 'bar', baz: 42 }
-    const submit = createSpy().andReturn(69)
+    const submit = createSpy()
     const startSubmit = createSpy()
     const stopSubmit = createSpy()
     const touch = createSpy()
@@ -395,8 +401,9 @@ describe('handleSubmit', () => {
     const props = { startSubmit, stopSubmit, touch, setSubmitFailed, setSubmitSucceeded, values, persistentSubmitErrors: true }
 
     handleSubmit(submit, props, true, asyncValidate, [ 'foo', 'baz' ])
-
-    expect(submit).toHaveBeenCalled()
+      .then(() => {
+        expect(submit).toHaveBeenCalled()
+      })
   })
 
   it('should not swallow errors', () => {
@@ -410,10 +417,11 @@ describe('handleSubmit', () => {
     const asyncValidate = createSpy()
     const props = { startSubmit, stopSubmit, touch, setSubmitFailed, setSubmitSucceeded, values }
 
-    expect(
-      () => handleSubmit(submit, props, true, asyncValidate, [ 'foo', 'baz' ])
-    ).toThrow('spline reticulation failed')
-    expect(submit).toHaveBeenCalled()
+    handleSubmit(submit, props, true, asyncValidate, [ 'foo', 'baz' ])
+      .catch(error => {
+        expect(error).toBe(new Error('spline reticulation failed'))
+        expect(submit).toHaveBeenCalled()
+      })
   })
 
   it('should not swallow async errors', () => {

--- a/src/__tests__/reduxForm.spec.js
+++ b/src/__tests__/reduxForm.spec.js
@@ -1578,33 +1578,34 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
 
       expect(stub.submit).toBeA('function')
       stub.submit()
-
-      expect(store.getState()).toEqualMap({
-        form: {
-          testForm: {
-            registeredFields: [
-              { name: 'username', type: 'Field' },
-              { name: 'password', type: 'Field' }
-            ],
-            anyTouched: true,
-            fields: {
-              username: {
-                touched: true
-              },
-              password: {
-                touched: true
+        .then(() => {
+          expect(store.getState()).toEqualMap({
+            form: {
+              testForm: {
+                registeredFields: [
+                  { name: 'username', type: 'Field' },
+                  { name: 'password', type: 'Field' }
+                ],
+                anyTouched: true,
+                fields: {
+                  username: {
+                    touched: true
+                  },
+                  password: {
+                    touched: true
+                  }
+                },
+                submitSucceeded: true
               }
-            },
-            submitSucceeded: true
-          }
-        }
-      })
-
-      expect(username.calls.length).toBe(2)
-      expect(username.calls[ 1 ].arguments[ 0 ].meta.touched).toBe(true)
-
-      expect(password.calls.length).toBe(2)
-      expect(password.calls[ 1 ].arguments[ 0 ].meta.touched).toBe(true)
+            }
+          })
+  
+          expect(username.calls.length).toBe(2)
+          expect(username.calls[ 1 ].arguments[ 0 ].meta.touched).toBe(true)
+  
+          expect(password.calls.length).toBe(2)
+          expect(password.calls[ 1 ].arguments[ 0 ].meta.touched).toBe(true)
+        })
     })
 
     it('should call onSubmitFail with errors if sync submit fails by throwing SubmissionError', () => {
@@ -1641,12 +1642,13 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
 
       expect(onSubmitFail).toNotHaveBeenCalled()
 
-      const caught = stub.submit()
-
-      expect(onSubmitFail)
-        .toHaveBeenCalled()
-        .toHaveBeenCalledWith(errors, store.dispatch)
-      expect(caught).toBe(errors)
+      stub.submit()
+        .then(caught => {
+          expect(onSubmitFail)
+            .toHaveBeenCalled()
+            .toHaveBeenCalledWith(errors, store.dispatch)
+          expect(caught).toBe(errors)
+        })
     })
 
     it('should call onSubmitFail with undefined if sync submit fails by throwing other error', () => {
@@ -1682,12 +1684,13 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
 
       expect(onSubmitFail).toNotHaveBeenCalled()
 
-      const caught = stub.submit()
-
-      expect(onSubmitFail)
-        .toHaveBeenCalled()
-        .toHaveBeenCalledWith(undefined, store.dispatch)
-      expect(caught).toNotExist()
+      stub.submit()
+        .then(caught => {
+          expect(onSubmitFail)
+            .toHaveBeenCalled()
+            .toHaveBeenCalledWith(undefined, store.dispatch)
+          expect(caught).toNotExist()
+        })
     })
 
     it('should call onSubmitFail if async submit fails', () => {
@@ -1726,7 +1729,9 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
         .then(caught => {
           expect(onSubmitFail)
             .toHaveBeenCalled()
-            .toHaveBeenCalledWith(errors, store.dispatch)
+          expect(onSubmitFail.calls[0].arguments[0]).toEqual(errors)
+          expect(onSubmitFail.calls[0].arguments[1]).toEqual(store.dispatch)
+          expect(onSubmitFail.calls[0].arguments[2]).toBeA(SubmissionError)
           expect(caught).toBe(errors)
         })
     })
@@ -1766,12 +1771,14 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(onSubmitFail).toNotHaveBeenCalled()
       expect(onSubmit).toNotHaveBeenCalled()
 
-      const result = stub.submit()
-      expect(onSubmit).toNotHaveBeenCalled()
-      expect(onSubmitFail)
-        .toHaveBeenCalled()
-        .toHaveBeenCalledWith(errors, store.dispatch)
-      expect(result).toEqual(errors)
+      stub.submit()
+        .then(result => {
+          expect(onSubmit).toNotHaveBeenCalled()
+          expect(onSubmitFail)
+            .toHaveBeenCalled()
+            .toHaveBeenCalledWith(errors, store.dispatch)
+          expect(result).toEqual(errors)
+        })
     })
 
     it('should call onSubmitFail if async validation prevents submit', () => {
@@ -1814,7 +1821,9 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
           expect(onSubmit).toNotHaveBeenCalled()
           expect(onSubmitFail)
             .toHaveBeenCalled()
-            .toHaveBeenCalledWith(errors, store.dispatch)
+          expect(onSubmitFail.calls[0].arguments[0]).toEqual(errors)
+          expect(onSubmitFail.calls[0].arguments[1]).toEqual(store.dispatch)
+          expect(onSubmitFail.calls[0].arguments[2]).toBeA(SubmissionError)
           expect(error).toBe(errors)
         })
     })
@@ -1851,12 +1860,13 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
 
       expect(onSubmitSuccess).toNotHaveBeenCalled()
 
-      const returned = stub.submit()
-
-      expect(onSubmitSuccess)
-        .toHaveBeenCalled()
-        .toHaveBeenCalledWith(result, store.dispatch)
-      expect(returned).toBe(result)
+      stub.submit()
+        .then(returned => {
+          expect(onSubmitSuccess)
+            .toHaveBeenCalled()
+            .toHaveBeenCalledWith(result, store.dispatch)
+          expect(returned).toBe(result)
+        })
     })
 
     it('should call onSubmitSuccess if async submit succeeds', () => {
@@ -1930,9 +1940,10 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
 
       expect(stub.submit).toBeA('function')
 
-      const caught = stub.submit()
-
-      expect(caught).toBe(errors)
+      stub.submit()
+        .catch(caught => {
+          expect(caught).toBe(errors)
+        })
     })
 
     it('should submit when submit() called and onSubmit provided as config param', () => {
@@ -1983,9 +1994,13 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       })
       const submit = createSpy()
 
+      let submitPromise = null;
       const Form = ({ handleSubmit }) =>
         (
-          <form onSubmit={handleSubmit(submit)}>
+          <form onSubmit={function () {
+            submitPromise = handleSubmit(submit).apply(this, arguments)
+            return submitPromise
+          }}>
             <Field name="bar" component="textarea"/>
             <input type="submit" value="Submit"/>
           </form>
@@ -2007,7 +2022,9 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
 
       TestUtils.Simulate.submit(form)
 
-      expect(submit).toHaveBeenCalled()
+      submitPromise.then(() => {
+        expect(submit).toHaveBeenCalled()
+      })
     })
 
     it('should be fine if form is not yet in Redux store', () => {
@@ -2137,9 +2154,10 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
 
       expect(stub.submit).toBeA('function')
       stub.submit()
-
-      expect(asyncValidate).toHaveBeenCalled()
-      expect(asyncValidate.calls[ 0 ].arguments[ 0 ]).toEqualMap({ bar: 'foo' })
+        .then(() => {
+          expect(asyncValidate).toHaveBeenCalled()
+          expect(asyncValidate.calls[ 0 ].arguments[ 0 ]).toEqualMap({ bar: 'foo' })
+        })
     })
 
     it('should not call async validation more than once if submit is clicked fast when handleSubmit receives an event', () => {
@@ -2157,8 +2175,12 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
         expect(values).toEqualMap({ bar: 'foo' })
       }
 
+      let submitPromise = null
       const Form = ({ handleSubmit }) => (
-        <form onSubmit={handleSubmit}>
+        <form onSubmit={function () {
+          submitPromise = handleSubmit.apply(this, arguments) || submitPromise
+          return submitPromise
+        }}>
           <Field name="bar" component={input} type="text"/>
         </form>
       )
@@ -2188,9 +2210,12 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       TestUtils.Simulate.submit(form)
       TestUtils.Simulate.submit(form)
 
-      expect(asyncValidate).toHaveBeenCalled()
-      expect(asyncValidate.calls.length).toBe(1)
-      expect(asyncValidate.calls[ 0 ].arguments[ 0 ]).toEqualMap({ bar: 'foo' })
+      submitPromise
+        .then(() => {
+          expect(asyncValidate).toHaveBeenCalled()
+          expect(asyncValidate.calls.length).toBe(1)
+          expect(asyncValidate.calls[ 0 ].arguments[ 0 ]).toEqualMap({ bar: 'foo' })
+        })
     })
 
     it('should return rejected promise when submit is rejected', () => {
@@ -2241,8 +2266,12 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
         expect(values).toEqualMap({ bar: 'foo' })
       }
 
+      let submitPromise = null
       const Form = ({ handleSubmit }) => (
-        <form onSubmit={handleSubmit(onSubmit)}>
+        <form onSubmit={function () {
+          submitPromise = handleSubmit(onSubmit).apply(this, arguments) || submitPromise
+          return submitPromise
+        }}>
           <Field name="bar" component={input} type="text"/>
         </form>
       )
@@ -2271,9 +2300,12 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       TestUtils.Simulate.submit(form)
       TestUtils.Simulate.submit(form)
 
-      expect(asyncValidate).toHaveBeenCalled()
-      expect(asyncValidate.calls.length).toBe(1)
-      expect(asyncValidate.calls[ 0 ].arguments[ 0 ]).toEqualMap({ bar: 'foo' })
+      submitPromise
+        .then(() => {
+          expect(asyncValidate).toHaveBeenCalled()
+          expect(asyncValidate.calls.length).toBe(1)
+          expect(asyncValidate.calls[ 0 ].arguments[ 0 ]).toEqualMap({ bar: 'foo' })
+        })
     })
 
     it('should reset when reset() called', () => {
@@ -2865,11 +2897,17 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       const renderInput = createSpy(props => <input {...props.input}/>).andCallThrough()
       const renderForm = createSpy()
       const onSubmit = createSpy()
+
+      let submitPromise = null
+      
       class Form extends Component {
         render() {
           renderForm(this.props)
           return (
-            <form onSubmit={this.props.handleSubmit}>
+            <form onSubmit={() => {
+              submitPromise = this.props.handleSubmit.apply(this, arguments)
+              return submitPromise
+            }}>
               <Field name="myField" component={renderInput}/>
             </form>
           )
@@ -2901,38 +2939,47 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       // test submit
       expect(onSubmit).toNotHaveBeenCalled()
       TestUtils.Simulate.submit(form)
-      expect(onSubmit).toHaveBeenCalled()
-      expect(onSubmit.calls.length).toBe(1)
-      expect(onSubmit.calls[0].arguments[0]).toEqualMap({})
-      expect(renderInput.calls.length).toBe(2)  // touched by submit
+      submitPromise
+        .then(() => {
+          expect(onSubmit).toHaveBeenCalled()
+          expect(onSubmit.calls.length).toBe(1)
+          expect(onSubmit.calls[0].arguments[0]).toEqualMap({})
+          expect(renderInput.calls.length).toBe(2)  // touched by submit
 
-      // autofill field
-      renderForm.calls[0].arguments[0].autofill('myField', 'autofilled value')
+          // autofill field
+          renderForm.calls[0].arguments[0].autofill('myField', 'autofilled value')
 
-      // check field
-      expect(renderInput).toHaveBeenCalled()
-      expect(renderInput.calls.length).toBe(3)
-      expect(renderInput.calls[2].arguments[0].input.value).toBe('autofilled value')
-      expect(renderInput.calls[2].arguments[0].meta.autofilled).toBe(true)
+          // check field
+          expect(renderInput).toHaveBeenCalled()
+          expect(renderInput.calls.length).toBe(3)
+          expect(renderInput.calls[2].arguments[0].input.value).toBe('autofilled value')
+          expect(renderInput.calls[2].arguments[0].meta.autofilled).toBe(true)
 
-      // test submitting autofilled value
-      TestUtils.Simulate.submit(form)
-      expect(onSubmit.calls.length).toBe(2)
-      expect(onSubmit.calls[1].arguments[0]).toEqualMap({ myField: 'autofilled value' })
+          // test submitting autofilled value
+          TestUtils.Simulate.submit(form)
+          return submitPromise
+        })
+        .then(() => {
+          expect(onSubmit.calls.length).toBe(2)
+          expect(onSubmit.calls[1].arguments[0]).toEqualMap({ myField: 'autofilled value' })
 
-      // user edits field
-      renderInput.calls[1].arguments[0].input.onChange('user value')
+          // user edits field
+          renderInput.calls[1].arguments[0].input.onChange('user value')
 
-      // check field
-      expect(renderInput).toHaveBeenCalled()
-      expect(renderInput.calls.length).toBe(4)
-      expect(renderInput.calls[3].arguments[0].input.value).toBe('user value')
-      expect(renderInput.calls[3].arguments[0].meta.autofilled).toBe(false)
+          // check field
+          expect(renderInput).toHaveBeenCalled()
+          expect(renderInput.calls.length).toBe(4)
+          expect(renderInput.calls[3].arguments[0].input.value).toBe('user value')
+          expect(renderInput.calls[3].arguments[0].meta.autofilled).toBe(false)
 
-      // why not test submitting again?
-      TestUtils.Simulate.submit(form)
-      expect(onSubmit.calls.length).toBe(3)
-      expect(onSubmit.calls[2].arguments[0]).toEqualMap({ myField: 'user value' })
+          // why not test submitting again?
+          TestUtils.Simulate.submit(form)
+          return submitPromise
+        })
+        .then(() => {
+          expect(onSubmit.calls.length).toBe(3)
+          expect(onSubmit.calls[2].arguments[0]).toEqualMap({ myField: 'user value' })
+        })
     })
 
     it('should not reinitialize values on remount if destroyOnMount is false', () => {
@@ -3176,30 +3223,28 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       // unmount form
       const stub = TestUtils.findRenderedComponentWithType(dom, Decorated)
       stub.submit()
-
-
-      return resolvedProm.then(() => {
-        // form state not destroyed (just fields unregistered)
-        expect(store.getState()).toEqualMap({
-          form: {
-            testForm: {
-              anyTouched: true,
-              fields: {
-                foo: {
-                  touched: true
-                }
-              },
-              registeredFields: [
-                {
-                  name: 'foo',
-                  type: 'Field'
-                }
-              ],
-              submitSucceeded: true
+        .then(() => {
+          // form state not destroyed (just fields unregistered)
+          expect(store.getState()).toEqualMap({
+            form: {
+              testForm: {
+                anyTouched: true,
+                fields: {
+                  foo: {
+                    touched: true
+                  }
+                },
+                registeredFields: [
+                  {
+                    name: 'foo',
+                    type: 'Field'
+                  }
+                ],
+                submitSucceeded: true
+              }
             }
-          }
+          })
         })
-      })
     })
 
     it('startSubmit in onSubmit sync', () => {
@@ -3231,28 +3276,29 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       // unmount form
       const stub = TestUtils.findRenderedComponentWithType(dom, Decorated)
       stub.submit()
-
-      // form state not destroyed (just fields unregistered)
-      expect(store.getState()).toEqualMap({
-        form: {
-          testForm: {
-            anyTouched: true,
-            fields: {
-              foo: {
-                touched: true
+        .then(() => {
+          // form state not destroyed (just fields unregistered)
+          expect(store.getState()).toEqualMap({
+            form: {
+              testForm: {
+                anyTouched: true,
+                fields: {
+                  foo: {
+                    touched: true
+                  }
+                },
+                registeredFields: [
+                  {
+                    name: 'foo',
+                    type: 'Field'
+                  }
+                ],
+                submitting: true,
+                submitSucceeded: true
               }
-            },
-            registeredFields: [
-              {
-                name: 'foo',
-                type: 'Field'
-              }
-            ],
-            submitting: true,
-            submitSucceeded: true
-          }
-        }
-      })
+            }
+          })
+        })
     })
   })
 }

--- a/src/__tests__/reduxForm.spec.js
+++ b/src/__tests__/reduxForm.spec.js
@@ -1994,7 +1994,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       })
       const submit = createSpy()
 
-      let submitPromise = null;
+      let submitPromise = null
       const Form = ({ handleSubmit }) =>
         (
           <form onSubmit={function () {

--- a/src/reduxForm.js
+++ b/src/reduxForm.js
@@ -3,7 +3,6 @@ import hoistStatics from 'hoist-non-react-statics'
 import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
 import { mapValues } from 'lodash'
-import isPromise from 'is-promise'
 import getDisplayName from './util/getDisplayName'
 import * as importedActions from './actions'
 import handleSubmit from './handleSubmit'
@@ -291,9 +290,6 @@ const createReduxForm =
           }
 
           listenToSubmit(promise) {
-            if (!isPromise(promise)) {
-              return promise
-            }
             this.submitPromise = promise
             return promise.then(this.submitCompleted)
           }


### PR DESCRIPTION
This PR is much bigger than I expected initially. When I started to look at handleSubmit it was hard for me to understand and had a lot of duplicated code, so I decided to update it. There are still some weird parts, I will highlight them inline.

This is a breaking change in the sense that ReduxForm.submit now always returns a Promise. The docs already said that is the case, but that was not true:
> submit() : Promise
> Submits the form. [You'd never have guessed that, right?] Returns a promise that will be resolved when the form is submitted successfully, or rejected if the submission fails.

I would like to make some more improvements to handleSubmit, but for now I tried for it to be as close to the previous behaviour as before.

I understand if you will not merge this in, I can rework it to simply add the 3rd param.