### PR TITLE
a Fields component within FormSection should not need to know the FormSection name

### DIFF
--- a/src/ConnectedFields.js
+++ b/src/ConnectedFields.js
@@ -49,7 +49,7 @@ const createConnectedFields = ({ deepEqual, getIn }) => {
 
     render() {
       const { component, withRef, _fields, _reduxForm, ...rest } = this.props
-      const { asyncValidate, blur, change, focus } = _reduxForm
+      const { asyncValidate, blur, change, focus, sectionPrefix } = _reduxForm
       const { custom, ...props } = Object.keys(_fields).reduce((accumulator, name) => {
         const connectedProps = _fields[ name ]
         const { custom, ...fieldProps } = createFieldProps(getIn,
@@ -64,7 +64,8 @@ const createConnectedFields = ({ deepEqual, getIn }) => {
           asyncValidate
         )
         accumulator.custom = custom
-        return plain.setIn(accumulator, name, fieldProps)
+        const fieldName = sectionPrefix ? name.replace(`${sectionPrefix}.`, '') : name
+        return plain.setIn(accumulator, fieldName, fieldProps)
       }, {})
       if (withRef) {
         props.ref = 'renderedComponent'


### PR DESCRIPTION
This fixes #2148,

Currently a `Fields` component within a `FormSection` needs to know what the FormSection prefix is in order to access the fields inside the `Fields` component. This PR makes it so that the form sectionPrefix doesn't carry over into the `Fields` component props. Also included is a test case.

```javascript
<FormSection name='parent'>
  <Fields name={['foo', 'bar']} component={renderFields} />
</FormSection>

...

// current
const renderFields = ({parent: {foo, bar}}) => (
  <div>
    <input {...foo} />
    <input {...bar} /> 
  </div>
)

// proposed
const renderFields = ({foo, bar}) => (
  <div>
    <input {...foo} />
    <input {...bar} /> 
  </div>
)

```