### PR TITLE
Force unregister fields

### DIFF
--- a/docs/api/ReduxForm.md
+++ b/docs/api/ReduxForm.md
@@ -58,6 +58,10 @@ component is unmounted. Defaults to `true`.
 Defaults to `false`.  If the `keepDirtyOnReinitialize` option is also set, the form
 will retain the value of dirty fields when reinitializing.
 
+#### `forceUnregisterOnUnmount : boolean` [optional]
+
+> Whether or not to force unregistration of fields -- use in conjunction with `destroyOnUnmount`. Useful for wizard-type forms where you want to destroy fields as they unmount, but not the form's state. Defaults to `false`, as forms are normally unregistered on unmount. 
+
 #### `getFormState : Function` [optional]
 
 > A function that takes the entire Redux state and returns the state slice which corresponds to

--- a/examples/wizard/src/WizardFormFirstPage.js
+++ b/examples/wizard/src/WizardFormFirstPage.js
@@ -17,7 +17,8 @@ const WizardFormFirstPage = (props) => {
 }
 
 export default reduxForm({
-  form: 'wizard',              // <------ same form name
-  destroyOnUnmount: false,     // <------ preserve form data
+  form: 'wizard',                 // <------ same form name
+  destroyOnUnmount: false,        // <------ preserve form data
+  forceUnregisterOnUnmount: true,  // <------ unregister fields on unmount
   validate
 })(WizardFormFirstPage)

--- a/examples/wizard/src/WizardFormSecondPage.js
+++ b/examples/wizard/src/WizardFormSecondPage.js
@@ -30,5 +30,6 @@ const WizardFormSecondPage = (props) => {
 export default reduxForm({
   form: 'wizard',  //Form name is same
   destroyOnUnmount: false,
+  forceUnregisterOnUnmount: true,  // <------ unregister fields on unmount
   validate
 })(WizardFormSecondPage)

--- a/examples/wizard/src/WizardFormThirdPage.js
+++ b/examples/wizard/src/WizardFormThirdPage.js
@@ -43,5 +43,6 @@ const WizardFormThirdPage = (props) => {
 export default reduxForm({
   form: 'wizard', //Form name is same
   destroyOnUnmount: false,
+  forceUnregisterOnUnmount: true,  // <------ unregister fields on unmount
   validate
 })(WizardFormThirdPage)

--- a/src/reduxForm.js
+++ b/src/reduxForm.js
@@ -91,6 +91,7 @@ const createReduxForm =
         keepDirtyOnReinitialize: false,
         getFormState: state => getIn(state, 'form'),
         pure: true,
+        forceUnregisterOnUnmount: false,
         ...initialConfig
       }
 
@@ -285,7 +286,7 @@ const createReduxForm =
           }
 
           unregister(name) {
-            if (this.props.destroyOnUnmount && !this.destroyed && (!this.unmounted || !instances)) {
+            if ((this.props.destroyOnUnmount || this.props.forceUnregisterOnUnmount) && !this.destroyed && (!this.unmounted || !instances)) {
               this.props.unregisterField(name)
               delete this.fieldValidators[ name ]
               delete this.fieldWarners[ name ]
@@ -418,6 +419,7 @@ const createReduxForm =
               change,
               destroy,
               destroyOnUnmount,
+              forceUnregisterOnUnmount,
               dirty,
               dispatch,
               enableReinitialize,
@@ -505,6 +507,7 @@ const createReduxForm =
         }
         Form.propTypes = {
           destroyOnUnmount: PropTypes.bool,
+          forceUnregisterOnUnmount: PropTypes.bool,
           form: PropTypes.string.isRequired,
           initialValues: PropTypes.object,
           getFormState: PropTypes.func,


### PR DESCRIPTION
The [wizard form](http://redux-form.com/6.3.1/examples/wizard/) is currently broken because of a change in 6.2.1 (specific PR here: https://github.com/erikras/redux-form/pull/2113). Bug report, with repro-steps: https://github.com/erikras/redux-form/issues/2231. 

When `destroyOnUnmount` is set to `false` it will no-longer unregister fields as components unmount, but it will keep the store's data, and so it will try to validate against fields that have, potentially, been unmounted and are not visible to the user. This PR introduces a new `prop` that will let you force the unregistration of fields. I was hesitant to add another prop, but I can't see a cleaner way of doing it, without re-introducing the bug that #2113 was trying to solve.

I updated the docs and the wizard form example as well.