### PR TITLE
Event Callbacks

### DIFF
--- a/docs/api/Field.md
+++ b/docs/api/Field.md
@@ -72,13 +72,41 @@ would pass `value => value.toUpperCase()`. The parameters to your normalize func
 > All the values in the entire form before the current change. This will be an Immutable `Map` if
 > you are using Immutable JS.
 
+#### `onBlur : (event, newValue, previousValue) => void` [optional]
+
+A callback that will be called whenever an `onBlur` event is fired from the underlying input.
+If you call `event.preventDefault()`, the `BLUR` action will _NOT_ be dispatched, and the value
+and focus state will not be updated in the Redux store.
+
+#### `onChange : (event, newValue, previousValue) => void` [optional]
+
+A callback that will be called whenever an `onChange` event is fired from the underlying input.
+If you call `event.preventDefault()`, the `CHANGE` action will _NOT_ be dispatched, and the value
+will not be updated in the Redux store.
+
+#### `onDragStart : (event) => void` [optional]
+
+A callback that will be called whenever an `onDragStart` event is fired from the underlying input.
+
+#### `onDrop : (event, newValue, previousValue) => void` [optional]
+
+A callback that will be called whenever an `onDrop` event is fired from the underlying input.
+If you call `event.preventDefault()`, the `CHANGE` action will _NOT_ be dispatched, and the value
+will not be updated in the Redux store.
+
+#### `onFocus : (event) => void` [optional]
+
+A callback that will be called whenever an `onFocus` event is fired from the underlying input.
+If you call `event.preventDefault()`, the `FOCUS` action will _NOT_ be dispatched, and
+the focus state will not be updated in the Redux store.
+
 #### `props : object` [optional]
 
 Object with custom props to pass through the `Field` component into a component provided
 to `component` prop. This props will be merged to props provided by `Field` itself. This _may_ be
-useful if you are using TypeScript. This construct is completely optional; the primary way of 
-passing props along to your `component` is to give them directly to the `Field` component, but 
-if, for whatever reason, you prefer to bundle them into a separate object, you may do so by 
+useful if you are using TypeScript. This construct is completely optional; the primary way of
+passing props along to your `component` is to give them directly to the `Field` component, but
+if, for whatever reason, you prefer to bundle them into a separate object, you may do so by
 passing them into `props`.
 
 #### `parse : (value, name) => parsedValue` [optional]

--- a/docs/api/Field.md
+++ b/docs/api/Field.md
@@ -297,10 +297,6 @@ tracking for you.
 > The error for this field if its value is not passing validation. Both synchronous,
 > asynchronous, and submit validation errors will be reported here.
 
-#### `meta.warning : String` [optional]
-
-> The warning for this field if its value is not passing warning validation.
-
 #### `meta.invalid : boolean`
 
 > `true` if the field value fails validation (has a validation error). Opposite of `valid`.
@@ -329,3 +325,7 @@ tracking for you.
 
 > `true` if this field has ever had focus. It will only work if you are passing `onFocus` to
 > your input element.
+
+#### `meta.warning : String` [optional]
+
+> The warning for this field if its value is not passing warning validation.

--- a/src/ConnectedField.js
+++ b/src/ConnectedField.js
@@ -57,39 +57,99 @@ const createConnectedField = ({ deepEqual, getIn, toJS }) => {
     }
 
     handleChange(event) {
-      const { name, dispatch, parse, normalize, _reduxForm } = this.props
-      const value = onChangeValue(event, { name, parse, normalize })
+      const { name, dispatch, parse, normalize, onChange, _reduxForm, value: previousValue } = this.props
+      const newValue = onChangeValue(event, { name, parse, normalize })
 
-      dispatch(_reduxForm.change(name, value))
+      let defaultPrevented = false
+      if (onChange) {
+        onChange({
+          ...event,
+          preventDefault: () => {
+            defaultPrevented = true
+            return event.preventDefault()
+          }
+        }, newValue, previousValue)
+      }
+      if (!defaultPrevented) {
+        // dispatch change action
+        dispatch(_reduxForm.change(name, newValue))
+      }
     }
 
-    handleFocus() {
-      const { name, dispatch, _reduxForm } = this.props
-      dispatch(_reduxForm.focus(name))
+    handleFocus(event) {
+      const { name, dispatch, onFocus, _reduxForm } = this.props
+
+      let defaultPrevented = false
+      if (onFocus) {
+        onFocus({
+          ...event,
+          preventDefault: () => {
+            defaultPrevented = true
+            return event.preventDefault()
+          }
+        })
+      }
+
+      if (!defaultPrevented) {
+        dispatch(_reduxForm.focus(name))
+      }
     }
 
     handleBlur(event) {
-      const { name, dispatch, parse, normalize, _reduxForm } = this.props
-      const value = onChangeValue(event, { name, parse, normalize })
+      const { name, dispatch, parse, normalize, onBlur, _reduxForm, value: previousValue } = this.props
+      const newValue = onChangeValue(event, { name, parse, normalize })
 
-      // dispatch blur action
-      dispatch(_reduxForm.blur(name, value))
+      let defaultPrevented = false
+      if (onBlur) {
+        onBlur({
+          ...event,
+          preventDefault: () => {
+            defaultPrevented = true
+            return event.preventDefault()
+          }
+        }, newValue, previousValue)
+      }
 
-      // call post-blur callback
-      if (_reduxForm.asyncValidate) {
-        _reduxForm.asyncValidate(name, value)
+      if (!defaultPrevented) {
+        // dispatch blur action
+        dispatch(_reduxForm.blur(name, newValue))
+
+        // call post-blur callback
+        if (_reduxForm.asyncValidate) {
+          _reduxForm.asyncValidate(name, newValue)
+        }
       }
     }
 
     handleDragStart(event) {
-      const { value } = this.props
+      const { onDragStart, value } = this.props
       event.dataTransfer.setData(dataKey, value == null ? '' : value)
+
+      if (onDragStart) {
+        onDragStart(event)
+      }
     }
 
     handleDrop(event) {
-      const { name, dispatch, _reduxForm } = this.props
-      dispatch(_reduxForm.change(name, event.dataTransfer.getData(dataKey)))
-      event.preventDefault()
+      const { name, dispatch, onDrop, _reduxForm, value: previousValue } = this.props
+      const newValue = event.dataTransfer.getData(dataKey)
+
+      let defaultPrevented = false
+      if (onDrop) {
+        onDrop({
+          ...event,
+          preventDefault: () => {
+            defaultPrevented = true
+            return event.preventDefault()
+          }
+        }, newValue, previousValue)
+      }
+
+      if (!defaultPrevented) {
+        // dispatch change action
+        dispatch(_reduxForm.change(name, newValue))
+        event.preventDefault()
+      }
     }
 
     render() {
@@ -98,8 +158,13 @@ const createConnectedField = ({ deepEqual, getIn, toJS }) => {
         withRef,
         name,
         // remove props that are part of redux internals:
-        _reduxForm, // eslint-disable-line no-unused-vars
-        normalize,  // eslint-disable-line no-unused-vars
+        _reduxForm,  // eslint-disable-line no-unused-vars
+        normalize,   // eslint-disable-line no-unused-vars
+        onBlur,      // eslint-disable-line no-unused-vars
+        onChange,    // eslint-disable-line no-unused-vars
+        onFocus,     // eslint-disable-line no-unused-vars
+        onDragStart, // eslint-disable-line no-unused-vars
+        onDrop,      // eslint-disable-line no-unused-vars
         ...rest
       } = this.props
       const { custom, ...props } = createFieldProps({ getIn, toJS },

--- a/src/Field.js
+++ b/src/Field.js
@@ -104,6 +104,11 @@ const createField = ({ deepEqual, getIn, setIn, toJS }) => {
     component: PropTypes.oneOfType([ PropTypes.func, PropTypes.string ]).isRequired,
     format: PropTypes.func,
     normalize: PropTypes.func,
+    onBlur: PropTypes.func,
+    onChange: PropTypes.func,
+    onFocus: PropTypes.func,
+    onDragStart: PropTypes.func,
+    onDrop: PropTypes.func,
     parse: PropTypes.func,
     props: PropTypes.object
   }

--- a/src/__tests__/Field.spec.js
+++ b/src/__tests__/Field.spec.js
@@ -1519,8 +1519,8 @@ const describeField = (name, structure, combineReducers, expect) => {
       )
 
       expect(renderSpy).toHaveBeenCalled()
-      const props = renderSpy.calls[0].arguments[0]
-      Object.keys(apiProps).forEach(key => expect(props[key]).toNotExist())
+      const props = renderSpy.calls[ 0 ].arguments[ 0 ]
+      Object.keys(apiProps).forEach(key => expect(props[ key ]).toNotExist())
     })
 
     it('should only rerender field that has changed', () => {
@@ -1559,6 +1559,377 @@ const describeField = (name, structure, combineReducers, expect) => {
       // expect input #2 to NOT have been rerendered
       expect(input2.calls.length).toBe(1)
     })
+
+    it('should allow onChange callback', () => {
+      const store = makeStore()
+      const renderInput = createSpy(props => <input {...props.input}/>).andCallThrough()
+      const callback = createSpy()
+      class Form extends Component {
+        render() {
+          return (<div>
+            <Field name="foo" component={renderInput} onChange={callback}/>
+          </div>)
+        }
+      }
+      const TestForm = reduxForm({ form: 'testForm' })(Form)
+      const dom = TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <TestForm/>
+        </Provider>
+      )
+
+      const input = TestUtils.findRenderedDOMComponentWithTag(dom, 'input')
+      input.value = 'bar'
+
+      expect(callback).toNotHaveBeenCalled()
+
+      // rendered once with no onChange prop passed down in custom props
+      expect(renderInput.calls.length).toBe(1)
+      expect(renderInput.calls[ 0 ].arguments[ 0 ].onChange).toNotExist()
+
+      TestUtils.Simulate.change(input)
+
+      // call back was called
+      expect(callback).toHaveBeenCalled()
+      expect(callback.calls.length).toBe(1)
+      expect(callback.calls[ 0 ].arguments[ 0 ]).toExist()  // event
+      expect(callback.calls[ 0 ].arguments[ 1 ]).toBe('bar')
+      expect(callback.calls[ 0 ].arguments[ 2 ]).toBe(undefined)
+
+      // value changed
+      expect(renderInput.calls.length).toBe(2)
+      expect(renderInput.calls[ 1 ].arguments[ 0 ].input.value).toBe('bar')
+    })
+
+    it('should allow onChange callback to prevent change', () => {
+      const store = makeStore()
+      const renderInput = createSpy(props => <input {...props.input}/>).andCallThrough()
+      const callback = createSpy(event => event.preventDefault()).andCallThrough()
+      class Form extends Component {
+        render() {
+          return (<div>
+            <Field name="foo" component={renderInput} onChange={callback}/>
+          </div>)
+        }
+      }
+      const TestForm = reduxForm({ form: 'testForm' })(Form)
+      const dom = TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <TestForm/>
+        </Provider>
+      )
+
+      const input = TestUtils.findRenderedDOMComponentWithTag(dom, 'input')
+      input.value = 'bar'
+
+      expect(callback).toNotHaveBeenCalled()
+
+      // rendered once with no onChange prop passed down in custom props
+      expect(renderInput.calls.length).toBe(1)
+      expect(renderInput.calls[ 0 ].arguments[ 0 ].onChange).toNotExist()
+
+      TestUtils.Simulate.change(input)
+
+      // call back was called
+      expect(callback).toHaveBeenCalled()
+      expect(callback.calls.length).toBe(1)
+      expect(callback.calls[ 0 ].arguments[ 0 ]).toExist()
+      expect(callback.calls[ 0 ].arguments[ 1 ]).toBe('bar')
+      expect(callback.calls[ 0 ].arguments[ 2 ]).toBe(undefined)
+
+      // value NOT changed
+      expect(renderInput.calls.length).toBe(1)
+      expect(renderInput.calls[ 0 ].arguments[ 0 ].input.value).toBe('')
+    })
+
+    it('should allow onBlur callback', () => {
+      const store = makeStore()
+      const renderInput = createSpy(props => <input {...props.input}/>).andCallThrough()
+      const callback = createSpy()
+      class Form extends Component {
+        render() {
+          return (<div>
+            <Field name="foo" component={renderInput} onBlur={callback}/>
+          </div>)
+        }
+      }
+      const TestForm = reduxForm({ form: 'testForm' })(Form)
+      const dom = TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <TestForm/>
+        </Provider>
+      )
+
+      const input = TestUtils.findRenderedDOMComponentWithTag(dom, 'input')
+      input.value = 'bar'
+
+      expect(callback).toNotHaveBeenCalled()
+
+      // rendered once with no onBlur prop passed down in custom props
+      expect(renderInput.calls.length).toBe(1)
+      expect(renderInput.calls[ 0 ].arguments[ 0 ].onBlur).toNotExist()
+
+      TestUtils.Simulate.blur(input)
+
+      // call back was called
+      expect(callback).toHaveBeenCalled()
+      expect(callback.calls.length).toBe(1)
+      expect(callback.calls[ 0 ].arguments[ 0 ]).toExist()  // event
+      expect(callback.calls[ 0 ].arguments[ 1 ]).toBe('bar')
+      expect(callback.calls[ 0 ].arguments[ 2 ]).toBe(undefined)
+
+      // value changed
+      expect(renderInput.calls.length).toBe(2)
+      expect(renderInput.calls[ 1 ].arguments[ 0 ].input.value).toBe('bar')
+    })
+
+    it('should allow onBlur callback to prevent blur', () => {
+      const store = makeStore()
+      const renderInput = createSpy(props => <input {...props.input}/>).andCallThrough()
+      const callback = createSpy(event => event.preventDefault()).andCallThrough()
+      class Form extends Component {
+        render() {
+          return (<div>
+            <Field name="foo" component={renderInput} onBlur={callback}/>
+          </div>)
+        }
+      }
+      const TestForm = reduxForm({ form: 'testForm' })(Form)
+      const dom = TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <TestForm/>
+        </Provider>
+      )
+
+      const input = TestUtils.findRenderedDOMComponentWithTag(dom, 'input')
+      input.value = 'bar'
+
+      expect(callback).toNotHaveBeenCalled()
+
+      // rendered once with no onBlur prop passed down in custom props
+      expect(renderInput.calls.length).toBe(1)
+      expect(renderInput.calls[ 0 ].arguments[ 0 ].onBlur).toNotExist()
+
+      TestUtils.Simulate.blur(input)
+
+      // call back was called
+      expect(callback).toHaveBeenCalled()
+      expect(callback.calls.length).toBe(1)
+      expect(callback.calls[ 0 ].arguments[ 0 ]).toExist()
+      expect(callback.calls[ 0 ].arguments[ 1 ]).toBe('bar')
+      expect(callback.calls[ 0 ].arguments[ 2 ]).toBe(undefined)
+
+      // value NOT changed
+      expect(renderInput.calls.length).toBe(1)
+      expect(renderInput.calls[ 0 ].arguments[ 0 ].input.value).toBe('')
+    })
+
+    it('should allow onFocus callback', () => {
+      const store = makeStore()
+      const renderInput = createSpy(props => <input {...props.input}/>).andCallThrough()
+      const callback = createSpy()
+      class Form extends Component {
+        render() {
+          return (<div>
+            <Field name="foo" component={renderInput} onFocus={callback}/>
+          </div>)
+        }
+      }
+      const TestForm = reduxForm({ form: 'testForm' })(Form)
+      const dom = TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <TestForm/>
+        </Provider>
+      )
+
+      const input = TestUtils.findRenderedDOMComponentWithTag(dom, 'input')
+
+      expect(callback).toNotHaveBeenCalled()
+
+      // rendered once with no onFocus prop passed down in custom props
+      expect(renderInput.calls.length).toBe(1)
+      expect(renderInput.calls[ 0 ].arguments[ 0 ].onFocus).toNotExist()
+
+      // not marked as active
+      expect(renderInput.calls[ 0 ].arguments[ 0 ].meta.active).toBe(false)
+
+      TestUtils.Simulate.focus(input)
+
+      // call back was called
+      expect(callback).toHaveBeenCalled()
+      expect(callback.calls.length).toBe(1)
+      expect(callback.calls[ 0 ].arguments[ 0 ]).toExist()  // event
+
+      // field marked active
+      expect(renderInput.calls.length).toBe(2)
+      expect(renderInput.calls[ 1 ].arguments[ 0 ].meta.active).toBe(true)
+    })
+
+    it('should allow onFocus callback to prevent focus', () => {
+      const store = makeStore()
+      const renderInput = createSpy(props => <input {...props.input}/>).andCallThrough()
+      const callback = createSpy(event => event.preventDefault()).andCallThrough()
+      class Form extends Component {
+        render() {
+          return (<div>
+            <Field name="foo" component={renderInput} onFocus={callback}/>
+          </div>)
+        }
+      }
+      const TestForm = reduxForm({ form: 'testForm' })(Form)
+      const dom = TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <TestForm/>
+        </Provider>
+      )
+
+      const input = TestUtils.findRenderedDOMComponentWithTag(dom, 'input')
+
+      expect(callback).toNotHaveBeenCalled()
+
+      // rendered once with no onFocus prop passed down in custom props
+      expect(renderInput.calls.length).toBe(1)
+      expect(renderInput.calls[ 0 ].arguments[ 0 ].onFocus).toNotExist()
+
+      // not marked as active
+      expect(renderInput.calls[ 0 ].arguments[ 0 ].meta.active).toBe(false)
+
+      TestUtils.Simulate.focus(input)
+
+      // call back was called
+      expect(callback).toHaveBeenCalled()
+      expect(callback.calls.length).toBe(1)
+      expect(callback.calls[ 0 ].arguments[ 0 ]).toExist()
+
+      // field NOT marked active
+      expect(renderInput.calls.length).toBe(1)
+      expect(renderInput.calls[ 0 ].arguments[ 0 ].meta.active).toBe(false)
+    })
+    
+    it('should allow onDrop callback', () => {
+      const store = makeStore()
+      const renderInput = createSpy(props => <input {...props.input}/>).andCallThrough()
+      const callback = createSpy()
+      class Form extends Component {
+        render() {
+          return (<div>
+            <Field name="foo" component={renderInput} onDrop={callback}/>
+          </div>)
+        }
+      }
+      const TestForm = reduxForm({ form: 'testForm' })(Form)
+      const dom = TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <TestForm/>
+        </Provider>
+      )
+
+      const input = TestUtils.findRenderedDOMComponentWithTag(dom, 'input')
+
+      expect(callback).toNotHaveBeenCalled()
+
+      // rendered once with no onDrop prop passed down in custom props
+      expect(renderInput.calls.length).toBe(1)
+      expect(renderInput.calls[ 0 ].arguments[ 0 ].onDrop).toNotExist()
+
+      TestUtils.Simulate.drop(input, {
+        dataTransfer: { getData: () => 'bar' }
+      })
+
+      // call back was called
+      expect(callback).toHaveBeenCalled()
+      expect(callback.calls.length).toBe(1)
+      expect(callback.calls[ 0 ].arguments[ 0 ]).toExist()  // event
+      expect(callback.calls[ 0 ].arguments[ 1 ]).toBe('bar')
+      expect(callback.calls[ 0 ].arguments[ 2 ]).toBe(undefined)
+
+      // value changed
+      expect(renderInput.calls.length).toBe(2)
+      expect(renderInput.calls[ 1 ].arguments[ 0 ].input.value).toBe('bar')
+    })
+
+    it('should allow onDrop callback to prevent drop', () => {
+      const store = makeStore()
+      const renderInput = createSpy(props => <input {...props.input}/>).andCallThrough()
+      const callback = createSpy(event => event.preventDefault()).andCallThrough()
+      class Form extends Component {
+        render() {
+          return (<div>
+            <Field name="foo" component={renderInput} onDrop={callback}/>
+          </div>)
+        }
+      }
+      const TestForm = reduxForm({ form: 'testForm' })(Form)
+      const dom = TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <TestForm/>
+        </Provider>
+      )
+
+      const input = TestUtils.findRenderedDOMComponentWithTag(dom, 'input')
+      input.value = 'bar'
+
+      expect(callback).toNotHaveBeenCalled()
+
+      // rendered once with no onDrop prop passed down in custom props
+      expect(renderInput.calls.length).toBe(1)
+      expect(renderInput.calls[ 0 ].arguments[ 0 ].onDrop).toNotExist()
+
+      TestUtils.Simulate.drop(input, {
+        dataTransfer: { getData: () => 'bar' }
+      })
+
+      // call back was called
+      expect(callback).toHaveBeenCalled()
+      expect(callback.calls.length).toBe(1)
+      expect(callback.calls[ 0 ].arguments[ 0 ]).toExist()
+      expect(callback.calls[ 0 ].arguments[ 1 ]).toBe('bar')
+      expect(callback.calls[ 0 ].arguments[ 2 ]).toBe(undefined)
+
+      // value NOT changed
+      expect(renderInput.calls.length).toBe(1)
+      expect(renderInput.calls[ 0 ].arguments[ 0 ].input.value).toBe('')
+    })
+
+    it('should allow onDragStart callback', () => {
+      const store = makeStore()
+      const renderInput = createSpy(props => <input {...props.input}/>).andCallThrough()
+      const callback = createSpy()
+      class Form extends Component {
+        render() {
+          return (<div>
+            <Field name="foo" component={renderInput} onDragStart={callback}/>
+          </div>)
+        }
+      }
+      const TestForm = reduxForm({ form: 'testForm' })(Form)
+      const dom = TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <TestForm/>
+        </Provider>
+      )
+
+      const input = TestUtils.findRenderedDOMComponentWithTag(dom, 'input')
+
+      expect(callback).toNotHaveBeenCalled()
+
+      // rendered once with no onDragStart prop passed down in custom props
+      expect(renderInput.calls.length).toBe(1)
+      expect(renderInput.calls[ 0 ].arguments[ 0 ].onDragStart).toNotExist()
+
+      TestUtils.Simulate.dragStart(input, {
+        dataTransfer: { setData: () => {} }
+      })
+
+      // call back was called
+      expect(callback).toHaveBeenCalled()
+      expect(callback.calls.length).toBe(1)
+      expect(callback.calls[ 0 ].arguments[ 0 ]).toExist()  // event
+
+      // value NOT changed
+      expect(renderInput.calls.length).toBe(1)
+    })
+
   })
 }
 


### PR DESCRIPTION
Introduces new `onBlur`, `onChange`, `onFocus`, `onDragStart`, and `onDrop` callback props that can be given to `Field`, which also provide `event.preventDefault()` functionality to cancel events triggering Redux actions.

Fixes #2334.