### PR TITLE
Exception thrown if server returned submit error for fieldArray

### DIFF
--- a/src/__tests__/reducer.change.spec.js
+++ b/src/__tests__/reducer.change.spec.js
@@ -212,6 +212,32 @@ const describeChange = (reducer, expect, { fromJS }) => () => {
         }
       })
   })
+  
+  it('should set value on change and remove field-level submit and async errors', () => {
+    const state = reducer(fromJS({
+      foo: {
+        values: {
+          myField: 'initial'
+        },
+        asyncErrors: {
+          myField: 'async error'
+        },
+        submitErrors: {
+          fieldArray: 'submit error'
+        },
+        error: 'some global error'
+      }
+    }), change('foo', 'fieldArray[0].Text', 'different', false))
+    expect(state)
+      .toEqualMap({
+        foo: {
+          values: {
+            myField: 'different'
+          },
+          error: 'some global error'
+        }
+      })
+  })
 
   it('should NOT remove field-level submit errors and global errors if persistentSubmitErrors is enabled', () => {
     const state = reducer(fromJS({

--- a/src/__tests__/reducer.change.spec.js
+++ b/src/__tests__/reducer.change.spec.js
@@ -213,7 +213,7 @@ const describeChange = (reducer, expect, { fromJS }) => () => {
       })
   })
   
-  it('should set value on change and remove field-level submit and async errors', () => {
+  it("shouldn't fail on submitError for array", () => {
     const state = reducer(fromJS({
       foo: {
         values: {

--- a/src/structure/plain/deleteIn.js
+++ b/src/structure/plain/deleteIn.js
@@ -16,7 +16,7 @@ const deleteInWithPath = (state, first, ...rest) => {
       }
       return state
     }
-    if (first in state) {
+    if (typeof state === 'object' && first in state) {
       const result = deleteInWithPath(state && state[ first ], ...rest)
       return state[ first ] === result ? state : {
         ...state,

--- a/src/structure/plain/deleteIn.js
+++ b/src/structure/plain/deleteIn.js
@@ -16,7 +16,7 @@ const deleteInWithPath = (state, first, ...rest) => {
       }
       return state
     }
-    if (typeof state === 'object' && first in state) {
+    if (first in state) {
       const result = deleteInWithPath(state && state[ first ], ...rest)
       return state[ first ] === result ? state : {
         ...state,


### PR DESCRIPTION
If I have a form with field array and if I set error to the field array an exception will be thrown every time I change any field in the array.  This is a test that fails in such a situation. [issue](https://github.com/erikras/redux-form/issues/2323)