### PR TITLE
Allow react-redux v5 as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,14 +88,14 @@
     "react": "^15.0.0",
     "react-addons-test-utils": "^15.0.0",
     "react-dom": "^15.0.0",
-    "react-redux": "^4.4.1",
+    "react-redux": "^5.0.1",
     "redux": "^3.3.1",
     "rifraf": "^2.0.2",
     "rimraf": "^2.5.2",
     "webpack": "^1.12.13"
   },
   "peerDependencies": {
-    "react-redux": "^3.0.0 || ^4.0.0",
+    "react-redux": "^3.0.0 || ^4.0.0 || ^5.0.0",
     "redux": "^3.0.0"
   },
   "npmName": "redux-form",

--- a/src/__tests__/createReduxForm.spec.js
+++ b/src/__tests__/createReduxForm.spec.js
@@ -2809,7 +2809,7 @@ describe('createReduxForm', () => {
 
     expect(() => decorated.someInstanceMethod()).toThrow();
     expect(decorated.getWrappedInstance().someInstanceMethod()).toBe(someData);
-    expect(decorated.refs.wrappedInstance.refs.wrappedInstance.refs.wrappedInstance.refs.wrappedInstance.someInstanceMethod()).toBe(someData);
+    expect(decorated.refs.wrappedInstance.refs.wrappedInstance.getWrappedInstance().refs.wrappedInstance.someInstanceMethod()).toBe(someData);
   });
 
   it('should change nested fields', () => {

--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -32,7 +32,7 @@ const createReduxForm =
               `To access the wrapped instance, you need to specify ` +
               `{ withRef: true } as the fourth argument of the connect() call.`
             );
-            return this.refs.wrappedInstance.refs.wrappedInstance.refs.wrappedInstance.refs.wrappedInstance;
+            return this.refs.wrappedInstance.refs.wrappedInstance.getWrappedInstance().refs.wrappedInstance;
           }
 
           handleSubmitPassback(submit) {


### PR DESCRIPTION
react-redux v5 was just released.
It has a backwards compatible api with v4 so should just work out of the box.