### PR TITLE
Provide validation functions with access to form props

### DIFF
--- a/docs/api/Field.md
+++ b/docs/api/Field.md
@@ -121,13 +121,13 @@ localized date formats into `Date`s.
 `parse` is called with the field `value` and `name` as arguments and should return the new
 parsed value to be stored in the Redux store.
 
-#### `validate : (value, allValues) => error` [optional]
+#### `validate : (value, allValues, props) => error` [optional]
 
-Allows you to to provide a field-level validation rule. The function will be given the current value of the field and all the other form values. If the field is valid, it should return `undefined`, if the field is invalid, it should return an error (usually, but not necessarily, a `String`).
+Allows you to to provide a field-level validation rule. The function will be given the current value of the field, all the other form values, and any props passed to the form. If the field is valid, it should return `undefined`, if the field is invalid, it should return an error (usually, but not necessarily, a `String`).
 
-#### `warn : (value, allValues) => warning` [optional]
+#### `warn : (value, allValues, props) => warning` [optional]
 
-Allows you to to provide a field-level warning rule. The function will be given the current value of the field and all the other form values. If the field needs a warning, it should return the warning (usually, but not necessarily, a `String`). If the field does not need a warning, it should return `undefined`.
+Allows you to to provide a field-level warning rule. The function will be given the current value of the field, all the other form values, and any props passed to the form. If the field needs a warning, it should return the warning (usually, but not necessarily, a `String`). If the field does not need a warning, it should return `undefined`.
 
 #### `withRef : boolean` [optional]
 

--- a/docs/api/FieldArray.md
+++ b/docs/api/FieldArray.md
@@ -30,13 +30,13 @@ be as simple as `'firstName'` or as complicated as
 
 A `Component` or stateless function to render the field array.
 
-#### `validate : (value, allValues) => error` [optional]
+#### `validate : (value, allValues, props) => error` [optional]
 
-Allows you to to provide a field-level validation rule. The function will be given the current value of the array field and all the other form values. If the array is valid, it should return `undefined`, if the array is invalid, it should return an error (usually, but not necessarily, a `String`).
+Allows you to to provide a field-level validation rule. The function will be given the current value of the array field, all the other form values, and any props passed to the form. If the array is valid, it should return `undefined`, if the array is invalid, it should return an error (usually, but not necessarily, a `String`).
 
-#### `warn : (value, allValues) => warning` [optional]
+#### `warn : (value, allValues, props) => warning` [optional]
 
-Allows you to to provide a field-level warning rule. The function will be given the current value of the array and all the other form values. If the array needs a warning, it should return the warning (usually, but not necessarily, a `String`). If the array does not need a warning, it should return `undefined`.
+Allows you to to provide a field-level warning rule. The function will be given the current value of the array field, all the other form values, and any props passed to the form. If the array needs a warning, it should return the warning (usually, but not necessarily, a `String`). If the array does not need a warning, it should return `undefined`.
 
 #### `withRef : boolean` [optional]
 

--- a/src/generateValidator.js
+++ b/src/generateValidator.js
@@ -2,9 +2,9 @@ import plain from './structure/plain'
 
 const toArray = value => Array.isArray(value) ? value : [ value ]
 
-const getError = (value, values, validators) => {
+const getError = (value, values, props, validators) => {
   for(const validator of toArray(validators)) {
-    const error = validator(value, values)
+    const error = validator(value, values, props)
     if(error) {
       return error
     }
@@ -12,11 +12,11 @@ const getError = (value, values, validators) => {
 }
 
 const generateValidator = (validators, { getIn }) =>
-  values => {
+  (values, props) => {
     let errors = {}
     Object.keys(validators).forEach(name => {
       const value = getIn(values, name)
-      const error = getError(value, values, validators[name])
+      const error = getError(value, values, props, validators[name])
       if(error) {
         errors = plain.setIn(errors, name, error)
       }


### PR DESCRIPTION
Currently, the API for `validate` passed to `config` allows props to be
accessible by validation rules. The same should be done for field-level
validations. This PR provides props passed to the form as the second argument
of the function returned by `generateValidator()`, making the APIs between the
two forms of validation consistent.

Refers to #2430