### PR TITLE
Ensure state is merged into meta props as plain object (#1877, #1955)

### DIFF
--- a/src/ConnectedField.js
+++ b/src/ConnectedField.js
@@ -9,7 +9,7 @@ const propsToNotUpdateFor = [
   '_reduxForm'
 ]
 
-const createConnectedField = ({ deepEqual, getIn }) => {
+const createConnectedField = ({ deepEqual, getIn, toJS }) => {
 
   const getSyncError = (syncErrors, name) => {
     const error = plain.getIn(syncErrors, name)
@@ -102,7 +102,7 @@ const createConnectedField = ({ deepEqual, getIn }) => {
         normalize,  // eslint-disable-line no-unused-vars
         ...rest
       } = this.props
-      const { custom, ...props } = createFieldProps(getIn,
+      const { custom, ...props } = createFieldProps({ getIn, toJS },
         name,
         {
           ...rest,

--- a/src/ConnectedFields.js
+++ b/src/ConnectedFields.js
@@ -8,7 +8,7 @@ const propsToNotUpdateFor = [
   '_reduxForm'
 ]
 
-const createConnectedFields = ({ deepEqual, getIn }) => {
+const createConnectedFields = ({ deepEqual, getIn, toJS }) => {
 
   const getSyncError = (syncErrors, name) => {
     const error = plain.getIn(syncErrors, name)
@@ -98,7 +98,7 @@ const createConnectedFields = ({ deepEqual, getIn }) => {
       const { sectionPrefix } = _reduxForm
       const { custom, ...props } = Object.keys(_fields).reduce((accumulator, name) => {
         const connectedProps = _fields[ name ]
-        const { custom, ...fieldProps } = createFieldProps(getIn,
+        const { custom, ...fieldProps } = createFieldProps({ getIn, toJS },
           name,
           {
             ...connectedProps,

--- a/src/Field.js
+++ b/src/Field.js
@@ -5,11 +5,12 @@ import shallowCompare from './util/shallowCompare'
 import prefixName from './util/prefixName'
 
 
-const createField = ({ deepEqual, getIn, setIn }) => {
+const createField = ({ deepEqual, getIn, setIn, toJS }) => {
 
   const ConnectedField = createConnectedField({
     deepEqual,
-    getIn
+    getIn,
+    toJS
   })
 
   class Field extends Component {

--- a/src/Fields.js
+++ b/src/Fields.js
@@ -14,11 +14,12 @@ const validateNameProp = prop => {
   }
 }
 
-const createFields = ({ deepEqual, getIn }) => {
+const createFields = ({ deepEqual, getIn, toJS }) => {
 
   const ConnectedFields = createConnectedFields({
     deepEqual,
-    getIn
+    getIn,
+    toJS
   })
   
   class Fields extends Component {

--- a/src/__tests__/createFieldProps.spec.js
+++ b/src/__tests__/createFieldProps.spec.js
@@ -7,24 +7,24 @@ import immutableExpectations from '../structure/immutable/expectations'
 import addExpectations from './addExpectations'
 
 const describeCreateFieldProps = (name, structure, expect) => {
-  const { empty, getIn, fromJS } = structure
+  const { empty, getIn, fromJS, toJS } = structure
 
   describe(name, () => {
     it('should pass value through', () => {
-      expect(createFieldProps(getIn, 'foo', { value: 'hello' }).input.value).toBe('hello')
+      expect(createFieldProps({ getIn, toJS }, 'foo', { value: 'hello' }).input.value).toBe('hello')
     })
 
     it('should pass dirty/pristine through', () => {
-      expect(createFieldProps(getIn, 'foo', { dirty: false, pristine: true }).meta.dirty).toBe(false)
-      expect(createFieldProps(getIn, 'foo', { dirty: false, pristine: true }).meta.pristine).toBe(true)
-      expect(createFieldProps(getIn, 'foo', { dirty: true, pristine: false }).meta.dirty).toBe(true)
-      expect(createFieldProps(getIn, 'foo', { dirty: true, pristine: false }).meta.pristine).toBe(false)
+      expect(createFieldProps({ getIn, toJS }, 'foo', { dirty: false, pristine: true }).meta.dirty).toBe(false)
+      expect(createFieldProps({ getIn, toJS }, 'foo', { dirty: false, pristine: true }).meta.pristine).toBe(true)
+      expect(createFieldProps({ getIn, toJS }, 'foo', { dirty: true, pristine: false }).meta.dirty).toBe(true)
+      expect(createFieldProps({ getIn, toJS }, 'foo', { dirty: true, pristine: false }).meta.pristine).toBe(false)
     })
 
     it('should provide onBlur', () => {
       const onBlur = createSpy()
       expect(onBlur).toNotHaveBeenCalled()
-      const result = createFieldProps(getIn, 'foo', { value: 'bar', onBlur })
+      const result = createFieldProps({ getIn, toJS }, 'foo', { value: 'bar', onBlur })
       expect(result.input.onBlur).toBeA('function')
       expect(onBlur).toNotHaveBeenCalled()
       result.input.onBlur('rabbit')
@@ -36,7 +36,7 @@ const describeCreateFieldProps = (name, structure, expect) => {
     it('should provide onChange', () => {
       const onChange = createSpy()
       expect(onChange).toNotHaveBeenCalled()
-      const result = createFieldProps(getIn, 'foo', { value: 'bar', onChange })
+      const result = createFieldProps({ getIn, toJS }, 'foo', { value: 'bar', onChange })
       expect(result.input.onChange).toBeA('function')
       expect(onChange).toNotHaveBeenCalled()
       result.input.onChange('rabbit')
@@ -48,7 +48,7 @@ const describeCreateFieldProps = (name, structure, expect) => {
     it('should provide onFocus', () => {
       const onFocus = createSpy()
       expect(onFocus).toNotHaveBeenCalled()
-      const result = createFieldProps(getIn, 'foo', { value: 'bar', onFocus })
+      const result = createFieldProps({ getIn, toJS }, 'foo', { value: 'bar', onFocus })
       expect(result.input.onFocus).toBeA('function')
       expect(onFocus).toNotHaveBeenCalled()
       result.input.onFocus('rabbit')
@@ -57,23 +57,23 @@ const describeCreateFieldProps = (name, structure, expect) => {
 
     it('should provide onDragStart', () => {
       const onDragStart = createSpy()
-      const result = createFieldProps(getIn, 'foo', { value: 'bar', onDragStart })
+      const result = createFieldProps({ getIn, toJS }, 'foo', { value: 'bar', onDragStart })
       expect(result.input.onDragStart).toBeA('function')
     })
 
     it('should provide onDrop', () => {
       const onDrop = createSpy()
-      const result = createFieldProps(getIn, 'foo', { value: 'bar', onDrop })
+      const result = createFieldProps({ getIn, toJS }, 'foo', { value: 'bar', onDrop })
       expect(result.input.onDrop).toBeA('function')
     })
 
     it('should read active from state', () => {
-      const inactiveResult = createFieldProps(getIn, 'foo', {
+      const inactiveResult = createFieldProps({ getIn, toJS }, 'foo', {
         value: 'bar',
         state: empty
       })
       expect(inactiveResult.meta.active).toBe(false)
-      const activeResult = createFieldProps(getIn, 'foo', {
+      const activeResult = createFieldProps({ getIn, toJS }, 'foo', {
         value: 'bar',
         state: fromJS({
           active: true
@@ -83,11 +83,11 @@ const describeCreateFieldProps = (name, structure, expect) => {
     })
 
     it('should pass along submitting flag', () => {
-      const notSubmittingResult = createFieldProps(getIn, 'foo', {
+      const notSubmittingResult = createFieldProps({ getIn, toJS }, 'foo', {
         value: 'bar'
       })
       expect(notSubmittingResult.meta.submitting).toBe(false)
-      const submittingResult = createFieldProps(getIn, 'foo', {
+      const submittingResult = createFieldProps({ getIn, toJS }, 'foo', {
         value: 'bar',
         submitting: true
       })
@@ -95,41 +95,41 @@ const describeCreateFieldProps = (name, structure, expect) => {
     })
 
     it('should pass along all custom state props', () => {
-      const pristineResult = createFieldProps(getIn, 'foo', {
+      const pristineResult = createFieldProps({ getIn, toJS }, 'foo', {
         value: 'bar'
       })
       expect(pristineResult.meta.customProp).toBe(undefined)
-      const customResult = createFieldProps(getIn, 'foo', {
+      const customResult = createFieldProps({ getIn, toJS }, 'foo', {
         value: 'bar',
-        state: {
+        state: fromJS({
           customProp: 'my-custom-prop'
-        }
+        })
       })
       expect(customResult.meta.customProp).toBe('my-custom-prop')
     })
 
     it('should not override canonical props with custom props', () => {
-      const pristineResult = createFieldProps(getIn, 'foo', {
+      const pristineResult = createFieldProps({ getIn, toJS }, 'foo', {
         value: 'bar'
       })
       expect(pristineResult.meta.customProp).toBe(undefined)
-      const customResult = createFieldProps(getIn, 'foo', {
+      const customResult = createFieldProps({ getIn, toJS }, 'foo', {
         value: 'bar',
         submitting: true,
-        state: {
+        state: fromJS({
           submitting: false
-        }
+        })
       })
       expect(customResult.meta.submitting).toBe(true)
     })
 
     it('should read touched from state', () => {
-      const untouchedResult = createFieldProps(getIn, 'foo', {
+      const untouchedResult = createFieldProps({ getIn, toJS }, 'foo', {
         value: 'bar',
         state: empty
       })
       expect(untouchedResult.meta.touched).toBe(false)
-      const touchedResult = createFieldProps(getIn, 'foo', {
+      const touchedResult = createFieldProps({ getIn, toJS }, 'foo', {
         value: 'bar',
         state: fromJS({
           touched: true
@@ -139,12 +139,12 @@ const describeCreateFieldProps = (name, structure, expect) => {
     })
 
     it('should read visited from state', () => {
-      const notVisitedResult = createFieldProps(getIn, 'foo', {
+      const notVisitedResult = createFieldProps({ getIn, toJS }, 'foo', {
         value: 'bar',
         state: empty
       })
       expect(notVisitedResult.meta.visited).toBe(false)
-      const visitedResult = createFieldProps(getIn, 'foo', {
+      const visitedResult = createFieldProps({ getIn, toJS }, 'foo', {
         value: 'bar',
         state: fromJS({
           visited: true
@@ -154,14 +154,14 @@ const describeCreateFieldProps = (name, structure, expect) => {
     })
 
     it('should read sync errors from prop', () => {
-      const noErrorResult = createFieldProps(getIn, 'foo', {
+      const noErrorResult = createFieldProps({ getIn, toJS }, 'foo', {
         value: 'bar',
         state: empty
       })
       expect(noErrorResult.meta.error).toNotExist()
       expect(noErrorResult.meta.valid).toBe(true)
       expect(noErrorResult.meta.invalid).toBe(false)
-      const errorResult = createFieldProps(getIn, 'foo', {
+      const errorResult = createFieldProps({ getIn, toJS }, 'foo', {
         value: 'bar',
         state: empty,
         syncError: 'This is an error'
@@ -172,12 +172,12 @@ const describeCreateFieldProps = (name, structure, expect) => {
     })
 
     it('should read sync warnings from prop', () => {
-      const noWarningResult = createFieldProps(getIn, 'foo', {
+      const noWarningResult = createFieldProps({ getIn, toJS }, 'foo', {
         value: 'bar',
         state: empty
       })
       expect(noWarningResult.meta.warning).toNotExist()
-      const warningResult = createFieldProps(getIn, 'foo', {
+      const warningResult = createFieldProps({ getIn, toJS }, 'foo', {
         value: 'bar',
         state: empty,
         syncWarning: 'This is an warning'
@@ -186,14 +186,14 @@ const describeCreateFieldProps = (name, structure, expect) => {
     })
 
     it('should read async errors from state', () => {
-      const noErrorResult = createFieldProps(getIn, 'foo', {
+      const noErrorResult = createFieldProps({ getIn, toJS }, 'foo', {
         value: 'bar',
         state: empty
       })
       expect(noErrorResult.meta.error).toNotExist()
       expect(noErrorResult.meta.valid).toBe(true)
       expect(noErrorResult.meta.invalid).toBe(false)
-      const errorResult = createFieldProps(getIn, 'foo', {
+      const errorResult = createFieldProps({ getIn, toJS }, 'foo', {
         value: 'bar',
         state: empty,
         syncError: 'This is an error'
@@ -204,14 +204,14 @@ const describeCreateFieldProps = (name, structure, expect) => {
     })
 
     it('should read submit errors from state', () => {
-      const noErrorResult = createFieldProps(getIn, 'foo', {
+      const noErrorResult = createFieldProps({ getIn, toJS }, 'foo', {
         value: 'bar',
         state: empty
       })
       expect(noErrorResult.meta.error).toNotExist()
       expect(noErrorResult.meta.valid).toBe(true)
       expect(noErrorResult.meta.invalid).toBe(false)
-      const errorResult = createFieldProps(getIn, 'foo', {
+      const errorResult = createFieldProps({ getIn, toJS }, 'foo', {
         value: 'bar',
         state: empty,
         submitError: 'This is an error'
@@ -222,14 +222,14 @@ const describeCreateFieldProps = (name, structure, expect) => {
     })
 
     it('should prioritize sync errors over async or submit errors', () => {
-      const noErrorResult = createFieldProps(getIn, 'foo', {
+      const noErrorResult = createFieldProps({ getIn, toJS }, 'foo', {
         value: 'bar',
         state: empty
       })
       expect(noErrorResult.meta.error).toNotExist()
       expect(noErrorResult.meta.valid).toBe(true)
       expect(noErrorResult.meta.invalid).toBe(false)
-      const errorResult = createFieldProps(getIn, 'foo', {
+      const errorResult = createFieldProps({ getIn, toJS }, 'foo', {
         value: 'bar',
         asyncError: 'async error',
         submitError: 'submit error',
@@ -241,7 +241,7 @@ const describeCreateFieldProps = (name, structure, expect) => {
     })
 
     it('should pass through other props', () => {
-      const result = createFieldProps(getIn, 'foo', {
+      const result = createFieldProps({ getIn, toJS }, 'foo', {
         value: 'bar',
         state: empty,
         someOtherProp: 'dog',
@@ -254,7 +254,7 @@ const describeCreateFieldProps = (name, structure, expect) => {
     })
 
     it('should pass through other props using props prop', () => {
-      const result = createFieldProps(getIn, 'foo', {
+      const result = createFieldProps({ getIn, toJS }, 'foo', {
         value: 'bar',
         state: empty,
         props: {
@@ -269,16 +269,16 @@ const describeCreateFieldProps = (name, structure, expect) => {
     })
 
     it('should set checked for checkboxes', () => {
-      expect(createFieldProps(getIn, 'foo', {
+      expect(createFieldProps({ getIn, toJS }, 'foo', {
         state: empty,
         type: 'checkbox'
       }).input.checked).toBe(false)
-      expect(createFieldProps(getIn, 'foo', {
+      expect(createFieldProps({ getIn, toJS }, 'foo', {
         value: true,
         state: empty,
         type: 'checkbox'
       }).input.checked).toBe(true)
-      expect(createFieldProps(getIn, 'foo', {
+      expect(createFieldProps({ getIn, toJS }, 'foo', {
         value: false,
         state: empty,
         type: 'checkbox'
@@ -286,18 +286,18 @@ const describeCreateFieldProps = (name, structure, expect) => {
     })
 
     it('should set checked for radio buttons', () => {
-      expect(createFieldProps(getIn, 'foo', {
+      expect(createFieldProps({ getIn, toJS }, 'foo', {
         state: empty,
         type: 'radio',
         _value: 'bar'
       }).input.checked).toBe(false)
-      expect(createFieldProps(getIn, 'foo', {
+      expect(createFieldProps({ getIn, toJS }, 'foo', {
         value: 'bar',
         state: empty,
         type: 'radio',
         _value: 'bar'
       }).input.checked).toBe(true)
-      expect(createFieldProps(getIn, 'foo', {
+      expect(createFieldProps({ getIn, toJS }, 'foo', {
         value: 'baz',
         state: empty,
         type: 'radio',
@@ -306,7 +306,7 @@ const describeCreateFieldProps = (name, structure, expect) => {
     })
 
     it('should default value to [] for multi-selects', () => {
-      expect(createFieldProps(getIn, 'foo', {
+      expect(createFieldProps({ getIn, toJS }, 'foo', {
         state: empty,
         type: 'select-multiple'
       }).input.value)
@@ -315,7 +315,7 @@ const describeCreateFieldProps = (name, structure, expect) => {
     })
 
     it('should default value to undefined for file inputs', () => {
-      expect(createFieldProps(getIn, 'foo', {
+      expect(createFieldProps({ getIn, toJS }, 'foo', {
         state: empty,
         type: 'file'
       }).input.value)
@@ -323,14 +323,14 @@ const describeCreateFieldProps = (name, structure, expect) => {
     })
 
     it('should replace undefined value with empty string', () => {
-      const result = createFieldProps(getIn, 'foo', {
+      const result = createFieldProps({ getIn, toJS }, 'foo', {
         state: empty
       })
       expect(result.input.value).toBe('')
     })
 
     it('should not format value when format prop is null', () => {
-      const result = createFieldProps(getIn, 'foo', {
+      const result = createFieldProps({ getIn, toJS }, 'foo', {
         state: empty,
         value: null,
         format: null

--- a/src/createFieldProps.js
+++ b/src/createFieldProps.js
@@ -28,7 +28,7 @@ const processProps = (type, props, _value) => {
   return props
 }
 
-const createFieldProps = (getIn, name,
+const createFieldProps = ({ getIn, toJS }, name,
   {
     asyncError, asyncValidating, onBlur, onChange, onDrop, onDragStart, dirty, dispatch, onFocus, format,
     pristine, props, state, submitError, submitting, value,
@@ -58,7 +58,7 @@ const createFieldProps = (getIn, name,
       value: formattedFieldValue
     }, _value),
     meta: {
-      ...state,
+      ...toJS(state),
       active: !!(state && getIn(state, 'active')),
       asyncValidating,
       autofilled: !!(state && getIn(state, 'autofilled')),

--- a/src/structure/immutable/index.js
+++ b/src/structure/immutable/index.js
@@ -17,7 +17,8 @@ const structure = {
     Iterable.isIndexed(value) ? value.toList() : value.toMap()),
   size: list => list ? list.size : 0,
   some: (iterable, callback) => Iterable.isIterable(iterable) ? iterable.some(callback) : false,
-  splice
+  splice,
+  toJS: value => Iterable.isIterable(value) ? value.toJS() : value
 }
 
 export default structure

--- a/src/structure/plain/index.js
+++ b/src/structure/plain/index.js
@@ -15,7 +15,8 @@ const structure = {
   fromJS: value => value,
   size: array => array ? array.length : 0,
   some,
-  splice
+  splice,
+  toJS: value => value
 }
 
 export default structure


### PR DESCRIPTION
cb3abb5b41976458fc0c54246df2eeea1f538d34 added functionality that merged the state into the meta object for fields. However, when using Immutable JS structures the state will be an Immutable.Iterable. When developing in React Native the `Object.assign` call here https://github.com/erikras/redux-form/commit/cb3abb5b41976458fc0c54246df2eeea1f538d34#diff-7eb826f425b082db29894569d83899f8R68 causes an exception as described in #1877 and #1955.

```
One of the sources for assign has an enumerable key on the prototype chain. This is an edge case that we do not support. This error is a performance optimization and not spec compliant.
```

I am assuming this is because the Object.assign polyfill is different in the React Native environment (any confirmation on this?). I tested the webpack polyfill in the Immutable example and it pretty much just transfers properties from one object to another without any checks. I am assuming this is why this error has not had any more attention since it does not happen in browser environments.

EDIT: Found the polyfill https://github.com/facebook/react-native/blob/master/packager/react-packager/src/Resolver/polyfills/polyfills.js#L56

As for the fix I added a `toJS` method to the structure types. This also means I had to expand the first argument in `createFieldProps` and `createFieldsProps` to be an object instead of just `getIn`. I am not familiar with the code base so any pointers and directions for style is much appreciated. It should be noted that I have not tested this solution in React Native environment (only a dirty hack that accomplishes the same). And I have not tested all the examples either but tests are passing.