### PR TITLE
[FieldArray] Pass reference to the `fields` prop in map, forEach, and reduce callbacks

### DIFF
--- a/docs/api/FieldArray.md
+++ b/docs/api/FieldArray.md
@@ -196,3 +196,35 @@ be called three times, with `'foo.bar[0]'`, `'foo.bar[1]'`, and `'foo.bar[2]'`.
 #### `index : Number`
 
 > The index of the item in the array.
+
+#### `fields : Object`
+
+> A reference to the [`fields` prop](#fields-props) to allow for the access to `swap`, `remove`,
+`pop`, etc., without requiring closure scoping.
+```javascript
+const renderSubFields = (member, index, fields) => (
+    <li key={index}>
+      <button
+        type="button"
+        title="Remove Member"
+        onClick={() => fields.remove(index)}/>
+      <h4>Member #{index + 1}</h4>
+      <Field
+        name={`${member}.firstName`}
+        type="text"
+        component={renderField}
+        label="First Name"/>
+      <Field
+        name={`${member}.lastName`}
+        type="text"
+        component={renderField}
+        label="Last Name"/>
+    </li>
+)
+const renderMembers = ({ fields }) => (
+  <ul>
+    <button type="button" onClick={() => fields.push({})}>Add Member</button>
+    {fields.map(renderSubFields)}
+  </ul>
+)
+```

--- a/src/__tests__/FieldArray.spec.js
+++ b/src/__tests__/FieldArray.spec.js
@@ -136,9 +136,9 @@ const describeFieldArray = (name, structure, combineReducers, expect) => {
       props.fields.forEach(iterate)
       expect(iterate).toHaveBeenCalled()
       expect(iterate.calls.length).toBe(3)
-      expect(iterate.calls[ 0 ].arguments).toEqual([ 'foo[0]', 0 ])
-      expect(iterate.calls[ 1 ].arguments).toEqual([ 'foo[1]', 1 ])
-      expect(iterate.calls[ 2 ].arguments).toEqual([ 'foo[2]', 2 ])
+      expect(iterate.calls[ 0 ].arguments).toEqual([ 'foo[0]', 0, props.fields ])
+      expect(iterate.calls[ 1 ].arguments).toEqual([ 'foo[1]', 1, props.fields ])
+      expect(iterate.calls[ 2 ].arguments).toEqual([ 'foo[2]', 2, props.fields ])
     })
 
     it('should provide map', () => {
@@ -152,9 +152,9 @@ const describeFieldArray = (name, structure, combineReducers, expect) => {
       props.fields.map(iterate)
       expect(iterate).toHaveBeenCalled()
       expect(iterate.calls.length).toBe(3)
-      expect(iterate.calls[ 0 ].arguments).toEqual([ 'foo[0]', 0 ])
-      expect(iterate.calls[ 1 ].arguments).toEqual([ 'foo[1]', 1 ])
-      expect(iterate.calls[ 2 ].arguments).toEqual([ 'foo[2]', 2 ])
+      expect(iterate.calls[ 0 ].arguments).toEqual([ 'foo[0]', 0, props.fields ])
+      expect(iterate.calls[ 1 ].arguments).toEqual([ 'foo[1]', 1, props.fields ])
+      expect(iterate.calls[ 2 ].arguments).toEqual([ 'foo[2]', 2, props.fields ])
     })
 
     it('should provide insert', () => {

--- a/src/__tests__/createFieldArrayProps.spec.js
+++ b/src/__tests__/createFieldArrayProps.spec.js
@@ -205,9 +205,9 @@ const describeCreateFieldProps = (name, structure, expect) => {
       result.fields.forEach(callback)
       expect(callback).toHaveBeenCalled()
       expect(callback.calls.length).toBe(3)
-      expect(callback.calls[ 0 ].arguments).toEqual([ 'foo[0]', 0 ])
-      expect(callback.calls[ 1 ].arguments).toEqual([ 'foo[1]', 1 ])
-      expect(callback.calls[ 2 ].arguments).toEqual([ 'foo[2]', 2 ])
+      expect(callback.calls[ 0 ].arguments).toEqual([ 'foo[0]', 0, result.fields ])
+      expect(callback.calls[ 1 ].arguments).toEqual([ 'foo[1]', 1, result.fields ])
+      expect(callback.calls[ 2 ].arguments).toEqual([ 'foo[2]', 2, result.fields ])
     })
 
     it('should provide map', () => {
@@ -225,9 +225,9 @@ const describeCreateFieldProps = (name, structure, expect) => {
       expect(getIn(mapResult, 2)).toEqual({ whatever: true, name: 'foo[2]' })
       expect(callback).toHaveBeenCalled()
       expect(callback.calls.length).toBe(3)
-      expect(callback.calls[ 0 ].arguments).toEqual([ 'foo[0]', 0 ])
-      expect(callback.calls[ 1 ].arguments).toEqual([ 'foo[1]', 1 ])
-      expect(callback.calls[ 2 ].arguments).toEqual([ 'foo[2]', 2 ])
+      expect(callback.calls[ 0 ].arguments).toEqual([ 'foo[0]', 0, result.fields ])
+      expect(callback.calls[ 1 ].arguments).toEqual([ 'foo[1]', 1, result.fields ])
+      expect(callback.calls[ 2 ].arguments).toEqual([ 'foo[2]', 2, result.fields ])
     })
 
     it('should provide reduce', () => {
@@ -248,14 +248,14 @@ const describeCreateFieldProps = (name, structure, expect) => {
       expect(reduceResult['foo[2]']).toEqual({ whatever: true, name: 'foo[2]' })
       expect(callback).toHaveBeenCalled()
       expect(callback.calls.length).toBe(3)
-      expect(callback.calls[ 0 ].arguments).toEqual([ {}, 'foo[0]', 0 ])
+      expect(callback.calls[ 0 ].arguments).toEqual([ {}, 'foo[0]', 0, result.fields ])
       expect(callback.calls[ 1 ].arguments).toEqual([ {
         'foo[0]': { whatever: true, name: 'foo[0]' }
-      }, 'foo[1]', 1 ])
+      }, 'foo[1]', 1, result.fields ])
       expect(callback.calls[ 2 ].arguments).toEqual([ {
         'foo[0]': { whatever: true, name: 'foo[0]' },
         'foo[1]': { whatever: true, name: 'foo[1]' }
-      }, 'foo[2]', 2 ])
+      }, 'foo[2]', 2, result.fields ])
     })
 
     it('should provide reduce when no value', () => {

--- a/src/createFieldArrayProps.js
+++ b/src/createFieldArrayProps.js
@@ -8,13 +8,13 @@ const createFieldArrayProps = (getIn, name,
   }) => {
   const error = syncError || asyncError || submitError
   const warning = syncWarning
-  return {
+  const finalProps = {
     fields: {
       _isFieldArray: true,
-      forEach: callback => (value || []).forEach((item, index) => callback(`${name}[${index}]`, index)),
+      forEach: callback => (value || []).forEach((item, index) => callback(`${name}[${index}]`, index, finalProps.fields)),
       insert: arrayInsert,
       length,
-      map: callback => (value || []).map((item, index) => callback(`${name}[${index}]`, index)),
+      map: callback => (value || []).map((item, index) => callback(`${name}[${index}]`, index, finalProps.fields)),
       move: arrayMove,
       name,
       pop: () => {
@@ -23,7 +23,7 @@ const createFieldArrayProps = (getIn, name,
       },
       push: arrayPush,
       reduce: (callback, initial) => (value || [])
-        .reduce((accumulator, item, index) => callback(accumulator, `${name}[${index}]`, index), initial),
+        .reduce((accumulator, item, index) => callback(accumulator, `${name}[${index}]`, index, finalProps.fields), initial),
       remove: arrayRemove,
       removeAll: arrayRemoveAll,
       shift: () => {
@@ -46,6 +46,7 @@ const createFieldArrayProps = (getIn, name,
     ...props,
     ...rest
   }
+  return finalProps
 }
 
 export default createFieldArrayProps


### PR DESCRIPTION
It's probably not well know but creating functions inline within a render call is a performance hit since new functions are created on each re-render. This in turns clutters our memory space and makes the GC work unnecessarily.

To avoid this it would be helpful if `fields.map`, `fields.forEach`, and `fields.reduce` passed along a `fields` reference to the callback provided. This allows us to create a callback method that can be passed directly the `fields.map` while still allowing access to `swap`, `remove`, `pop`, etc.

Example:
```javascript
 const renderSubFields = (member, index, fields) => (
     <li key={index}>
       <button
         type="button"
         title="Remove Member"
         onClick={() => fields.remove(index)}/>
       <h4>Member #{index + 1}</h4>
       <Field
         name={`${member}.firstName`}
         type="text"
         component={renderField}
         label="First Name"/>
       <Field
         name={`${member}.lastName`}
         type="text"
         component={renderField}
         label="Last Name"/>
     </li>
 )
 const renderMembers = ({ fields }) => (
   <ul>
     <button type="button" onClick={() => fields.push({})}>Add Member</button>
     {fields.map(renderSubFields)}
   </ul>
 )
 ```