### PR TITLE
Allowed submitting when submit errors exist

### DIFF
--- a/src/__tests__/reduxForm.spec.js
+++ b/src/__tests__/reduxForm.spec.js
@@ -39,7 +39,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
   describe(name, () => {
     const makeStore = (initial = {}, logger) => {
       const reducers = { form: reducer }
-      if(logger) {
+      if (logger) {
         reducers.logger = logger
       }
       return createStore(combineReducers(reducers), fromJS({ form: initial }))
@@ -183,7 +183,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
           values: {
             foo: 'bar'
           }
-        }).dirty).toBe(true) 
+        }).dirty).toBe(true)
       })
       it('should be `false` when `state.initial` equals `state.values`', () => {
         expect(propChecker({
@@ -248,17 +248,17 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
         expect(propChecker({}, undefined, {
           validate: () => (errors)
         }).valid).toBe(expectation)
-        
+
         // Check Async Errors
-        expect(propChecker({ 
-          asyncErrors: errors 
+        expect(propChecker({
+          asyncErrors: errors
         }).valid).toBe(expectation)
       }
-      
+
       it('should default to `true`', () => {
         checkValidPropGivenErrors({}, true)
       })
-      
+
       it('should be `false` when `errors` has a `string` property', () => {
         checkValidPropGivenErrors({ foo: 'bar' }, false)
       })
@@ -274,13 +274,13 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       it('should be `true` when `errors` has a `null` property', () => {
         checkValidPropGivenErrors({ foo: null }, true)
       })
-      
+
       it('should be `true` when `errors` has an empty array', () => {
         checkValidPropGivenErrors({
-          myArrayField: [ ]
+          myArrayField: []
         }, true)
       })
-      
+
       it('should be `true` when `errors` has an array with only `undefined` values', () => {
         checkValidPropGivenErrors({
           myArrayField: [
@@ -289,18 +289,18 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
           ]
         }, true)
       })
-      
+
       it('should be `true` when `errors` has an array containing strings', () => {
         // Note: I didn't write the isValid, but my intuition tells me this seems incorrect. – ncphillips
         checkValidPropGivenErrors({
           myArrayField: [ 'baz' ]
         }, true)
       })
-      
+
     })
 
     describe('invalid prop', () => {
-      
+
       const checkInvalidPropGivenErrors = (errors, expectation) => {
         // Check Sync Errors
         expect(propChecker({}, undefined, {
@@ -312,29 +312,29 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
           asyncErrors: errors
         }).invalid).toBe(expectation)
       }
-      
+
       it('should default to `false`', () => {
         checkInvalidPropGivenErrors({}, false)
       })
-      
+
       it('should be `true` when errors has a `string` propertry', () => {
         checkInvalidPropGivenErrors({ foo: 'sync error' }, true)
       })
-       
+
       it('should be `true` when errors has a `number` property', () => {
         checkInvalidPropGivenErrors({ foo: 12 }, true)
       })
-      
+
       it('should be `false` when errors has only an `undefined` property', () => {
         checkInvalidPropGivenErrors({ foo: undefined }, false)
       })
-      
+
       it('should be `false` when errors has only a `null` property', () => {
         checkInvalidPropGivenErrors({ foo: null }, false)
       })
-      
+
       it('should be `false` when errors has only an empty array', () => {
-        checkInvalidPropGivenErrors({ myArrayField: [ ] }, false)
+        checkInvalidPropGivenErrors({ myArrayField: [] }, false)
       })
     })
 
@@ -1742,9 +1742,9 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
 
       expect(onSubmitFail)
         .toHaveBeenCalled()
-      expect(onSubmitFail.calls[0].arguments[0]).toEqual(errors)
-      expect(onSubmitFail.calls[0].arguments[1]).toEqual(store.dispatch)
-      expect(onSubmitFail.calls[0].arguments[2]).toBeA(SubmissionError)
+      expect(onSubmitFail.calls[ 0 ].arguments[ 0 ]).toEqual(errors)
+      expect(onSubmitFail.calls[ 0 ].arguments[ 1 ]).toEqual(store.dispatch)
+      expect(onSubmitFail.calls[ 0 ].arguments[ 2 ]).toBeA(SubmissionError)
       expect(caught).toBe(errors)
     })
 
@@ -1785,9 +1785,9 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
 
       expect(onSubmitFail)
         .toHaveBeenCalled()
-      expect(onSubmitFail.calls[0].arguments[0]).toEqual(undefined)
-      expect(onSubmitFail.calls[0].arguments[1]).toEqual(store.dispatch)
-      expect(onSubmitFail.calls[0].arguments[2]).toBeA(Error)
+      expect(onSubmitFail.calls[ 0 ].arguments[ 0 ]).toEqual(undefined)
+      expect(onSubmitFail.calls[ 0 ].arguments[ 1 ]).toEqual(store.dispatch)
+      expect(onSubmitFail.calls[ 0 ].arguments[ 2 ]).toBeA(Error)
       expect(caught).toNotExist()
     })
 
@@ -1827,9 +1827,9 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
         .then(caught => {
           expect(onSubmitFail)
             .toHaveBeenCalled()
-          expect(onSubmitFail.calls[0].arguments[0]).toEqual(errors)
-          expect(onSubmitFail.calls[0].arguments[1]).toEqual(store.dispatch)
-          expect(onSubmitFail.calls[0].arguments[2]).toBeA(SubmissionError)
+          expect(onSubmitFail.calls[ 0 ].arguments[ 0 ]).toEqual(errors)
+          expect(onSubmitFail.calls[ 0 ].arguments[ 1 ]).toEqual(store.dispatch)
+          expect(onSubmitFail.calls[ 0 ].arguments[ 2 ]).toBeA(SubmissionError)
           expect(caught).toBe(errors)
         })
     })
@@ -1873,9 +1873,9 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(onSubmit).toNotHaveBeenCalled()
       expect(onSubmitFail)
         .toHaveBeenCalled()
-      expect(onSubmitFail.calls[0].arguments[0]).toEqual(errors)
-      expect(onSubmitFail.calls[0].arguments[1]).toEqual(store.dispatch)
-      expect(onSubmitFail.calls[0].arguments[2]).toBe(null)
+      expect(onSubmitFail.calls[ 0 ].arguments[ 0 ]).toEqual(errors)
+      expect(onSubmitFail.calls[ 0 ].arguments[ 1 ]).toEqual(store.dispatch)
+      expect(onSubmitFail.calls[ 0 ].arguments[ 2 ]).toBe(null)
       expect(result).toEqual(errors)
     })
 
@@ -1919,9 +1919,9 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
           expect(onSubmit).toNotHaveBeenCalled()
           expect(onSubmitFail)
             .toHaveBeenCalled()
-          expect(onSubmitFail.calls[0].arguments[0]).toEqual(errors)
-          expect(onSubmitFail.calls[0].arguments[1]).toEqual(store.dispatch)
-          expect(onSubmitFail.calls[0].arguments[2]).toBe(null)
+          expect(onSubmitFail.calls[ 0 ].arguments[ 0 ]).toEqual(errors)
+          expect(onSubmitFail.calls[ 0 ].arguments[ 1 ]).toEqual(store.dispatch)
+          expect(onSubmitFail.calls[ 0 ].arguments[ 2 ]).toBe(null)
           expect(error).toBe(errors)
         })
     })
@@ -2580,7 +2580,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(propsAtNthRender(formRender, 1).valid).toBe(false)
       expect(propsAtNthRender(formRender, 1).invalid).toBe(true)
 
-      input.calls[0].arguments[0].input.onChange('bar')
+      input.calls[ 0 ].arguments[ 0 ].input.onChange('bar')
 
       expect(formRender.calls.length).toBe(4)
       expect(propsAtNthRender(formRender, 3).error).toNotExist()
@@ -2688,7 +2688,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(formRender.calls.length).toBe(2)
       expect(propsAtNthRender(formRender, 1).warning).toBe('form wide sync warning')
 
-      input.calls[0].arguments[0].input.onChange('bar')
+      input.calls[ 0 ].arguments[ 0 ].input.onChange('bar')
 
       // expect(formRender.calls.length).toBe(4) // TODO: this gets called an extra time (4 instead of 3). why?
       expect(propsAtNthRender(formRender, 3).warning).toNotExist()
@@ -2846,7 +2846,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
         expect(propsAtNthRender(inputRender, 3).meta.error).toBe('async error')
       })
     })
-    
+
 
     describe('validateIfNeeded', () => {
 
@@ -2859,7 +2859,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
 
         // initial render
         expect(shouldValidate).toHaveBeenCalled()
-        expect(shouldValidate.calls[0].arguments[0].initialRender).toBe(true)
+        expect(shouldValidate.calls[ 0 ].arguments[ 0 ].initialRender).toBe(true)
         expect(validate).toNotHaveBeenCalled()
 
         shouldValidate.reset()
@@ -2869,7 +2869,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
         TestUtils.Simulate.change(inputElement, { target: { value: 'bar' } })
 
         expect(shouldValidate).toHaveBeenCalled()
-        expect(shouldValidate.calls[0].arguments[0].initialRender).toBe(false)
+        expect(shouldValidate.calls[ 0 ].arguments[ 0 ].initialRender).toBe(false)
         expect(validate).toNotHaveBeenCalled()
       })
 
@@ -2882,7 +2882,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
 
         // initial render
         expect(shouldValidate).toHaveBeenCalled()
-        expect(shouldValidate.calls[0].arguments[0].initialRender).toBe(true)
+        expect(shouldValidate.calls[ 0 ].arguments[ 0 ].initialRender).toBe(true)
         expect(validate).toHaveBeenCalled()
 
         shouldValidate.reset()
@@ -2892,7 +2892,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
         TestUtils.Simulate.change(inputElement, { target: { value: 'bar' } })
 
         expect(shouldValidate).toHaveBeenCalled()
-        expect(shouldValidate.calls[0].arguments[0].initialRender).toBe(false)
+        expect(shouldValidate.calls[ 0 ].arguments[ 0 ].initialRender).toBe(false)
         expect(validate).toHaveBeenCalled()
       })
 
@@ -3030,13 +3030,13 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
 
       expect(renderForm).toHaveBeenCalled()
       expect(renderForm.calls.length).toBe(1)
-      expect(renderForm.calls[0].arguments[0].autofill).toBeA('function')
+      expect(renderForm.calls[ 0 ].arguments[ 0 ].autofill).toBeA('function')
 
       // check field
       expect(renderInput).toHaveBeenCalled()
       expect(renderInput.calls.length).toBe(1)
-      expect(renderInput.calls[0].arguments[0].input.value).toBe('')
-      expect(renderInput.calls[0].arguments[0].meta.autofilled).toBe(false)
+      expect(renderInput.calls[ 0 ].arguments[ 0 ].input.value).toBe('')
+      expect(renderInput.calls[ 0 ].arguments[ 0 ].meta.autofilled).toBe(false)
 
       const form = TestUtils.findRenderedDOMComponentWithTag(dom, 'form')
 
@@ -3045,36 +3045,36 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       TestUtils.Simulate.submit(form)
       expect(onSubmit).toHaveBeenCalled()
       expect(onSubmit.calls.length).toBe(1)
-      expect(onSubmit.calls[0].arguments[0]).toEqualMap({})
+      expect(onSubmit.calls[ 0 ].arguments[ 0 ]).toEqualMap({})
       expect(renderInput.calls.length).toBe(2)  // touched by submit
 
       // autofill field
-      renderForm.calls[0].arguments[0].autofill('myField', 'autofilled value')
+      renderForm.calls[ 0 ].arguments[ 0 ].autofill('myField', 'autofilled value')
 
       // check field
       expect(renderInput).toHaveBeenCalled()
       expect(renderInput.calls.length).toBe(3)
-      expect(renderInput.calls[2].arguments[0].input.value).toBe('autofilled value')
-      expect(renderInput.calls[2].arguments[0].meta.autofilled).toBe(true)
+      expect(renderInput.calls[ 2 ].arguments[ 0 ].input.value).toBe('autofilled value')
+      expect(renderInput.calls[ 2 ].arguments[ 0 ].meta.autofilled).toBe(true)
 
       // test submitting autofilled value
       TestUtils.Simulate.submit(form)
       expect(onSubmit.calls.length).toBe(2)
-      expect(onSubmit.calls[1].arguments[0]).toEqualMap({ myField: 'autofilled value' })
+      expect(onSubmit.calls[ 1 ].arguments[ 0 ]).toEqualMap({ myField: 'autofilled value' })
 
       // user edits field
-      renderInput.calls[1].arguments[0].input.onChange('user value')
+      renderInput.calls[ 1 ].arguments[ 0 ].input.onChange('user value')
 
       // check field
       expect(renderInput).toHaveBeenCalled()
       expect(renderInput.calls.length).toBe(4)
-      expect(renderInput.calls[3].arguments[0].input.value).toBe('user value')
-      expect(renderInput.calls[3].arguments[0].meta.autofilled).toBe(false)
+      expect(renderInput.calls[ 3 ].arguments[ 0 ].input.value).toBe('user value')
+      expect(renderInput.calls[ 3 ].arguments[ 0 ].meta.autofilled).toBe(false)
 
       // why not test submitting again?
       TestUtils.Simulate.submit(form)
       expect(onSubmit.calls.length).toBe(3)
-      expect(onSubmit.calls[2].arguments[0]).toEqualMap({ myField: 'user value' })
+      expect(onSubmit.calls[ 2 ].arguments[ 0 ]).toEqualMap({ myField: 'user value' })
     })
 
     it('should not reinitialize values on remount if destroyOnMount is false', () => {
@@ -3219,8 +3219,8 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(formRender).toHaveBeenCalled()
       expect(formRender.calls.length).toBe(1)
 
-      expect(formRender.calls[0].arguments[0].blur).toBeA('function')
-      formRender.calls[0].arguments[0].blur('foo', 'newValue')
+      expect(formRender.calls[ 0 ].arguments[ 0 ].blur).toBeA('function')
+      formRender.calls[ 0 ].arguments[ 0 ].blur('foo', 'newValue')
 
       // check modified state
       expect(store.getState()).toEqualMap({
@@ -3270,8 +3270,8 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(formRender).toHaveBeenCalled()
       expect(formRender.calls.length).toBe(1)
 
-      expect(formRender.calls[0].arguments[0].change).toBeA('function')
-      formRender.calls[0].arguments[0].change('foo', 'newValue')
+      expect(formRender.calls[ 0 ].arguments[ 0 ].change).toBeA('function')
+      formRender.calls[ 0 ].arguments[ 0 ].change('foo', 'newValue')
 
       // check modified state
       expect(store.getState()).toEqualMap({
@@ -3371,7 +3371,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
         </Provider>
       )
 
-      // unmount form
+      // submit form
       const stub = TestUtils.findRenderedComponentWithType(dom, Decorated)
       stub.submit()
 
@@ -3396,6 +3396,69 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
           }
         }
       })
+    })
+
+    it('submits even if submit errors exist', () => {
+      const store = makeStore({})
+      let count = 0
+      const onSubmit = createSpy(() => new Promise(resolve => {
+        count++
+        if (count === 1) { // first time throw exception
+          throw new SubmissionError({ _error: 'Bad human!' })
+        }
+        resolve()
+      })).andCallThrough()
+      const renderSpy = createSpy(() => {
+      })
+
+      class Form extends Component {
+        render() {
+          const { handleSubmit, error, valid } = this.props
+          renderSpy(valid, error)
+          return (
+            <form onSubmit={handleSubmit}>
+              <Field name="foo" component="input" type="text"/>
+            </form>
+          )
+        }
+      }
+      const Decorated = reduxForm({
+        form: 'testForm',
+        onSubmit
+      })(Form)
+
+      const dom = TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <Decorated/>
+        </Provider>
+      )
+
+      expect(renderSpy).toHaveBeenCalled()
+      expect(renderSpy.calls.length).toBe(1)
+      expect(renderSpy.calls[ 0 ].arguments[ 0 ]).toBe(true)
+      expect(renderSpy.calls[ 0 ].arguments[ 1 ]).toBe(undefined)
+      expect(onSubmit).toNotHaveBeenCalled()
+
+      // submit form
+      const stub = TestUtils.findRenderedComponentWithType(dom, Decorated)
+      return stub.submit()
+        .then(() => {
+          expect(onSubmit).toHaveBeenCalled()
+          expect(onSubmit.calls.length).toBe(1)
+
+          expect(renderSpy.calls.length).toBe(4)
+          expect(renderSpy.calls[ 3 ].arguments[ 0 ]).toBe(false)
+          expect(renderSpy.calls[ 3 ].arguments[ 1 ]).toBe('Bad human!')
+        })
+        .then(() => stub.submit()) // call submit again!
+        .then(() => {
+          expect(onSubmit.calls.length).toBe(2)
+
+          expect(renderSpy.calls.length).toBe(6)
+          expect(renderSpy.calls[ 5 ].arguments[ 0 ]).toBe(true)
+          expect(renderSpy.calls[ 5 ].arguments[ 1 ]).toBe(undefined)
+        })
+
     })
 
     it('submits when the SUBMIT action is dispatched', () => {
@@ -3428,29 +3491,29 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       let callIndex = logger.calls.length
 
       // update input
-      inputRender.calls[0].arguments[0].input.onChange('hello')
+      inputRender.calls[ 0 ].arguments[ 0 ].input.onChange('hello')
 
       // check that change action was dispatched
-      expect(logger.calls[callIndex++].arguments[1])
+      expect(logger.calls[ callIndex++ ].arguments[ 1 ])
         .toEqual(change('testForm', 'foo', 'hello', false, false))
 
       // dispatch submit action
       store.dispatch(submit('testForm'))
 
       // check that submit action was dispatched
-      expect(logger.calls[callIndex++].arguments[1])
+      expect(logger.calls[ callIndex++ ].arguments[ 1 ])
         .toEqual(submit('testForm'))
 
       // check that clear submit action was dispatched
-      expect(logger.calls[callIndex++].arguments[1])
+      expect(logger.calls[ callIndex++ ].arguments[ 1 ])
         .toEqual(clearSubmit('testForm'))
 
       // check that touch action was dispatched
-      expect(logger.calls[callIndex++].arguments[1])
+      expect(logger.calls[ callIndex++ ].arguments[ 1 ])
         .toEqual(touch('testForm', 'foo'))
 
       // check that submit succeeded action was dispatched
-      expect(logger.calls[callIndex++].arguments[1])
+      expect(logger.calls[ callIndex++ ].arguments[ 1 ])
         .toEqual(setSubmitSucceeded('testForm'))
 
       // check no additional actions dispatched
@@ -3458,7 +3521,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
 
       expect(onSubmit).toHaveBeenCalled()
       expect(onSubmit.calls.length).toBe(1)
-      expect(onSubmit.calls[0].arguments[0]).toEqualMap({ foo: 'hello' })
+      expect(onSubmit.calls[ 0 ].arguments[ 0 ]).toEqualMap({ foo: 'hello' })
     })
   })
 }

--- a/src/handleSubmit.js
+++ b/src/handleSubmit.js
@@ -9,11 +9,6 @@ const handleSubmit = (submit, props, valid, asyncValidate, fields) => {
 
   touch(...fields) // mark all fields as touched
 
-  // XXX: Always submitting when persistentSubmitErrors is enabled ignores sync errors.
-  // It would be better to check whether the form as any other errors except submit errors.
-  // This would either require changing the meaning of `valid` (maybe breaking change),
-  // having a more complex conditional in here, or executing sync validation in here
-  // the same way as async validation is executed.
   if (valid || persistentSubmitErrors) {
     const doSubmit = () => {
       let result

--- a/src/reduxForm.js
+++ b/src/reduxForm.js
@@ -375,14 +375,14 @@ const createReduxForm =
               // submitOrEvent is an event: fire submit if not already submitting
               if (!this.submitPromise) {
                 return this.listenToSubmit(handleSubmit(checkSubmit(onSubmit),
-                  this.props, this.isValid(), this.asyncValidate, this.getFieldList()))
+                  this.props, this.props.validExceptSubmit, this.asyncValidate, this.getFieldList()))
               }
             } else {
               // submitOrEvent is the submit function: return deferred submit thunk
               return silenceEvents(() =>
               !this.submitPromise &&
               this.listenToSubmit(handleSubmit(checkSubmit(submitOrEvent),
-                this.props, this.isValid(), this.asyncValidate, this.getFieldList())))
+                this.props, this.props.validExceptSubmit, this.asyncValidate, this.getFieldList())))
             }
           }
 
@@ -451,6 +451,7 @@ const createReduxForm =
               updateSyncErrors,
               updateSyncWarnings,
               valid,
+              validExceptSubmit,
               values,
               warning,
               ...rest
@@ -539,7 +540,8 @@ const createReduxForm =
             const syncErrors = getIn(formState, 'syncErrors') || {}
             const syncWarnings = getIn(formState, 'syncWarnings') || {}
             const registeredFields = getIn(formState, 'registeredFields') || []
-            const valid = isValid(form, getFormState)(state)
+            const valid = isValid(form, getFormState, false)(state)
+            const validExceptSubmit = isValid(form, getFormState, true)(state)
             const anyTouched = !!getIn(formState, 'anyTouched')
             const submitting = !!getIn(formState, 'submitting')
             const submitFailed = !!getIn(formState, 'submitFailed')
@@ -565,6 +567,7 @@ const createReduxForm =
               triggerSubmit,
               values,
               valid,
+              validExceptSubmit,
               warning
             }
           },

--- a/src/selectors/__tests__/isInvalid.spec.js
+++ b/src/selectors/__tests__/isInvalid.spec.js
@@ -9,20 +9,21 @@ const describeIsInvalid = (name, structure, expect) => {
   const isInvalid = createIsInvalid(structure)
 
   const { fromJS, getIn, setIn } = structure
+  const getFormState = state => getIn(state, 'form')
 
   describe(name, () => {
     it('should return a function', () => {
-      expect(isInvalid('foo')).toBeA('function')
+      expect(isInvalid('foo', getFormState)).toBeA('function')
     })
 
     it('should return false when form data not present', () => {
-      expect(isInvalid('foo')(fromJS({
+      expect(isInvalid('foo', getFormState)(fromJS({
         form: {}
       }))).toBe(false)
     })
 
     it('should return false when there are no errors', () => {
-      expect(isInvalid('foo')(fromJS({
+      expect(isInvalid('foo', getFormState)(fromJS({
         form: {
           foo: {
             values: {
@@ -38,7 +39,7 @@ const describeIsInvalid = (name, structure, expect) => {
     })
 
     it('should return false when there are sync errors for a NON-registered field', () => {
-      expect(isInvalid('foo')(setIn(fromJS({
+      expect(isInvalid('foo', getFormState)(setIn(fromJS({
         form: {
           foo: {
             values: {
@@ -60,7 +61,7 @@ const describeIsInvalid = (name, structure, expect) => {
     })
 
     it('should return true when there are sync errors for registered fields', () => {
-      expect(isInvalid('foo')(setIn(fromJS({
+      expect(isInvalid('foo', getFormState)(setIn(fromJS({
         form: {
           foo: {
             values: {
@@ -79,7 +80,7 @@ const describeIsInvalid = (name, structure, expect) => {
     })
 
     it('should return true with sync error for registered array field', () => {
-      expect(isInvalid('foo')(setIn(fromJS({
+      expect(isInvalid('foo', getFormState)(setIn(fromJS({
         form: {
           foo: {
             values: {
@@ -100,7 +101,7 @@ const describeIsInvalid = (name, structure, expect) => {
     })
 
     it('should return true when there is a syncError', () => {
-      expect(isInvalid('foo')(fromJS({
+      expect(isInvalid('foo', getFormState)(fromJS({
         form: {
           foo: {
             values: {
@@ -119,7 +120,7 @@ const describeIsInvalid = (name, structure, expect) => {
     })
 
     it('should return false when there are async errors for a NON-registered field', () => {
-      expect(isInvalid('foo')(fromJS({
+      expect(isInvalid('foo', getFormState)(fromJS({
         form: {
           foo: {
             values: {
@@ -139,7 +140,7 @@ const describeIsInvalid = (name, structure, expect) => {
     })
 
     it('should return true when there are async errors for registered fields', () => {
-      expect(isInvalid('foo')(fromJS({
+      expect(isInvalid('foo', getFormState)(fromJS({
         form: {
           foo: {
             values: {
@@ -159,7 +160,7 @@ const describeIsInvalid = (name, structure, expect) => {
     })
 
     it('should return true with async error for registered array field', () => {
-      expect(isInvalid('foo')(fromJS({
+      expect(isInvalid('foo', getFormState)(fromJS({
         form: {
           foo: {
             values: {
@@ -181,7 +182,7 @@ const describeIsInvalid = (name, structure, expect) => {
     })
 
     it('should return false when there are submit errors for a NON-registered field', () => {
-      expect(isInvalid('foo')(fromJS({
+      expect(isInvalid('foo', getFormState)(fromJS({
         form: {
           foo: {
             values: {
@@ -201,7 +202,7 @@ const describeIsInvalid = (name, structure, expect) => {
     })
 
     it('should return true when there are submit errors for registered fields', () => {
-      expect(isInvalid('foo')(fromJS({
+      expect(isInvalid('foo', getFormState)(fromJS({
         form: {
           foo: {
             values: {
@@ -221,7 +222,7 @@ const describeIsInvalid = (name, structure, expect) => {
     })
 
     it('should return true with submit error for registered array field', () => {
-      expect(isInvalid('foo')(fromJS({
+      expect(isInvalid('foo', getFormState)(fromJS({
         form: {
           foo: {
             values: {

--- a/src/selectors/__tests__/isValid.spec.js
+++ b/src/selectors/__tests__/isValid.spec.js
@@ -9,20 +9,21 @@ const describeIsValid = (name, structure, expect) => {
   const isValid = createIsValid(structure)
 
   const { fromJS, getIn, setIn } = structure
+  const getFormState = state => getIn(state, 'form')
 
   describe(name, () => {
     it('should return a function', () => {
-      expect(isValid('foo')).toBeA('function')
+      expect(isValid('foo', getFormState)).toBeA('function')
     })
 
     it('should return true when form data not present', () => {
-      expect(isValid('foo')(fromJS({
+      expect(isValid('foo', getFormState)(fromJS({
         form: {}
       }))).toBe(true)
     })
 
     it('should return true when there are no errors', () => {
-      expect(isValid('foo')(fromJS({
+      expect(isValid('foo', getFormState)(fromJS({
         form: {
           foo: {
             values: {
@@ -38,7 +39,7 @@ const describeIsValid = (name, structure, expect) => {
     })
 
     it('should return true when there are sync errors for a NON-registered field', () => {
-      expect(isValid('foo')(setIn(fromJS({
+      expect(isValid('foo', getFormState)(setIn(fromJS({
         form: {
           foo: {
             values: {
@@ -60,7 +61,7 @@ const describeIsValid = (name, structure, expect) => {
     })
 
     it('should return false when there are sync errors for registered fields', () => {
-      expect(isValid('foo')(setIn(fromJS({
+      expect(isValid('foo', getFormState)(setIn(fromJS({
         form: {
           foo: {
             values: {
@@ -79,7 +80,7 @@ const describeIsValid = (name, structure, expect) => {
     })
 
     it('should return false with sync error for registered array field', () => {
-      expect(isValid('foo')(setIn(fromJS({
+      expect(isValid('foo', getFormState)(setIn(fromJS({
         form: {
           foo: {
             values: {
@@ -100,7 +101,7 @@ const describeIsValid = (name, structure, expect) => {
     })
 
     it('should return false when there is a syncError', () => {
-      expect(isValid('foo')(fromJS({
+      expect(isValid('foo', getFormState)(fromJS({
         form: {
           foo: {
             values: {
@@ -119,7 +120,7 @@ const describeIsValid = (name, structure, expect) => {
     })
 
     it('should return true when there are async errors for a NON-registered field', () => {
-      expect(isValid('foo')(fromJS({
+      expect(isValid('foo', getFormState)(fromJS({
         form: {
           foo: {
             values: {
@@ -139,7 +140,7 @@ const describeIsValid = (name, structure, expect) => {
     })
 
     it('should return false when there are async errors for registered fields', () => {
-      expect(isValid('foo')(fromJS({
+      expect(isValid('foo', getFormState)(fromJS({
         form: {
           foo: {
             values: {
@@ -159,7 +160,7 @@ const describeIsValid = (name, structure, expect) => {
     })
 
     it('should return false with async error for registered array field', () => {
-      expect(isValid('foo')(fromJS({
+      expect(isValid('foo', getFormState)(fromJS({
         form: {
           foo: {
             values: {
@@ -181,7 +182,7 @@ const describeIsValid = (name, structure, expect) => {
     })
 
     it('should return true when there are submit errors for a NON-registered field', () => {
-      expect(isValid('foo')(fromJS({
+      expect(isValid('foo', getFormState)(fromJS({
         form: {
           foo: {
             values: {
@@ -201,7 +202,7 @@ const describeIsValid = (name, structure, expect) => {
     })
 
     it('should return false when there are submit errors for registered fields', () => {
-      expect(isValid('foo')(fromJS({
+      expect(isValid('foo', getFormState)(fromJS({
         form: {
           foo: {
             values: {
@@ -221,7 +222,7 @@ const describeIsValid = (name, structure, expect) => {
     })
 
     it('should return false with submit error for registered array field', () => {
-      expect(isValid('foo')(fromJS({
+      expect(isValid('foo', getFormState)(fromJS({
         form: {
           foo: {
             values: {
@@ -240,6 +241,62 @@ const describeIsValid = (name, structure, expect) => {
           }
         }
       }))).toBe(false)
+    })
+
+    it('should return false when there is a form-wide submit error', () => {
+      expect(isValid('foo', getFormState)(fromJS({
+        form: {
+          foo: {
+            values: {
+              dog: 'Odie',
+              cat: 'Garfield'
+            },
+            registeredFields: [
+              { name: 'dog', type: 'Field' },
+              { name: 'cat', type: 'Field' }
+            ],
+            error: 'Form wide'
+          }
+        }
+      }))).toBe(false)
+    })
+
+    it('should return true when there are submit errors for registered fields but told to ignore submit errors', () => {
+      expect(isValid('foo', getFormState, true)(fromJS({
+        form: {
+          foo: {
+            values: {
+              dog: 'Odie',
+              cat: 'Garfield'
+            },
+            registeredFields: [
+              { name: 'dog', type: 'Field' },
+              { name: 'cat', type: 'Field' }
+            ],
+            submitErrors: {
+              dog: 'Too old'
+            }
+          }
+        }
+      }))).toBe(true)
+    })
+
+    it('should return true when there is a form-wide submit error, but ignoring submit errors', () => {
+      expect(isValid('foo', getFormState, true)(fromJS({
+        form: {
+          foo: {
+            values: {
+              dog: 'Odie',
+              cat: 'Garfield'
+            },
+            registeredFields: [
+              { name: 'dog', type: 'Field' },
+              { name: 'cat', type: 'Field' }
+            ],
+            error: 'Form wide'
+          }
+        }
+      }))).toBe(true)
     })
 
     it('should use getFormState if provided', () => {

--- a/src/selectors/isValid.js
+++ b/src/selectors/isValid.js
@@ -3,17 +3,25 @@ import createHasError from '../hasError'
 const createIsValid = structure => {
   const { getIn } = structure
   const hasError = createHasError(structure)
-  return (form, getFormState = state => getIn(state, 'form')) =>
+  return (form, getFormState, ignoreSubmitErrors) =>
     state => {
       const formState = getFormState(state)
       const syncError = getIn(formState, `${form}.syncError`)
       if (syncError) {
         return false
       }
+      if (!ignoreSubmitErrors) {
+        const error = getIn(formState, `${form}.error`)
+        if (error) {
+          return false
+        }
+      }
       const syncErrors = getIn(formState, `${form}.syncErrors`)
       const asyncErrors = getIn(formState, `${form}.asyncErrors`)
-      const submitErrors = getIn(formState, `${form}.submitErrors`)
-      if(!syncErrors && !asyncErrors && !submitErrors) {
+      const submitErrors = ignoreSubmitErrors ?
+        undefined :
+        getIn(formState, `${form}.submitErrors`)
+      if (!syncErrors && !asyncErrors && !submitErrors) {
         return true
       }
 


### PR DESCRIPTION
Fixes #2244 and addresses a comment left by @orfjackal in `handleSubmit.js`.

The problem was that it should still try to submit even if previous submission errors exist. Now it will only not submit if sync or async errors exist.