### PR TITLE
Multi-destroy and getFormNames selector

### DIFF
--- a/docs/api/Selectors.md
+++ b/docs/api/Selectors.md
@@ -15,6 +15,7 @@ import {
   getFormSyncErrors,
   getFormAsyncErrors,
   getFormSubmitErrors,
+  getFormNames,
   isDirty,
   isPristine,
   isValid,
@@ -30,6 +31,7 @@ MyComponent = connect(
     syncErrors: getFormSyncErrors('myForm')(state),
     asyncErrors: getFormAsyncErrors('myForm')(state),
     submitErrors: getFormSubmitErrors('myForm')(state),
+    names: getFormNames('myForm')(state),
     dirty: isDirty('myForm')(state),
     pristine: isPristine('myForm')(state),
     valid: isValid('myForm')(state),
@@ -58,6 +60,12 @@ MyComponent = connect(
 ### `getFormSubmitErrors(formName:String)` returns `(state) => formSubmitErrors:Object`
 
 > Returns the form submit validation errors.
+
+### `getFormNames(formName:String)` returns `(state) => formNames:Array`
+
+> Gets the names of all the forms currently managed by Redux-Form.
+
+> If you are using ImmutableJS, it will return a `List`.
 
 ### `isDirty(formName:String)` returns `(state) => dirty:boolean`
 

--- a/docs/api/Selectors.md
+++ b/docs/api/Selectors.md
@@ -61,7 +61,7 @@ MyComponent = connect(
 
 > Returns the form submit validation errors.
 
-### `getFormNames(formName:String)` returns `(state) => formNames:Array`
+### `getFormNames()` returns `(state) => formNames:Array`
 
 > Gets the names of all the forms currently managed by Redux-Form.
 

--- a/docs/api/Selectors.md
+++ b/docs/api/Selectors.md
@@ -6,8 +6,14 @@
 [**selectors**](http://redux.js.org/docs/recipes/ComputingDerivedData.html) that may be used in
 any part of your application to query the state of any of your forms.
 
-All of the selectors listed below have the same usage pattern: they all take the name of the
-form, and create a selector for whatever form state the selector is for.
+All of the selectors listed below have the same usage pattern: they all (apart from
+getFormNames) take the name of the form, and create a selector for whatever form state
+the selector is for.
+
+They also all take an undocumented final parameter `getFormState()` that is
+used to select the mount point of the `redux-form` reducer from the root Redux reducer (it
+defaults to `state => state.form`, assuming that you have mounted the `redux-form` reducer under
+`form`.
 
 ```js
 import {
@@ -64,6 +70,11 @@ MyComponent = connect(
 ### `getFormNames()` returns `(state) => formNames:Array`
 
 > Gets the names of all the forms currently managed by Redux-Form.
+
+> The reason that this is a function that returns a function is twofold:
+
+> 1. symmetry with the other selectors
+> 2. to allow for the `getFormState` parameter described at the top of this page.
 
 > If you are using ImmutableJS, it will return a `List`.
 

--- a/src/__tests__/actions.spec.js
+++ b/src/__tests__/actions.spec.js
@@ -391,7 +391,15 @@ describe('actions', () => {
       .toEqual({
         type: DESTROY,
         meta: {
-          form: 'myForm'
+          form: [ 'myForm' ]
+        }
+      })
+      .toPass(isFSA)
+    expect(destroy('myForm1', 'myForm2'))
+      .toEqual({
+        type: DESTROY,
+        meta: {
+          form: [ 'myForm1', 'myForm2' ]
         }
       })
       .toPass(isFSA)

--- a/src/__tests__/reducer.destroy.spec.js
+++ b/src/__tests__/reducer.destroy.spec.js
@@ -20,6 +20,32 @@ const describeDestroy = (reducer, expect, { fromJS }) => () => {
         }
       })
   })
+
+  it('should destroy form state for multiple forms', () => {
+    const state = reducer(fromJS({
+      foo: {
+        values: {
+          myField: 'fooInitialValue'
+        },
+        active: 'myFooField'
+      },
+      bar: {
+        values: {
+          myField: 'barInitialValue'
+        },
+        active: 'myBarField'
+      },
+      otherThing: {
+        touchThis: false
+      }
+    }), destroy('foo', 'bar'))
+    expect(state)
+      .toEqualMap({
+        otherThing: {
+          touchThis: false
+        }
+      })
+  })
 }
 
 export default describeDestroy

--- a/src/actions.js
+++ b/src/actions.js
@@ -67,7 +67,7 @@ export const clearSubmit = (form) =>
 export const clearAsyncError = (form, field) =>
   ({ type: CLEAR_ASYNC_ERROR, meta: { form, field } })
 
-export const destroy = (form) =>
+export const destroy = (...form) =>
   ({ type: DESTROY, meta: { form } })
 
 export const focus = (form, field) =>

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -411,7 +411,7 @@ const createReducer = structure => {
         return state
       }
       if (action.type === DESTROY) {
-        return deleteInWithCleanUp(state, action.meta.form)
+        return action.meta.form.reduce((result, form) => deleteInWithCleanUp(result, form), state)
       }
       const formState = getIn(state, form)
       const result = reducer(formState, action)

--- a/src/selectors/__tests__/getFormNames.spec.js
+++ b/src/selectors/__tests__/getFormNames.spec.js
@@ -12,11 +12,11 @@ const describeGetFormNames = (name, structure, expect) => {
 
   describe(name, () => {
     it('should return a function', () => {
-      expect(getFormNames('foo')).toBeA('function')
+      expect(getFormNames()).toBeA('function')
     })
 
     it('should get the form names from state', () => {
-      expect(getFormNames('foo')(fromJS({
+      expect(getFormNames()(fromJS({
         form: {
           foo: {
             values: {
@@ -35,7 +35,7 @@ const describeGetFormNames = (name, structure, expect) => {
     })
 
     it('should use getFormState if provided', () => {
-      expect(getFormNames('foo', state => getIn(state, 'someOtherSlice'))(fromJS({
+      expect(getFormNames(state => getIn(state, 'someOtherSlice'))(fromJS({
         someOtherSlice: {
           foo: {
             values: {

--- a/src/selectors/__tests__/getFormNames.spec.js
+++ b/src/selectors/__tests__/getFormNames.spec.js
@@ -1,0 +1,59 @@
+import createGetFormNames from '../getFormNames'
+import plain from '../../structure/plain'
+import plainExpectations from '../../structure/plain/expectations'
+import immutable from '../../structure/immutable'
+import immutableExpectations from '../../structure/immutable/expectations'
+import addExpectations from '../../__tests__/addExpectations'
+
+const describeGetFormNames = (name, structure, expect) => {
+  const getFormNames = createGetFormNames(structure)
+
+  const { fromJS, getIn } = structure
+
+  describe(name, () => {
+    it('should return a function', () => {
+      expect(getFormNames('foo')).toBeA('function')
+    })
+
+    it('should get the form names from state', () => {
+      expect(getFormNames('foo')(fromJS({
+        form: {
+          foo: {
+            values: {
+              dog: 'Snoopy',
+              cat: 'Garfield'
+            }
+          },
+          bar: {
+            values: {
+              dog: 'Fido',
+              cat: 'Whiskers'
+            }
+          }
+        }
+      }))).toEqualMap([ 'foo', 'bar' ])
+    })
+
+    it('should use getFormState if provided', () => {
+      expect(getFormNames('foo', state => getIn(state, 'someOtherSlice'))(fromJS({
+        someOtherSlice: {
+          foo: {
+            values: {
+              dog: 'Snoopy',
+              cat: 'Garfield'
+            }
+          },
+          bar: {
+            values: {
+              dog: 'Fido',
+              cat: 'Whiskers'
+            }
+          }
+        }
+      }))).toEqualMap([ 'foo', 'bar' ])
+    })
+  })
+}
+
+describeGetFormNames('getFormNames.plain', plain, addExpectations(plainExpectations))
+describeGetFormNames('getFormNames.immutable', immutable, addExpectations(immutableExpectations))

--- a/src/selectors/getFormNames.js
+++ b/src/selectors/getFormNames.js
@@ -1,5 +1,5 @@
 const createGetFormNames = ({ getIn, keys }) =>
-  (form, getFormState = state => getIn(state, 'form')) =>
+  (getFormState = state => getIn(state, 'form')) =>
     state => keys(getFormState(state))
 
 export default createGetFormNames

--- a/src/selectors/getFormNames.js
+++ b/src/selectors/getFormNames.js
@@ -1,0 +1,5 @@
+const createGetFormNames = ({ getIn, keys }) =>
+  (form, getFormState = state => getIn(state, 'form')) =>
+    state => keys(getFormState(state))
+
+export default createGetFormNames

--- a/src/structure/immutable/__tests__/keys.spec.js
+++ b/src/structure/immutable/__tests__/keys.spec.js
@@ -1,0 +1,23 @@
+import expect from 'expect'
+import { is, fromJS, Map, List } from 'immutable'
+import keys from '../keys'
+
+const expectEqual = (a, b) => expect(is(a, b)).toBe(true)
+
+describe('structure.immutable.keys', () => {
+  it('should return empty List if state is undefined', () => {
+    expectEqual(keys(undefined), List())
+  })
+
+  it('should return empty List if no keys', () => {
+    expectEqual(keys(Map()), List())
+  })
+
+  it('should return keys', () => {
+    expectEqual(keys(fromJS({
+      a: 1,
+      b: 2,
+      c: 3
+    })), List([ 'a', 'b', 'c' ]))
+  })
+})

--- a/src/structure/immutable/index.js
+++ b/src/structure/immutable/index.js
@@ -1,13 +1,16 @@
 import { Map, Iterable, List, fromJS } from 'immutable'
 import { toPath } from 'lodash'
 import deepEqual from './deepEqual'
+import keys from './keys'
 import setIn from './setIn'
 import splice from './splice'
 import plainGetIn from '../plain/getIn'
 
+const emptyList = List()
+
 const structure = {
   empty: Map(),
-  emptyList: List(),
+  emptyList,
   getIn: (state, field) =>
     Map.isMap(state) || List.isList(state) ? state.getIn(toPath(field)) : plainGetIn(state, field),
   setIn,
@@ -15,6 +18,7 @@ const structure = {
   deleteIn: (state, field) => state.deleteIn(toPath(field)),
   fromJS: jsValue => fromJS(jsValue, (key, value) =>
     Iterable.isIndexed(value) ? value.toList() : value.toMap()),
+  keys,
   size: list => list ? list.size : 0,
   some: (iterable, callback) => Iterable.isIterable(iterable) ? iterable.some(callback) : false,
   splice,

--- a/src/structure/immutable/keys.js
+++ b/src/structure/immutable/keys.js
@@ -1,0 +1,7 @@
+import { Iterable, List } from 'immutable'
+
+const empty = List()
+
+const keys = value => Iterable.isIterable(value) ? value.keySeq() : empty
+
+export default keys

--- a/src/structure/plain/__tests__/keys.spec.js
+++ b/src/structure/plain/__tests__/keys.spec.js
@@ -1,0 +1,20 @@
+import expect from 'expect'
+import keys from '../keys'
+
+describe('structure.plain.keys', () => {
+  it('should return empty array if state is undefined', () => {
+    expect(keys(undefined)).toEqual([])
+  })
+
+  it('should return empty if no keys', () => {
+    expect(keys({})).toEqual([])
+  })
+
+  it('should return keys', () => {
+    expect(keys({
+      a: 1,
+      b: 2,
+      c: 3
+    })).toEqual([ 'a', 'b', 'c' ])
+  })
+})

--- a/src/structure/plain/index.js
+++ b/src/structure/plain/index.js
@@ -3,6 +3,7 @@ import getIn from './getIn'
 import setIn from './setIn'
 import deepEqual from './deepEqual'
 import deleteIn from './deleteIn'
+import keys from './keys'
 import { some } from 'lodash'
 
 const structure = {
@@ -13,6 +14,7 @@ const structure = {
   deepEqual,
   deleteIn,
   fromJS: value => value,
+  keys,
   size: array => array ? array.length : 0,
   some,
   splice,

--- a/src/structure/plain/keys.js
+++ b/src/structure/plain/keys.js
@@ -1,0 +1,3 @@
+const keys = value => value ? Object.keys(value) : []
+
+export default keys


### PR DESCRIPTION
* Allowed multiple form names to be passed to `destroy()` action creator.
* Created `getFormNames(state)` selector

Fixes #2397.

Allows for fun stuff like:
```jsx
import { getFormNames, isDirty } from 'redux-form'

const dirtyForms = getFormNames()(state).filter(form => isDirty(form)(state))
```