### PR TITLE
Choose getIn based off Iterable.isIterable()

### DIFF
--- a/src/structure/immutable/index.js
+++ b/src/structure/immutable/index.js
@@ -12,7 +12,7 @@ const structure = {
   empty: Map(),
   emptyList,
   getIn: (state, field) =>
-    Map.isMap(state) || List.isList(state) ? state.getIn(toPath(field)) : plainGetIn(state, field),
+    Iterable.isIterable(state) ? state.getIn(toPath(field)) : plainGetIn(state, field),
   setIn,
   deepEqual,
   deleteIn: (state, field) => state.deleteIn(toPath(field)),


### PR DESCRIPTION
Currently `structure.getIn` breaks when using Immutable `Record`s or other keyed Immutable objects that aren't `Map`s or `List`s, because it tries to use the `plainGetIn` on those.

I've tested this fix in the context of an app I'm working on and these changes work in my case, but haven't verified with any actual tests. By definition all `Iterable`s have `getIn` so I think it's a low risk change, at least one that's guaranteed to not break any existing desired behaviours with `Map`s and `List`s.

The symptoms are that `ConnectedField`s are unable to find the field's values in state and `value` is subsequently passed down as an empty string.