### PR TITLE
Fix arrays of object fields (v5)

### DIFF
--- a/src/__tests__/readField.spec.js
+++ b/src/__tests__/readField.spec.js
@@ -708,6 +708,62 @@ describe('readField', () => {
     });
   });
 
+  it('should change complex field instances when updating a mixed field', () => {
+    const fields = {};
+    readField({
+      pig: {
+        foo: [
+          {
+            dog: {
+              value: 'hello'
+            }
+          }
+        ]
+      }
+    }, 'pig.foo[].dog', undefined, fields, {}, undefined, false, defaultProps);
+    expectField({
+      field: fields.pig.foo[0].dog,
+      name: 'pig.foo[0].dog',
+      value: 'hello',
+      dirty: true,
+      touched: false,
+      visited: false,
+      error: undefined,
+      initialValue: '',
+      readonly: false
+    });
+    const beforeArrayField = fields.pig.foo;
+    const beforeObjectField = fields.pig.foo[0];
+
+    readField({
+      pig: {
+        foo: [
+          {
+            dog: {
+              value: 'goodbye'
+            }
+          }
+        ]
+      }
+    }, 'pig.foo[].dog', undefined, fields, {}, undefined, false, defaultProps);
+    expectField({
+      field: fields.pig.foo[0].dog,
+      name: 'pig.foo[0].dog',
+      value: 'goodbye',
+      dirty: true,
+      touched: false,
+      visited: false,
+      error: undefined,
+      initialValue: '',
+      readonly: false
+    });
+    const afterArrayField = fields.pig.foo;
+    const afterObjectField = fields.pig.foo[0];
+
+    expect(beforeArrayField).toNotBe(afterArrayField); // field instance should be different
+    expect(beforeObjectField).toNotBe(afterObjectField); // field instance should be different
+  });
+
   it('should read an array field with an initial value', () => {
     const fields = {};
     readField({

--- a/src/readField.js
+++ b/src/readField.js
@@ -80,10 +80,14 @@ const readField = (state, fieldName, pathToHere = '', fields, syncErrors, asyncV
       const nextPath = `${pathToHere}${key}[${index}]${rest ? '.' : ''}`;
       const nextPrefix = `${prefix}${key}[]${rest ? '.' : ''}`;
 
-      const result = readField(fieldState, rest, nextPath, dest, syncErrors,
+      let result = readField(fieldState, rest, nextPath, dest, syncErrors,
         asyncValidate, isReactNative, props, callback, nextPrefix);
-      if (!rest && fieldArray[index] !== result) {
-        // if nothing after [] in field name, assign directly to array
+      if (fieldArray[index] !== result) {
+        if (rest) {
+          // if something's after [] in field name, the array item is an object field
+          // we need it to compare !== to the original (so react re-renders appropriately)
+          result = {...dest};
+        }
         fieldArray[index] = result;
         changed = true;
       }


### PR DESCRIPTION
Yet another instance of issue #375.

Specifically, any array that contained non-immediate descendants (e.g.
arrayField[].deepObjectField, or arrayField[][], but not plain old
arrayField[]) would remain the same instance if any of its descendant
fields were updated but no items were added to or removed from the
top-level array.

The issue was that we were only making a fresh copy of the array (that's
`changed = true`) in the case where it a raw-value array item was
changed, but not in the general case.