### PR TITLE
Allow FieldArray to be impure

### DIFF
--- a/src/FieldArray.js
+++ b/src/FieldArray.js
@@ -1,7 +1,6 @@
 import { Component, PropTypes, createElement } from 'react'
 import invariant from 'invariant'
 import createConnectedFieldArray from './ConnectedFieldArray'
-import shallowCompare from './util/shallowCompare'
 import prefixName from './util/prefixName'
 
 const toArray = value => Array.isArray(value) ? value : [ value ]
@@ -26,10 +25,6 @@ const createFieldArray = ({ deepEqual, getIn, size }) => {
       if (!context._reduxForm) {
         throw new Error('FieldArray must be inside a component decorated with reduxForm()')
       }
-    }
-
-    shouldComponentUpdate(nextProps, nextState) {
-      return shallowCompare(this, nextProps, nextState)
     }
 
     componentWillMount() {


### PR DESCRIPTION
I am trying to implement some interface that is similar to http://redux-form.com/6.4.3/examples/selectingFormValues/ but fields should be wrapped into `FieldArray`.

Currently, this is not possible, because `shouldComponentUpdate` prevents all further updates, even they are possible. See added test, it didn't passed before, but currently it passes.