### PR TITLE
feat(initialize): add keepSubmitSucceeded option

### DIFF
--- a/docs/api/ActionCreators.md
+++ b/docs/api/ActionCreators.md
@@ -69,12 +69,18 @@ insert, so the item already at the `to` position will be bumped to a higher inde
 
 > Marks the given field as `active` and `visited`.
 
-### `initialize(form:String, data:Object, keepDirty:boolean)`
+### `initialize(form:String, data:Object, [keepDirty:boolean], [options:{keepDirty:boolean, keepSubmitSucceeded:boolean}])`
 
 > Sets the initial values in the form with which future data values will be compared to calculate
 `dirty` and `pristine`. The `data` parameter may contain deep nested array and object values that match the shape of
-your form fields. If the `keepDirty` parameter is `true`, the values of currently dirty fields will be retained
-to avoid overwriting user edits.
+your form fields.
+
+> If the `keepDirty` parameter is `true`, the values of currently dirty fields will be retained
+to avoid overwriting user edits.  (`keepDirty` can appear as either the third argument, or a property of `options` as
+the 3rd or 4th argument, for the sake of backwards compatibility).
+
+> If the `keepSubmitSucceeded` parameter is `true`, 
+it will not clear the `submitSucceeded` flag if it is set.
 
 ### `registerField(form:String, name:String, type:String)`
 

--- a/src/__tests__/reducer.initialize.spec.js
+++ b/src/__tests__/reducer.initialize.spec.js
@@ -172,6 +172,37 @@ const describeInitialize = (reducer, expect, { fromJS }) => () => {
         }
       })
   })
+  
+  it('should not retain submitSucceeded when keepSubmitSucceeded is not set', () => {
+    const state = reducer(fromJS({
+      foo: {
+        submitSucceeded: true 
+      }
+    }), initialize('foo', {}))
+    expect(state)
+      .toEqualMap({
+        foo: {
+          values: {},
+          initial: {}
+        }
+      })    
+  })
+  
+  it('should retain submitSucceeded when keepSubmitSucceeded is set', () => {
+    const state = reducer(fromJS({
+      foo: {
+        submitSucceeded: true 
+      }
+    }), initialize('foo', {}, { keepSubmitSucceeded: true }))
+    expect(state)
+      .toEqualMap({
+        foo: {
+          values: {},
+          initial: {},
+          submitSucceeded: true 
+        }
+      })    
+  })
 
   it('should retain dirty values when keepDirty is set', () => {
     const state = reducer(fromJS({
@@ -255,6 +286,36 @@ const describeInitialize = (reducer, expect, { fromJS }) => () => {
           ],
           values: {
             myField: 'newValue'
+          },
+          initial: {
+            myField: 'newValue'
+          }
+        }
+      })
+  })
+  
+  it('allows passing keepDirty in options argument', () => {
+    const state = reducer(fromJS({
+      foo: {
+        registeredFields: [
+          { name: 'myField', type: 'Field' }
+        ],
+        values: {
+          myField: 'dirtyValue'
+        },
+        initial: {
+          myField: 'initialValue'
+        }
+      }
+    }), initialize('foo', { myField: 'newValue' }, { keepDirty: true }))
+    expect(state)
+      .toEqualMap({
+        foo: {
+          registeredFields: [
+            { name: 'myField', type: 'Field' }
+          ],
+          values: {
+            myField: 'dirtyValue'
           },
           initial: {
             myField: 'newValue'

--- a/src/actions.js
+++ b/src/actions.js
@@ -73,8 +73,13 @@ export const destroy = (...form) =>
 export const focus = (form, field) =>
   ({ type: FOCUS, meta: { form, field } })
 
-export const initialize = (form, values, keepDirty) =>
-  ({ type: INITIALIZE, meta: { form, keepDirty }, payload: values })
+export const initialize = (form, values, keepDirty, otherMeta = {}) => {
+  if (keepDirty instanceof Object) {
+    otherMeta = keepDirty
+    keepDirty = false
+  }
+  return { type: INITIALIZE, meta: { form, keepDirty, ...otherMeta }, payload: values }
+}
 
 export const registerField = (form, name, type) =>
   ({ type: REGISTER_FIELD, meta: { form }, payload: { name, type } })

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -183,7 +183,7 @@ const createReducer = structure => {
       result = setIn(result, 'active', field)
       return result
     },
-    [INITIALIZE](state, { payload, meta: { keepDirty } }) {
+    [INITIALIZE](state, { payload, meta: { keepDirty, keepSubmitSucceeded } }) {
       const mapData = fromJS(payload)
       let result = empty // clean all field state
 
@@ -237,6 +237,9 @@ const createReducer = structure => {
             newValues = setIn(newValues, name, previousValue)
           }
         })
+      }
+      if (keepSubmitSucceeded && getIn(state, 'submitSucceeded')) {
+        result = setIn(result, 'submitSucceeded', true) 
       }
       result = setIn(result, 'values', newValues)
       result = setIn(result, 'initial', mapData)


### PR DESCRIPTION
My proposed solution to #1994 
Also, I made it possible to pass `keepDirty` in the same options argument as `keepSubmitSucceeded` is passed in, for the sake of cleanliness, but I preserved backwards compatibility.