### PR TITLE
clear this.submitPromise on submit rejection

### DIFF
--- a/src/reduxForm.js
+++ b/src/reduxForm.js
@@ -106,6 +106,7 @@ const createReduxForm =
             this.register = this.register.bind(this)
             this.unregister = this.unregister.bind(this)
             this.submitCompleted = this.submitCompleted.bind(this)
+            this.submitFailed = this.submitFailed.bind(this)
 
             instances++
           }
@@ -308,12 +309,17 @@ const createReduxForm =
             return result
           }
 
+          submitFailed(error) {
+            delete this.submitPromise
+            throw error
+          }
+
           listenToSubmit(promise) {
             if (!isPromise(promise)) {
               return promise
             }
             this.submitPromise = promise
-            return promise.then(this.submitCompleted)
+            return promise.then(this.submitCompleted, this.submitFailed)
           }
 
           submit(submitOrEvent) {


### PR DESCRIPTION
When `asyncValidation` failed during form submit `handleSubmit` returns rejected promise with validation errors. In this case `this.submitPromise` isn't cleared and all subsequent calls to `submit` silently stop working.