### PR TITLE
FormSection fixes

### DIFF
--- a/docs/api/Field.md
+++ b/docs/api/Field.md
@@ -222,7 +222,8 @@ The following properties and methods are available on an instance of a `Field` c
 
 #### `name : String`
 
-> The `name` prop that you passed in.
+> When nested in `FormSection`, returns the `name` prop prefixed with the `FormSection` name.
+Otherwise, returns the `name` prop that you passed in.
 
 #### `pristine : boolean`
 
@@ -259,7 +260,8 @@ to be destructured into your `<input/>` component.
 
 #### `input.name : String`
 
-> The name prop passed in.
+> When nested in `FormSection`, returns the `name` prop prefixed with the `FormSection` name.
+Otherwise, returns the `name` prop that you passed in.
 
 #### `input.onBlur(eventOrValue) : Function`
 

--- a/docs/api/FieldArray.md
+++ b/docs/api/FieldArray.md
@@ -54,7 +54,8 @@ The following properties and methods are available on an instance of a `FieldArr
 
 #### `name : String`
 
-> The `name` prop that you passed in.
+> When nested in `FormSection`, returns the `name` prop prefixed with the `FormSection` name.
+Otherwise, returns the `name` prop that you passed in.
 
 #### `valid : boolean`
 

--- a/docs/api/Fields.md
+++ b/docs/api/Fields.md
@@ -126,7 +126,8 @@ The following properties and methods are available on an instance of a `Field` c
 
 #### `names : Array<String>`
 
-> The `names` prop that you passed in.
+> When nested in `FormSection`, returns the `names` prop prefixed with the `FormSection` name.
+Otherwise, returns a copy of the `names` prop that you passed in.
 
 #### `pristine : boolean`
 

--- a/src/ConnectedFieldArray.js
+++ b/src/ConnectedFieldArray.js
@@ -69,12 +69,13 @@ const createConnectedFieldArray = ({ deepEqual, getIn, size }) => {
         component,
         withRef,
         name,
-        _reduxForm, // eslint-disable-line no-unused-vars
+        _reduxForm,
         ...rest
       } = this.props
       const props = createFieldArrayProps(
         getIn,
         name,
+        _reduxForm.sectionPrefix,
         this.getValue,
         {
           ...rest,

--- a/src/Fields.js
+++ b/src/Fields.js
@@ -41,7 +41,7 @@ const createFields = ({ deepEqual, getIn, toJS }) => {
       }
       const { context } = this  
       const { _reduxForm: { register } } = context
-      this.names.forEach(name => register(prefixName(context, name), 'Field'))
+      this.names.forEach(name => register(name, 'Field'))
     }
 
     componentWillReceiveProps(nextProps) {
@@ -69,7 +69,8 @@ const createFields = ({ deepEqual, getIn, toJS }) => {
     }
 
     get names() {
-      return this.props.names
+      const { context } = this
+      return this.props.names.map(name => prefixName(context, name))
     }
 
     get dirty() {

--- a/src/__tests__/Field.spec.js
+++ b/src/__tests__/Field.spec.js
@@ -589,6 +589,45 @@ const describeField = (name, structure, combineReducers, expect) => {
       expect(input.calls[ 1 ].arguments[ 0 ].meta.touched).toBe(true)
     })
 
+    it('should prefix name getter when inside FormSection', () => {
+      const store = makeStore()
+      class Form extends Component {
+        render() {
+          return (<FormSection name="foo" component="span">
+            <Field name="bar" component="input"/>
+          </FormSection>)
+        }
+      }
+      const TestForm = reduxForm({ form: 'testForm' })(Form)
+      const dom = TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <TestForm/>
+        </Provider>
+      )
+      const stub = TestUtils.findRenderedComponentWithType(dom, Field)
+      expect(stub.name).toBe('foo.bar')
+    })
+    it('should prefix name getter when inside multiple FormSection', () => {
+      const store = makeStore()
+      class Form extends Component {
+        render() {
+          return (<FormSection name="foo">
+            <FormSection name="fighter">
+              <Field name="bar" component="input"/>
+            </FormSection>
+          </FormSection>)
+        }
+      }
+      const TestForm = reduxForm({ form: 'testForm' })(Form)
+      const dom = TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <TestForm/>
+        </Provider>
+      )
+      const stub = TestUtils.findRenderedComponentWithType(dom, Field)
+      expect(stub.name).toBe('foo.fighter.bar')
+    })
+
     it('should prefix name when inside FormSection', () => {
       const store = makeStore()
       class Form extends Component {

--- a/src/__tests__/Fields.spec.js
+++ b/src/__tests__/Fields.spec.js
@@ -678,6 +678,52 @@ const describeFields = (name, structure, combineReducers, expect) => {
       expect(input.calls[ 1 ].arguments[ 0 ].bar.meta.touched).toBe(true)
     })
 
+    it('should prefix name getter when inside FormSection', () => {
+      const store = makeStore()
+      const renderFields = ({ foo, bar }) => <div>
+        <input {...foo.input}/>
+        <input {...bar.input}/>
+      </div>
+      class Form extends Component {
+        render() {
+          return (<FormSection name="foo">
+            <Fields names={[ 'foo', 'bar' ]} component={renderFields}/>
+          </FormSection>)
+        }
+      }
+      const TestForm = reduxForm({ form: 'testForm' })(Form)
+      const dom = TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <TestForm/>
+        </Provider>
+      )
+      const stub = TestUtils.findRenderedComponentWithType(dom, Fields)
+      expect(stub.names).toEqual([ 'foo.foo', 'foo.bar' ])
+    })
+    it('should prefix name getter when inside multiple FormSection', () => {
+      const store = makeStore()
+      const renderFields = ({ foo, bar }) => <div>
+        <input {...foo.input}/>
+        <input {...bar.input}/>
+      </div>
+      class Form extends Component {
+        render() {
+          return (<FormSection name="foo">
+            <FormSection name="fighter">
+              <Fields names={[ 'foo', 'bar' ]} component={renderFields}/>
+            </FormSection>
+          </FormSection>)
+        }
+      }
+      const TestForm = reduxForm({ form: 'testForm' })(Form)
+      const dom = TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <TestForm/>
+        </Provider>
+      )
+      const stub = TestUtils.findRenderedComponentWithType(dom, Fields)
+      expect(stub.names).toEqual([ 'foo.fighter.foo', 'foo.fighter.bar' ])
+    })
 
     it('should prefix name when inside FormSection', () => {
       const store = makeStore()

--- a/src/__tests__/createFieldArrayProps.spec.js
+++ b/src/__tests__/createFieldArrayProps.spec.js
@@ -8,7 +8,7 @@ import addExpectations from './addExpectations'
 
 const describeCreateFieldProps = (name, structure, expect) => {
   const { fromJS, getIn, size } = structure
-  const defaultParams = [ getIn, 'foo', () => 69 ]
+  const defaultParams = [ getIn, 'foo', undefined, () => 69 ]
 
   describe(name, () => {
     it('should pass props through', () => {
@@ -213,7 +213,7 @@ const describeCreateFieldProps = (name, structure, expect) => {
     it('should provide get that uses passed in getValue', () => {
       const value = fromJS([ 'a', 'b', 'c' ])
       const getValue = index => value && getIn(value, index) + 'DOG'
-      const result = createFieldArrayProps(getIn, 'foo', getValue, { value })
+      const result = createFieldArrayProps(getIn, 'foo', undefined, getValue, { value })
       expect(result.fields.get).toBeA('function')
       expect(result.fields.get(0)).toBe('aDOG')
       expect(result.fields.get(1)).toBe('bDOG')

--- a/src/createFieldArrayProps.js
+++ b/src/createFieldArrayProps.js
@@ -1,4 +1,4 @@
-const createFieldArrayProps = (getIn, name, getValue,
+const createFieldArrayProps = (getIn, name, sectionPrefix, getValue,
   {
     arrayInsert, arrayMove, arrayPop, arrayPush, arrayRemove, arrayRemoveAll, arrayShift,
     arraySplice, arraySwap, arrayUnshift, asyncError, // eslint-disable-line no-unused-vars
@@ -8,15 +8,16 @@ const createFieldArrayProps = (getIn, name, getValue,
   }) => {
   const error = syncError || asyncError || submitError
   const warning = syncWarning
+  const fieldName = sectionPrefix ? name.replace(`${sectionPrefix}.`, '') : name
   const finalProps = {
     fields: {
       _isFieldArray: true,
-      forEach: callback => (value || []).forEach((item, index) => callback(`${name}[${index}]`, index, finalProps.fields)),
+      forEach: callback => (value || []).forEach((item, index) => callback(`${fieldName}[${index}]`, index, finalProps.fields)),
       get: getValue,
       getAll: () => value,
       insert: arrayInsert,
       length,
-      map: callback => (value || []).map((item, index) => callback(`${name}[${index}]`, index, finalProps.fields)),
+      map: callback => (value || []).map((item, index) => callback(`${fieldName}[${index}]`, index, finalProps.fields)),
       move: arrayMove,
       name,
       pop: () => {
@@ -25,7 +26,7 @@ const createFieldArrayProps = (getIn, name, getValue,
       },
       push: arrayPush,
       reduce: (callback, initial) => (value || [])
-        .reduce((accumulator, item, index) => callback(accumulator, `${name}[${index}]`, index, finalProps.fields), initial),
+        .reduce((accumulator, item, index) => callback(accumulator, `${fieldName}[${index}]`, index, finalProps.fields), initial),
       remove: arrayRemove,
       removeAll: arrayRemoveAll,
       shift: () => {

--- a/src/util/__tests__/prefixName.spec.js
+++ b/src/util/__tests__/prefixName.spec.js
@@ -19,13 +19,4 @@ describe('prefixName', () => {
     }
     expect(prefixName(context, 'bar')).toBe('bar')
   })
-
-  it('should not prefix array fields', () => {
-    const context = {
-      _reduxForm: {
-        sectionPrefix: 'foo'
-      }
-    }
-    expect(prefixName(context, 'bar.bar[0]')).toBe('bar.bar[0]')
-  })
 })

--- a/src/util/prefixName.js
+++ b/src/util/prefixName.js
@@ -1,6 +1,4 @@
-const isFieldArrayRegx = /\[\d+\]$/
-
 export default function formatName(context, name) {
   const { _reduxForm: { sectionPrefix } } = context
-  return !sectionPrefix || isFieldArrayRegx.test(name) ? name : `${sectionPrefix}.${name}`
+  return !sectionPrefix ? name : `${sectionPrefix}.${name}`
 }


### PR DESCRIPTION
Breaking change: Change `Fields` `names` instance API to return `FormSection` prefixed names, to be consistent with `Field` and `FieldArray`.

Breaking change: Change instance API documentation of `Field`, `Fields` and `FieldArray` `name` and `names` to match the behavior of the code with regards to `FormSection`, which is to return the `FormSection` prefixed `name` and `names`.

In `FieldArray`, `fields` `map`, `forEach` and `reduce` now call back with unprefixed name, as the prefix is added in `Field` and `Fields`. Fixes #2121.