### PR TITLE
restore default value for getFormState removed in d84aa7

### DIFF
--- a/src/selectors/__tests__/isValid.spec.js
+++ b/src/selectors/__tests__/isValid.spec.js
@@ -318,6 +318,12 @@ const describeIsValid = (name, structure, expect) => {
         }
       }))).toBe(false)
     })
+
+    it('should have default getFormState', () => {
+      expect(isValid('foo')(fromJS({
+        form: {}
+      }))).toBe(true)
+    })
   })
 }
 

--- a/src/selectors/isValid.js
+++ b/src/selectors/isValid.js
@@ -3,7 +3,7 @@ import createHasError from '../hasError'
 const createIsValid = structure => {
   const { getIn } = structure
   const hasError = createHasError(structure)
-  return (form, getFormState, ignoreSubmitErrors) =>
+  return (form, getFormState = state => getIn(state, 'form'), ignoreSubmitErrors = false) =>
     state => {
       const formState = getFormState(state)
       const syncError = getIn(formState, `${form}.syncError`)


### PR DESCRIPTION
Hi,

This change https://github.com/erikras/redux-form/commit/d84aa7f055f54ed7a7e0c1eabc7b5b1ec769d331 introduced regression in using `isValid` as selection http://redux-form.com/6.3.1/docs/api/Selectors.md/

Trying to use:
`valid: isValid('myForm')(state)` 
will cause `TypeError: getFormState is not a function`