### PR TITLE
deepEqual fix so it doesn't treat 1 and 1. as equal

### DIFF
--- a/src/structure/plain/__tests__/deepEqual.spec.js
+++ b/src/structure/plain/__tests__/deepEqual.spec.js
@@ -200,5 +200,12 @@ describe('structure.plain.deepEqual', () => {
       }
     }, true)
   })
+  it('should not treat a number X and a string "X." as equal', function () {
+    testBothWays({
+      a: 1
+    }, {
+      a: '1.'
+    }, false)
+  })  
 })
 

--- a/src/structure/plain/deepEqual.js
+++ b/src/structure/plain/deepEqual.js
@@ -1,7 +1,7 @@
 import { isEqualWith } from 'lodash'
 
 const customizer = (obj, other) => {
-  if (obj == other) return true
+  if (obj === other) return true
   if ((obj == null || obj === '' || obj === false) &&
     (other == null || other === '' || other === false)) return true
 


### PR DESCRIPTION
Hello,

Long story short, in our project we have a NumberField that gets number values (int and float) from the user and keeps them as a valid js number in the store. However, if they want to enter floating points, as soon as they start typing `"."` we can't transfer that to a number (as `Number("10.") === 10)` so essentially user won't be able to type `"."`) so we have to save it in the redux form state as a string `"10." ` (previously it was a number) till user puts some valid decimal points.

But the Field component doesn't re-render because the ConnectedField uses deepEqual in its shouldComponentUpdate and deepEqual is doing `if (obj == other) return true` instead of `if (obj === other) return true` and in JS `("1." == 1) === true`(I thought we've all read the [JavaScript: The Good Parts](http://shop.oreilly.com/product/9780596517748.do) 😛  just joking you guys are awesome).

it's a small change and I've added a new test for it in the `deepEqual.spec.js` and everything passes. It would be great if we could merge this asap.

Thank you very much
