### PR TITLE
Pass in name to `createFieldProps`

### DIFF
--- a/src/ConnectedField.js
+++ b/src/ConnectedField.js
@@ -106,6 +106,7 @@ const createConnectedField = ({ deepEqual, getIn, toJS }) => {
         name,
         {
           ...rest,
+          name,
           onBlur: this.handleBlur,
           onChange: this.handleChange,
           onDrop: this.handleDrop,

--- a/src/__tests__/Field.spec.js
+++ b/src/__tests__/Field.spec.js
@@ -1473,6 +1473,32 @@ const describeField = (name, structure, combineReducers, expect) => {
       expect(usernameInput.calls[ 2 ].arguments[ 0 ].meta.valid).toBe(true)
       expect(usernameInput.calls[ 2 ].arguments[ 0 ].meta.warning).toBe(undefined)
     })
+
+    it('should pass `name` along to underlying component', () => {
+      const store = makeStore()
+      const usernameInput = createSpy(props => <input {...props.input}/>).andCallThrough()
+      class Form extends Component {
+        render() {
+          return (<div>
+            <Field name="username" component={usernameInput}/>
+          </div>)
+        }
+      }
+      const TestForm = reduxForm({
+        form: 'testForm'
+      })(Form)
+      TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <TestForm/>
+        </Provider>
+      )
+
+      // username input rendered
+      expect(usernameInput).toHaveBeenCalled()
+
+      // username field got name
+      expect(usernameInput.calls[ 0 ].arguments[ 0 ].name).toBe('username')
+    })
   })
 }
 


### PR DESCRIPTION
It disappeared in https://github.com/erikras/redux-form/pull/2161/files#r94125255

It's absence breaks my code