### PR TITLE
Persist errors through the initialize action

### DIFF
--- a/src/__tests__/reducer.initialize.spec.js
+++ b/src/__tests__/reducer.initialize.spec.js
@@ -300,6 +300,45 @@ const describeInitialize = (reducer, expect, { fromJS }) => () => {
         }
       })
   })
+
+  it('should persist errors if they exist', () => {
+    const state = reducer(fromJS({
+      foo: {
+        registeredFields: [
+          { name: 'myField', type: 'Field' }
+        ],
+        values: {
+          myField: 'newValue'
+        },
+        initial: {
+          myField: 'initialValue'
+        },
+        error: 'form wide error',
+        syncErrors: {
+          myField: 'field error'
+        }
+      }
+    }), initialize('foo', { myField: 'newValue' }, true))
+    expect(state)
+      .toEqualMap({
+        foo: {
+          registeredFields: [
+            { name: 'myField', type: 'Field' }
+          ],
+          values: {
+            myField: 'newValue'
+          },
+          initial: {
+            myField: 'newValue'
+          },
+          error: 'form wide error',
+          syncErrors: {
+            myField: 'field error'
+          }
+        }
+      })
+  })
+  
 }
 
 export default describeInitialize

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -194,6 +194,16 @@ const createReducer = structure => {
         result = setIn(result, 'syncWarnings', syncWarnings)
       }
 
+      // persist old errors, they will get recalculated if the new form values are different from the old values
+      const error = getIn(state, 'error')
+      if (error) {
+        result = setIn(result, 'error', error)
+      }
+      const syncErrors = getIn(state, 'syncErrors')
+      if (syncErrors) {
+        result = setIn(result, 'syncErrors', syncErrors)
+      }
+
       const registeredFields = getIn(state, 'registeredFields')
       if (registeredFields) {
         result = setIn(result, 'registeredFields', registeredFields)


### PR DESCRIPTION
Analogous to the fixes for #2142, this fixes an issue with persisting existing errors across initialization.