### PR TITLE
Add initial value selector

### DIFF
--- a/docs/api/Selectors.md
+++ b/docs/api/Selectors.md
@@ -18,6 +18,7 @@ defaults to `state => state.form`, assuming that you have mounted the `redux-for
 ```js
 import {
   getFormValues,
+  getFormInitialValues,
   getFormSyncErrors,
   getFormAsyncErrors,
   getFormSubmitErrors,
@@ -34,6 +35,7 @@ import {
 MyComponent = connect(
   state => ({
     values: getFormValues('myForm')(state),
+    initialValues: getFormInitialValues('myForm')(state),
     syncErrors: getFormSyncErrors('myForm')(state),
     asyncErrors: getFormAsyncErrors('myForm')(state),
     submitErrors: getFormSubmitErrors('myForm')(state),
@@ -54,6 +56,10 @@ MyComponent = connect(
 ### `getFormValues(formName:String)` returns `(state) => formValues:Object`
 
 > Gets the form values. Shocking, right?
+
+### `getFormInitialValues(formName:String)` returns `(state) => formInitialValues:Object`
+
+> Gets the form's initial values.
 
 ### `getFormSyncErrors(formName:String)` returns `(state) => formSyncErrors:Object`
 

--- a/src/__tests__/immutable.spec.js
+++ b/src/__tests__/immutable.spec.js
@@ -25,6 +25,7 @@ import {
   focus,
   formValueSelector,
   getFormValues,
+  getFormInitialValues,
   getFormSyncErrors,
   getFormAsyncErrors,
   getFormSubmitErrors,
@@ -124,6 +125,9 @@ describe('immutable', () => {
   })
   it('should export getFormValues', () => {
     expect(getFormValues).toExist().toBeA('function')
+  })
+  it('should export getFormInitialValues', () => {
+    expect(getFormInitialValues).toExist().toBeA('function')
   })
   it('should export getFormSyncErrors', () => {
     expect(getFormSyncErrors).toExist().toBeA('function')

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -25,6 +25,7 @@ import {
   focus,
   formValueSelector,
   getFormValues,
+  getFormInitialValues,
   getFormSyncErrors,
   getFormAsyncErrors,
   getFormSubmitErrors,
@@ -124,6 +125,9 @@ describe('index', () => {
   })
   it('should export getFormValues', () => {
     expect(getFormValues).toExist().toBeA('function')
+  })
+  it('should export getFormInitialValues', () => {
+    expect(getFormInitialValues).toExist().toBeA('function')
   })
   it('should export getFormSyncErrors', () => {
     expect(getFormSyncErrors).toExist().toBeA('function')

--- a/src/createAll.js
+++ b/src/createAll.js
@@ -6,6 +6,7 @@ import createFieldArray from './FieldArray'
 import createFormValueSelector from './formValueSelector'
 import createValues from './values'
 import createGetFormValues from './selectors/getFormValues'
+import createGetFormInitialValues from './selectors/getFormInitialValues'
 import createGetFormSyncErrors from './selectors/getFormSyncErrors'
 import createGetFormAsyncErrors from './selectors/getFormAsyncErrors'
 import createGetFormSubmitErrors from './selectors/getFormSubmitErrors'
@@ -34,6 +35,7 @@ const createAll = structure => ({
   FormSection,
   formValueSelector: createFormValueSelector(structure),
   getFormValues: createGetFormValues(structure),
+  getFormInitialValues: createGetFormInitialValues(structure),
   getFormSyncErrors: createGetFormSyncErrors(structure),
   getFormAsyncErrors: createGetFormAsyncErrors(structure),
   getFormSubmitErrors: createGetFormSubmitErrors(structure),

--- a/src/immutable.js
+++ b/src/immutable.js
@@ -25,6 +25,7 @@ export const {
   focus,
   formValueSelector,
   getFormValues,
+  getFormInitialValues,
   getFormSyncErrors,
   getFormAsyncErrors,
   getFormSubmitErrors,

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ export const {
   focus,
   formValueSelector,
   getFormValues,
+  getFormInitialValues,
   getFormSyncErrors,
   getFormAsyncErrors,
   getFormSubmitErrors,

--- a/src/selectors/__tests__/getFormInitialValues.spec.js
+++ b/src/selectors/__tests__/getFormInitialValues.spec.js
@@ -1,0 +1,53 @@
+import createGetFormInitialValues from '../getFormInitialValues'
+import plain from '../../structure/plain'
+import plainExpectations from '../../structure/plain/expectations'
+import immutable from '../../structure/immutable'
+import immutableExpectations from '../../structure/immutable/expectations'
+import addExpectations from '../../__tests__/addExpectations'
+
+const describeGetFormInitialValues = (name, structure, expect) => {
+  const getFormInitialValues = createGetFormInitialValues(structure)
+
+  const { fromJS, getIn } = structure
+
+  describe(name, () => {
+    it('should return a function', () => {
+      expect(getFormInitialValues('foo')).toBeA('function')
+    })
+
+    it('should get the initial form values from state', () => {
+      expect(getFormInitialValues('foo')(fromJS({
+        form: {
+          foo: {
+            initialValues: {
+              dog: 'Snoopy',
+              cat: 'Garfield'
+            }
+          }
+        }
+      }))).toEqualMap({
+        dog: 'Snoopy',
+        cat: 'Garfield'
+      })
+    })
+
+    it('should use getFormState if provided', () => {
+      expect(getFormInitialValues('foo', state => getIn(state, 'someOtherSlice'))(fromJS({
+        someOtherSlice: {
+          foo: {
+            initialValues: {
+              dog: 'Snoopy',
+              cat: 'Garfield'
+            }
+          }
+        }
+      }))).toEqualMap({
+        dog: 'Snoopy',
+        cat: 'Garfield'
+      })
+    })
+  })
+}
+
+describeGetFormInitialValues('getFormInitialValues.plain', plain, addExpectations(plainExpectations))
+describeGetFormInitialValues('getFormInitialValues.immutable', immutable, addExpectations(immutableExpectations))

--- a/src/selectors/__tests__/getFormInitialValues.spec.js
+++ b/src/selectors/__tests__/getFormInitialValues.spec.js
@@ -19,7 +19,7 @@ const describeGetFormInitialValues = (name, structure, expect) => {
       expect(getFormInitialValues('foo')(fromJS({
         form: {
           foo: {
-            initialValues: {
+            initial: {
               dog: 'Snoopy',
               cat: 'Garfield'
             }
@@ -35,7 +35,7 @@ const describeGetFormInitialValues = (name, structure, expect) => {
       expect(getFormInitialValues('foo', state => getIn(state, 'someOtherSlice'))(fromJS({
         someOtherSlice: {
           foo: {
-            initialValues: {
+            initial: {
               dog: 'Snoopy',
               cat: 'Garfield'
             }

--- a/src/selectors/getFormInitialValues.js
+++ b/src/selectors/getFormInitialValues.js
@@ -1,5 +1,5 @@
 const createGetFormInitialValues = ({ getIn }) =>
   (form, getFormState = state => getIn(state, 'form')) =>
-    state => getIn(getFormState(state), `${form}.initialValues`)
+    state => getIn(getFormState(state), `${form}.initial`)
 
 export default createGetFormInitialValues

--- a/src/selectors/getFormInitialValues.js
+++ b/src/selectors/getFormInitialValues.js
@@ -1,0 +1,5 @@
+const createGetFormInitialValues = ({ getIn }) =>
+  (form, getFormState = state => getIn(state, 'form')) =>
+    state => getIn(getFormState(state), `${form}.initialValues`)
+
+export default createGetFormInitialValues


### PR DESCRIPTION
This seemed like an important missing selector. While a user of redux-form will usually have access to the initial values they passed in one way or another, exposing a selector for them can make it easier to hook into redux-form with epic, thunks, and sagas (invoking the selector on getState()) and keep business logic out of the component.

I'd be happy to describe a specific use case if desired.