### PR TITLE
Remove `values` from instance API docs

### DIFF
--- a/docs/api/ReduxForm.md
+++ b/docs/api/ReduxForm.md
@@ -293,10 +293,6 @@ when the form is submitted successfully, or rejected if the submission fails.
 
 `true` when the form is valid (has no validation errors), `false` otherwise.
 
-#### `values : Object`
-
-The current values of all the fields in the form.
-
 #### `wrappedInstance : ReactElement`
 
 A reference to the instance of the component you decorated with `reduxForm()`. Mainly useful for


### PR DESCRIPTION
Been using v6 for a little while and have noticed the fact that you can't do `this.props.values` anymore. The reasoning for this appears to be stated in point 1 [here](https://github.com/erikras/redux-form/issues/726):

> When writing the initial API, I provided things that seemed convenient for small forms, like having this.props.values be the current state of the values of your form. This required having the wrapping form component to be connected to the Redux store, _and to re-render on every value change_.

This makes sense. In order to get current values now, it appears one should use a selector.

With that being the case,  it seems like this part of the docs is incorrect? Shouldn't `values` be removed here? Or am I missing something? The `values` key doesn't appear to be part of my props object.

![screen shot 2017-01-04 at 1 09 39 pm](https://cloud.githubusercontent.com/assets/1316441/21657687/a7869af6-d280-11e6-9979-9234cf23f591.png)
