### PR TITLE
remove errors caused by using {...rest} and add DateTimePicker example

### DIFF
--- a/examples/react-widgets/package.json
+++ b/examples/react-widgets/package.json
@@ -12,6 +12,7 @@
     "html-loader": "^0.4.3",
     "json-loader": "^0.5.4",
     "markdown-loader": "^0.1.7",
+    "moment": "^2.16.0",
     "raw-loader": "^0.5.1",
     "react": "^15.3.1",
     "react-dom": "^15.3.1",

--- a/examples/react-widgets/src/ReactWidgets.md
+++ b/examples/react-widgets/src/ReactWidgets.md
@@ -10,7 +10,9 @@ Very few modifications are needed. All of these can be done as props to the `Fie
   * Needs value to be an array, so default it to `[]`
 * `SelectList`
   * Needs `onBlur` to be rewritten ignoring the parameter
-  
+* `DateTimePicker`
+  * Needs value to be a date or null.
+
 For more information, see the `react-widgets` docs.
 
 The delay between when you click "Submit" and when the alert dialog pops up is intentional,

--- a/examples/react-widgets/src/ReactWidgetsForm.js
+++ b/examples/react-widgets/src/ReactWidgetsForm.js
@@ -3,23 +3,46 @@ import { Field, reduxForm } from 'redux-form'
 import DropdownList from 'react-widgets/lib/DropdownList'
 import SelectList from 'react-widgets/lib/SelectList'
 import Multiselect from 'react-widgets/lib/Multiselect'
+import DateTimePicker from 'react-widgets/lib/DateTimePicker'
+import moment from 'moment'
+import momentLocaliser from 'react-widgets/lib/localizers/moment'
+
 import 'react-widgets/dist/css/react-widgets.css'
+
+momentLocaliser(moment)
 
 const colors = [ { color: 'Red', value: 'ff0000' },
   { color: 'Green', value: '00ff00' },
   { color: 'Blue', value: '0000ff' } ]
 
-const renderDropdownList = ({ input, ...rest }) =>
-  <DropdownList {...input} {...rest}/>
+const renderDropdownList = ({ input, data, valueField, textField }) =>
+  <DropdownList {...input}
+    data={data}
+    valueField={valueField}
+    textField={textField}
+    onChange={input.onChange} />
 
-const renderMultiselect = ({ input, ...rest }) =>
+const renderMultiselect = ({ input, data, valueField, textField }) =>
   <Multiselect {...input}
     onBlur={() => input.onBlur()}
     value={input.value || []} // requires value to be an array
-    {...rest}/>
+    data={data}
+    valueField={valueField}
+    textField={textField}
+  />
 
-const renderSelectList = ({ input, ...rest }) =>
-  <SelectList {...input} onBlur={() => input.onBlur()} {...rest}/>
+const renderSelectList = ({ input, data }) =>
+  <SelectList {...input}
+    onBlur={() => input.onBlur()}
+    data={data} />
+
+const renderDateTimePicker = ({ input: { onChange, value }, showTime }) =>
+  <DateTimePicker
+    onChange={onChange}
+    format="DD MMM YYYY"
+    time={showTime}
+    value={value && new Date(value) || null}
+  />
 
 let ReactWidgetsForm = props => {
   const { handleSubmit, pristine, reset, submitting } = props
@@ -47,6 +70,14 @@ let ReactWidgetsForm = props => {
           name="sex"
           component={renderSelectList}
           data={[ 'male', 'female' ]}/>
+      </div>
+      <div>
+        <label>DOB</label>
+        <Field
+          name="dob"
+          showTime={false}
+          component={renderDateTimePicker}
+        />
       </div>
       <div>
         <button type="submit" disabled={pristine || submitting}>Submit</button>


### PR DESCRIPTION
The react-widgets example was erroring when using `{...rest}` like this:
```
const renderMultiselect = ({ input, ...rest }) =>
  <Multiselect {...input}
    onBlur={() => input.onBlur()}
    value={input.value || []} // requires value to be an array
    {...rest}/>
```

With this error:

> warning.js:36 Warning: Unknown prop `meta` on <div> tag. Remove this prop from the element. For details

I removed rest and used explicit parameters.

I am not convinced this is the best way, the other way would be to do something like this:
```
const colors = [ { color: 'Red', value: 'ff0000' },
  { color: 'Green', value: '00ff00' },
  { color: 'Blue', value: '0000ff' } ]

/* eslint-disable no-unused-vars */
const renderDropdownList = ({ input, meta, ...rest }) =>
  <DropdownList {...input} {...rest} />

const renderMultiselect = ({ input, meta, ...rest }) =>{
  const value = input.value

  delete input.value

  return (
    <Multiselect {...input}
                 {...rest}
                 value={value || null}/>
  )
}

const renderSelectList = ({ input, meta, ...rest }) =>
  <SelectList {...input} {...rest} />
```

But if you were seeing these examples for the first time, I don't like the `renderMultiselect` above even though this what I used in my own project.

the eslint-disable comment is also confusing so I am not sold on this either.

Any feedback appreciated.

I also added a `DateTimePicker` example also:

```
const renderDateTimePicker = ({ input: { onChange, value }, showTime }) =>
  <DateTimePicker
    onChange={onChange}
    format="DD MMM YYYY"
    time={showTime}
    value={value && new Date(value) || null}
  />

```