### PR TITLE
First call of validate always receives undefined/empty object when enableReinitialize:true

### DIFF
--- a/src/reduxForm.js
+++ b/src/reduxForm.js
@@ -525,8 +525,9 @@ const createReduxForm =
             const { form, getFormState, initialValues, enableReinitialize, keepDirtyOnReinitialize } = props
             const formState = getIn(getFormState(state) || empty, form) || empty
             const stateInitial = getIn(formState, 'initial')
+            const initialized = !!stateInitial;
 
-            const shouldUpdateInitialValues = enableReinitialize && !deepEqual(initialValues, stateInitial)
+            const shouldUpdateInitialValues = enableReinitialize && initialized && !deepEqual(initialValues, stateInitial)
             const shouldResetValues = shouldUpdateInitialValues && !keepDirtyOnReinitialize
 
             let initial = initialValues || stateInitial || empty
@@ -561,7 +562,7 @@ const createReduxForm =
               asyncValidating: getIn(formState, 'asyncValidating') || false,
               dirty: !pristine,
               error,
-              initialized: !!stateInitial,
+              initialized,
               invalid: !valid,
               pristine,
               registeredFields,

--- a/src/reduxForm.js
+++ b/src/reduxForm.js
@@ -525,7 +525,7 @@ const createReduxForm =
             const { form, getFormState, initialValues, enableReinitialize, keepDirtyOnReinitialize } = props
             const formState = getIn(getFormState(state) || empty, form) || empty
             const stateInitial = getIn(formState, 'initial')
-            const initialized = !!stateInitial;
+            const initialized = !!stateInitial
 
             const shouldUpdateInitialValues = enableReinitialize && initialized && !deepEqual(initialValues, stateInitial)
             const shouldResetValues = shouldUpdateInitialValues && !keepDirtyOnReinitialize


### PR DESCRIPTION
Resolves #1901 

Starting from changes in #1992, the first run of validate function receives undefined (in v6.2.0) or empty object(since v6.2.1) if ```enableReinitialize``` option is true.

This caused "Cannot read property 'xxx' of undefined" kinda errors in implementation based on v6.1.1 or before.