### PR TITLE
add keepSubmitSucceeded option to initialize action

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -183,7 +183,7 @@ const createReducer = structure => {
       result = setIn(result, 'active', field)
       return result
     },
-    [INITIALIZE](state, { payload, meta: { keepDirty } }) {
+    [INITIALIZE](state, { payload, meta: { keepDirty, keepSubmitSucceeded } }) {
       const mapData = fromJS(payload)
       let result = empty // clean all field state
 
@@ -237,6 +237,9 @@ const createReducer = structure => {
             newValues = setIn(newValues, name, previousValue)
           }
         })
+      }
+      if (keepSubmitSucceeded && getIn(state, 'submitSucceeded')) {
+        result = setIn(result, 'submitSucceeded', true) 
       }
       result = setIn(result, 'values', newValues)
       result = setIn(result, 'initial', mapData)


### PR DESCRIPTION
this way one can re-initialize the form after submission without blowing away the `submitSucceeded` value.
My proposed solution to #1994 

Let me know if you guys are OK with this and I can add docs and tests for it.