### PR TITLE
Add Props to onSubmitSuccess and onSubmitFail

### DIFF
--- a/docs/api/ReduxForm.md
+++ b/docs/api/ReduxForm.md
@@ -60,7 +60,7 @@ will retain the value of dirty fields when reinitializing.
 
 #### `forceUnregisterOnUnmount : boolean` [optional]
 
-> Whether or not to force unregistration of fields -- use in conjunction with `destroyOnUnmount`. Useful for wizard-type forms where you want to destroy fields as they unmount, but not the form's state. Defaults to `false`, as forms are normally unregistered on unmount. 
+> Whether or not to force unregistration of fields -- use in conjunction with `destroyOnUnmount`. Useful for wizard-type forms where you want to destroy fields as they unmount, but not the form's state. Defaults to `false`, as forms are normally unregistered on unmount.
 
 #### `getFormState : Function` [optional]
 
@@ -126,7 +126,11 @@ called with the following parameters:
 ##### `submitError : Error`
 
 > The error object that caused the submission to fail. If `errors` is set this will be most likely a `SubmissionError`, otherwise it can be any error or null.
- 
+
+> ##### `props : Object`
+
+> The props passed into your decorated component.
+
 #### `onSubmitSuccess : Function` [optional]
 
 > A callback function that will be called when a submission succeeds.  It will be called with the
@@ -139,6 +143,10 @@ following parameters:
 > ##### `dispatch : Function`
 
 > The Redux `dispatch` function.
+
+> ##### `props : Object`
+
+> The props passed into your decorated component.
 
 #### `propNamespace : String` [optional]
 

--- a/src/__tests__/handleSubmit.spec.js
+++ b/src/__tests__/handleSubmit.spec.js
@@ -155,6 +155,7 @@ describe('handleSubmit', () => {
         expect(onSubmitFail.calls[0].arguments[0]).toEqual(values)
         expect(onSubmitFail.calls[0].arguments[1]).toEqual(dispatch)
         expect(onSubmitFail.calls[0].arguments[2]).toBe(null)
+        expect(onSubmitFail.calls[0].arguments[3]).toEqual(props)
         expect(touch)
           .toHaveBeenCalled()
           .toHaveBeenCalledWith('foo', 'baz')

--- a/src/__tests__/reduxForm.spec.js
+++ b/src/__tests__/reduxForm.spec.js
@@ -1959,11 +1959,13 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
 
       expect(onSubmitSuccess).toNotHaveBeenCalled()
 
+      const calledProps = stub.refs.wrapped.wrappedInstance.props
+
       const returned = stub.submit()
 
       expect(onSubmitSuccess)
         .toHaveBeenCalled()
-        .toHaveBeenCalledWith(result, store.dispatch)
+        .toHaveBeenCalledWith(result, store.dispatch, calledProps)
       expect(returned).toBe(result)
     })
 
@@ -1999,11 +2001,13 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
 
       expect(onSubmitSuccess).toNotHaveBeenCalled()
 
+      const calledProps = stub.refs.wrapped.wrappedInstance.props
+
       return stub.submit()
         .then(returned => {
           expect(onSubmitSuccess)
             .toHaveBeenCalled()
-            .toHaveBeenCalledWith(result, store.dispatch)
+            .toHaveBeenCalledWith(result, store.dispatch, calledProps)
           expect(returned).toBe(result)
         })
     })

--- a/src/handleSubmit.js
+++ b/src/handleSubmit.js
@@ -19,7 +19,7 @@ const handleSubmit = (submit, props, valid, asyncValidate, fields) => {
         stopSubmit(error)
         setSubmitFailed(...fields)
         if (onSubmitFail) {
-          onSubmitFail(error, dispatch, submitError)
+          onSubmitFail(error, dispatch, submitError, props)
         }
         if (error || onSubmitFail) {
           // if you've provided an onSubmitFail callback, don't re-throw the error
@@ -35,7 +35,7 @@ const handleSubmit = (submit, props, valid, asyncValidate, fields) => {
             stopSubmit()
             setSubmitSucceeded()
             if (onSubmitSuccess) {
-              onSubmitSuccess(submitResult, dispatch)
+              onSubmitSuccess(submitResult, dispatch, props)
             }
             return submitResult
           }, submitError => {
@@ -43,7 +43,7 @@ const handleSubmit = (submit, props, valid, asyncValidate, fields) => {
             stopSubmit(error)
             setSubmitFailed(...fields)
             if (onSubmitFail) {
-              onSubmitFail(error, dispatch, submitError)
+              onSubmitFail(error, dispatch, submitError, props)
             }
             if (error || onSubmitFail) {
               // if you've provided an onSubmitFail callback, don't re-throw the error
@@ -55,7 +55,7 @@ const handleSubmit = (submit, props, valid, asyncValidate, fields) => {
       } else {
         setSubmitSucceeded()
         if (onSubmitSuccess) {
-          onSubmitSuccess(result, dispatch)
+          onSubmitSuccess(result, dispatch, props)
         }
       }
       return result
@@ -73,7 +73,7 @@ const handleSubmit = (submit, props, valid, asyncValidate, fields) => {
         .catch(asyncErrors => {
           setSubmitFailed(...fields)
           if (onSubmitFail) {
-            onSubmitFail(asyncErrors, dispatch, null)
+            onSubmitFail(asyncErrors, dispatch, null, props)
           }
           return Promise.reject(asyncErrors)
         })
@@ -83,7 +83,7 @@ const handleSubmit = (submit, props, valid, asyncValidate, fields) => {
   } else {
     setSubmitFailed(...fields)
     if (onSubmitFail) {
-      onSubmitFail(syncErrors, dispatch, null)
+      onSubmitFail(syncErrors, dispatch, null, props)
     }
     return syncErrors
   }


### PR DESCRIPTION
Completes #2394 

In some situations it would be helpful to have access to the props on the component during the onSubmitSuccess and onSubmitFail callbacks. This PR passes them in on those callbacks.