### PR TITLE
Rewrite setInPath for 2.5x speed improvement.

### DIFF
--- a/src/structure/plain/setIn.js
+++ b/src/structure/plain/setIn.js
@@ -1,26 +1,31 @@
 import { toPath } from 'lodash'
 
-const setInWithPath = (state, value, first, ...rest) => {
-  if (first === undefined) {
+const setInWithPath = (state, value, path, pathIndex) => {
+  if (pathIndex >= path.length) {
     return value
   }
-  const next = setInWithPath(state && state[first], value, ...rest)
+
+  const first = path[pathIndex]
+  const next = setInWithPath(state && state[first], value, path, pathIndex + 1)
+
   if (!state) {
     const initialized = isNaN(first) ? {} : []
     initialized[first] = next
     return initialized
   }
+
   if (Array.isArray(state)) {
-    const copy = [ ...state ]
+    const copy = state.slice()
     copy[first] = next
     return copy
   }
+
   return {
     ...state,
     [first]: next
   }
 }
 
-const setIn = (state, field, value) => setInWithPath(state, value, ...toPath(field))
+const setIn = (state, field, value) => setInWithPath(state, value, toPath(field), 0)
 
 export default setIn


### PR DESCRIPTION
See https://jsperf.com/plainsetin for benchmark. Makes a huge difference in real world due to much less stress on GC.