### PR TITLE
Improved FormSection wrapper component

### DIFF
--- a/docs/api/FormSection.md
+++ b/docs/api/FormSection.md
@@ -9,6 +9,15 @@ It does this by prefixing the name of `Field`, `Fields` and `FieldArray` childre
 
 > The name all child fields should be prefixed with. 
 
+### `component : String | Component` [optional]
+
+> If you give `FormSection` more than one child element, it will be forced to create a component
+to wrap them with. You can specify what type of component you would like it to be (`div`,
+`section`, `span`). Defaults to `'div'`.
+
+> Note that any additional props (e.g. 'className', 'style') that you pass to `FormSection` will be
+passed along to the wrapper component.
+
 ## Example usage
 
 An example use case for `FormSection` is an order form where it's possible to have enter the details of a buyer and a separate recipient.

--- a/src/ConnectedField.js
+++ b/src/ConnectedField.js
@@ -93,7 +93,15 @@ const createConnectedField = ({ deepEqual, getIn }) => {
     }
 
     render() {
-      const { component, withRef, name, ...rest } = this.props
+      const {
+        component,
+        withRef,
+        name,
+        // remove props that are part of redux internals:
+        _reduxForm, // eslint-disable-line no-unused-vars
+        normalize,  // eslint-disable-line no-unused-vars
+        ...rest
+      } = this.props
       const { custom, ...props } = createFieldProps(getIn,
         name,
         {

--- a/src/FormSection.js
+++ b/src/FormSection.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from 'react'
+import React, { createElement, Component, PropTypes } from 'react'
 import prefixName from './util/prefixName'
 
 class FormSection extends Component {
@@ -20,18 +20,31 @@ class FormSection extends Component {
   }
 
   render() {
-    const { children } = this.props
+    const {
+      children,
+      name, // eslint-disable-line no-unused-vars
+      component,
+      ...rest
+    } = this.props
 
     if (React.isValidElement(children)) {
       return children
     }
 
-    return <div>{children}</div>
+    return createElement(component, {
+      ...rest,
+      children
+    })
   }
 }
 
 FormSection.propTypes = {
-  name: PropTypes.string.isRequired
+  name: PropTypes.string.isRequired,
+  component: PropTypes.oneOfType([ PropTypes.func, PropTypes.string ])
+}
+
+FormSection.defaultProps = {
+  component: 'div'
 }
 
 FormSection.childContextTypes = {

--- a/src/__tests__/Field.spec.js
+++ b/src/__tests__/Field.spec.js
@@ -579,7 +579,7 @@ const describeField = (name, structure, combineReducers, expect) => {
       const store = makeStore()
       class Form extends Component {
         render() {
-          return (<FormSection name="foo">
+          return (<FormSection name="foo" component="span">
             <Field name="bar" component="input"/>
           </FormSection>)
         }

--- a/src/__tests__/FormSection.spec.js
+++ b/src/__tests__/FormSection.spec.js
@@ -37,7 +37,6 @@ const describeFormSection = (name, structure, combineReducers, expect) => {
       }).toThrow(/must be inside a component decorated with reduxForm/)
     })
 
-
     it('should not wrap in unnecessary div', () => {
       const store = makeStore({
         testForm: {
@@ -67,6 +66,48 @@ const describeFormSection = (name, structure, combineReducers, expect) => {
       const divTags = TestUtils.scryRenderedDOMComponentsWithTag(dom, 'div')
 
       expect(divTags.length).toEqual(0)
+    })
+
+    it('should pass along unused props to div', () => {
+      const store = makeStore({
+        testForm: {
+          values: {
+            foo: {
+              bar: '42'
+            }
+          }
+        }
+      })
+      class Form extends Component {
+        render() {
+          return (
+            <FormSection name="foo"
+              component="section"
+              className="form-section"
+              style={{ fontWeight: 'bold' }}>
+              <Field name="bar" component="input"/>
+              <Field name="baz" component="input"/>
+            </FormSection>
+          )
+        }
+      }
+      const TestForm = reduxForm({ form: 'testForm' })(Form)
+      const dom = TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <TestForm />
+        </Provider>
+      )
+
+      const section = TestUtils.findRenderedDOMComponentWithTag(dom, 'section')
+
+      // 🤢 This line is DISGUSTING!! Is there a better way to get the props on the <section> ??
+      const props = section[Object.keys(section)[0]]._currentElement.props
+
+      expect(props.name).toNotExist()
+      expect(props.component).toNotExist()
+      expect(props.className).toBe('form-section')
+      expect(props.style).toExist()
+      expect(props.style.fontWeight).toBe('bold')
     })
 
 


### PR DESCRIPTION
When `FormSection` needs to wrap its children in a component, you may now:

* Specify the type of component, e.g. `div`, `section`, etc.
* Pass through props, e.g. `className`, `style`, to said component

Closes #2271 and #2274.