### PR TITLE
Keep track of registration count in registeredFields

### DIFF
--- a/src/__tests__/Field.spec.js
+++ b/src/__tests__/Field.spec.js
@@ -647,7 +647,7 @@ const describeField = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [ { name: 'foo.bar', type: 'Field' } ]
+            registeredFields: { 'foo.bar': { name: 'foo.bar', type: 'Field', count: 1 } }
           }
         }
       })
@@ -674,7 +674,7 @@ const describeField = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [ { name: 'foo.fighter.bar', type: 'Field' } ]
+            registeredFields: { 'foo.fighter.bar': { name: 'foo.fighter.bar', type: 'Field', count: 1 } }
           }
         }
       })
@@ -705,7 +705,7 @@ const describeField = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [ { name: 'foo', type: 'Field' } ]
+            registeredFields: { foo: { name: 'foo', type: 'Field', count: 1 } }
           }
         }
       })
@@ -716,7 +716,7 @@ const describeField = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [ { name: 'bar', type: 'Field' } ]
+            registeredFields: { bar: { name: 'bar', type: 'Field', count: 1 } }
           }
         }
       })
@@ -1275,7 +1275,7 @@ const describeField = (name, structure, combineReducers, expect) => {
             values: {
               age: 15 // number
             },
-            registeredFields: [ { name: 'age', type: 'Field' } ]
+            registeredFields: { age: { name: 'age', type: 'Field', count: 1 } }
           }
         }
       })

--- a/src/__tests__/FieldArray.spec.js
+++ b/src/__tests__/FieldArray.spec.js
@@ -694,11 +694,11 @@ const describeFieldArray = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [
-              { name: 'foo.bar', type: 'FieldArray' },
-              { name: 'foo.bar[0].val', type: 'Field' },
-              { name: 'foo.bar[1].val', type: 'Field' }
-            ],
+            registeredFields: {
+              'foo.bar': { name: 'foo.bar', type: 'FieldArray', count: 1 },
+              'foo.bar[0].val': { name: 'foo.bar[0].val', type: 'Field', count: 1 },
+              'foo.bar[1].val': { name: 'foo.bar[1].val', type: 'Field', count: 1 }
+            },
             values: {
               foo: { bar: [ { val: 'dog' }, { val: 'cat' } ] }
             }
@@ -764,11 +764,11 @@ const describeFieldArray = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [
-              { name: 'foo.fighter.bar', type: 'FieldArray' },
-              { name: 'foo.fighter.bar[0].val', type: 'Field' },
-              { name: 'foo.fighter.bar[1].val', type: 'Field' }
-            ],
+            registeredFields: {
+              'foo.fighter.bar': { name: 'foo.fighter.bar', type: 'FieldArray', count: 1 },
+              'foo.fighter.bar[0].val': { name: 'foo.fighter.bar[0].val', type: 'Field', count: 1 },
+              'foo.fighter.bar[1].val': { name: 'foo.fighter.bar[1].val', type: 'Field', count: 1 }
+            },
             values: {
               foo: { fighter: { bar: [ { val: 'dog' }, { val: 'cat' } ] } }
             }
@@ -1393,9 +1393,9 @@ const describeFieldArray = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [
-              { name: 'dogs', type: 'FieldArray' }
-            ]
+            registeredFields: {
+              dogs: { name: 'dogs', type: 'FieldArray', count: 1 }
+            }
           }
         }
       })
@@ -1425,10 +1425,10 @@ const describeFieldArray = (name, structure, combineReducers, expect) => {
             values: {
               dogs: [ undefined ]
             },
-            registeredFields: [
-              { name: 'dogs', type: 'FieldArray' },
-              { name: 'dogs[0]', type: 'Field' }
-            ]
+            registeredFields: {
+              dogs: { name: 'dogs', type: 'FieldArray', count: 1 },
+              'dogs[0]': { name: 'dogs[0]', type: 'Field', count: 1 }
+            }
           }
         }
       })
@@ -1462,9 +1462,9 @@ const describeFieldArray = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [
-              { name: 'dogs', type: 'FieldArray' }
-            ]
+            registeredFields: {
+              dogs: { name: 'dogs', type: 'FieldArray', count: 1 }
+            }
           }
         }
       })
@@ -1494,10 +1494,10 @@ const describeFieldArray = (name, structure, combineReducers, expect) => {
             values: {
               dogs: [ 'Fido' ]
             },
-            registeredFields: [
-              { name: 'dogs', type: 'FieldArray' },
-              { name: 'dogs[0]', type: 'Field' }
-            ]
+            registeredFields: {
+              dogs: { name: 'dogs', type: 'FieldArray', count: 1 },
+              'dogs[0]': { name: 'dogs[0]', type: 'Field', count: 1 }
+            }
           }
         }
       })
@@ -1531,9 +1531,9 @@ const describeFieldArray = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [
-              { name: 'dogs', type: 'FieldArray' }
-            ]
+            registeredFields: {
+              dogs: { name: 'dogs', type: 'FieldArray', count: 1 }
+            }
           }
         }
       })
@@ -1563,10 +1563,10 @@ const describeFieldArray = (name, structure, combineReducers, expect) => {
             values: {
               dogs: [ undefined ]
             },
-            registeredFields: [
-              { name: 'dogs', type: 'FieldArray' },
-              { name: 'dogs[0]', type: 'Field' }
-            ]
+            registeredFields: {
+              dogs: { name: 'dogs', type: 'FieldArray', count: 1 },
+              'dogs[0]': { name: 'dogs[0]', type: 'Field', count: 1 }
+            }
           }
         }
       })
@@ -1600,9 +1600,9 @@ const describeFieldArray = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [
-              { name: 'dogs', type: 'FieldArray' }
-            ]
+            registeredFields: {
+              dogs: { name: 'dogs', type: 'FieldArray', count: 1 }
+            }
           }
         }
       })
@@ -1632,10 +1632,10 @@ const describeFieldArray = (name, structure, combineReducers, expect) => {
             values: {
               dogs: [ 'Fido' ]
             },
-            registeredFields: [
-              { name: 'dogs', type: 'FieldArray' },
-              { name: 'dogs[0]', type: 'Field' }
-            ]
+            registeredFields: {
+              dogs: { name: 'dogs', type: 'FieldArray', count: 1 },
+              'dogs[0]': { name: 'dogs[0]', type: 'Field', count: 1 }
+            }
           }
         }
       })
@@ -1670,9 +1670,9 @@ const describeFieldArray = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [
-              { name: 'dogs', type: 'FieldArray' }
-            ]
+            registeredFields: {
+              dogs: { name: 'dogs', type: 'FieldArray', count: 1 }
+            }
           }
         }
       })
@@ -1702,10 +1702,10 @@ const describeFieldArray = (name, structure, combineReducers, expect) => {
             values: {
               dogs: [ undefined ]
             },
-            registeredFields: [
-              { name: 'dogs', type: 'FieldArray' },
-              { name: 'dogs[0]', type: 'Field' }
-            ]
+            registeredFields: {
+              dogs: { name: 'dogs', type: 'FieldArray', count: 1 },
+              'dogs[0]': { name: 'dogs[0]', type: 'Field', count: 1 }
+            }
           }
         }
       })
@@ -1739,9 +1739,9 @@ const describeFieldArray = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [
-              { name: 'dogs', type: 'FieldArray' }
-            ]
+            registeredFields: {
+              dogs: { name: 'dogs', type: 'FieldArray', count: 1 }
+            }
           }
         }
       })
@@ -1771,10 +1771,10 @@ const describeFieldArray = (name, structure, combineReducers, expect) => {
             values: {
               dogs: [ 'Fido' ]
             },
-            registeredFields: [
-              { name: 'dogs', type: 'FieldArray' },
-              { name: 'dogs[0]', type: 'Field' }
-            ]
+            registeredFields: {
+              dogs: { name: 'dogs', type: 'FieldArray', count: 1 },
+              'dogs[0]': { name: 'dogs[0]', type: 'Field', count: 1 }
+            }
           }
         }
       })

--- a/src/__tests__/Fields.spec.js
+++ b/src/__tests__/Fields.spec.js
@@ -608,10 +608,10 @@ const describeFields = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [
-              { name: 'dog', type: 'Field' },
-              { name: 'cat', type: 'Field' }
-            ]
+            registeredFields: {
+              dog: { name: 'dog', type: 'Field', count: 1 },
+              cat: { name: 'cat', type: 'Field', count: 1 }
+            }
           }
         }
       })
@@ -622,10 +622,10 @@ const describeFields = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [
-              { name: 'cow', type: 'Field' },
-              { name: 'ewe', type: 'Field' }
-            ]
+            registeredFields: {
+              cow: { name: 'cow', type: 'Field', count: 1 },
+              ewe: { name: 'ewe', type: 'Field', count: 1 }
+            }
           }
         }
       })
@@ -748,10 +748,10 @@ const describeFields = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [ 
-              { name: 'foo.foo', type: 'Field' },
-              { name: 'foo.bar', type: 'Field' }              
-            ]
+            registeredFields: {
+              'foo.foo': { name: 'foo.foo', type: 'Field', count: 1 },
+              'foo.bar': { name: 'foo.bar', type: 'Field', count: 1 }              
+            }
           }
         }
       })
@@ -782,10 +782,10 @@ const describeFields = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [ 
-              { name: 'foo.fighter.foo', type: 'Field' },
-              { name: 'foo.fighter.bar', type: 'Field' }              
-            ]
+            registeredFields: {
+              'foo.fighter.foo': { name: 'foo.fighter.foo', type: 'Field', count: 1 },
+              'foo.fighter.bar': { name: 'foo.fighter.bar', type: 'Field', count: 1 }
+            }
           }
         }
       })
@@ -1121,7 +1121,7 @@ const describeFields = (name, structure, combineReducers, expect) => {
             values: {
               age: 15 // number
             },
-            registeredFields: [ { name: 'age', type: 'Field' } ]
+            registeredFields: { age: { name: 'age', type: 'Field', count: 1 } }
           }
         }
       })

--- a/src/__tests__/FormSection.spec.js
+++ b/src/__tests__/FormSection.spec.js
@@ -158,7 +158,7 @@ const describeFormSection = (name, structure, combineReducers, expect) => {
                 bar: '15'
               }
             },
-            registeredFields: [ { name: 'foo.bar', type: 'Field' } ]
+            registeredFields: { 'foo.bar': { name: 'foo.bar', type: 'Field', count: 1 } }
           }
         }
       })
@@ -217,10 +217,10 @@ const describeFormSection = (name, structure, combineReducers, expect) => {
                 baz: '100'
               }
             },
-            registeredFields: [
-              { name: 'foo.bar', type: 'Field' },
-              { name: 'foo.baz', type: 'Field' }
-            ]
+            registeredFields: {
+              'foo.bar': { name: 'foo.bar', type: 'Field', count: 1 },
+              'foo.baz': { name: 'foo.baz', type: 'Field', count: 1 }
+            }
           }
         }
       })
@@ -274,12 +274,12 @@ const describeFormSection = (name, structure, combineReducers, expect) => {
                 bar: [ 'dog', 'cat', 'fish' ]
               }
             },
-            registeredFields: [
-              { name: 'foo.bar', type: 'FieldArray' },
-              { name: 'foo.bar[0]', type: 'Field' },
-              { name: 'foo.bar[1]', type: 'Field' },
-              { name: 'foo.bar[2]', type: 'Field' }
-            ]
+            registeredFields: {
+              'foo.bar': { name: 'foo.bar', type: 'FieldArray', count: 1 },
+              'foo.bar[0]': { name: 'foo.bar[0]', type: 'Field', count: 1 },
+              'foo.bar[1]': { name: 'foo.bar[1]', type: 'Field', count: 1 },
+              'foo.bar[2]': { name: 'foo.bar[2]', type: 'Field', count: 1 }
+            }
           }
         }
       })
@@ -294,11 +294,11 @@ const describeFormSection = (name, structure, combineReducers, expect) => {
                 bar: [ 'dog', 'cat' ]
               }
             },
-            registeredFields: [
-              { name: 'foo.bar', type: 'FieldArray' },
-              { name: 'foo.bar[0]', type: 'Field' },
-              { name: 'foo.bar[1]', type: 'Field' }
-            ]
+            registeredFields: {
+              'foo.bar': { name: 'foo.bar', type: 'FieldArray', count: 1 },
+              'foo.bar[0]': { name: 'foo.bar[0]', type: 'Field', count: 1 },
+              'foo.bar[1]': { name: 'foo.bar[1]', type: 'Field', count: 1 }
+            }
           }
         }
       })

--- a/src/__tests__/actions.spec.js
+++ b/src/__tests__/actions.spec.js
@@ -568,7 +568,8 @@ describe('actions', () => {
           form: 'myForm'
         },
         payload: {
-          name: 'foo'
+          name: 'foo',
+          destroyOnUnmount: true
         }
       })
       .toPass(isFSA)

--- a/src/__tests__/reducer.initialize.spec.js
+++ b/src/__tests__/reducer.initialize.spec.js
@@ -140,10 +140,10 @@ const describeInitialize = (reducer, expect, { fromJS }) => () => {
   it('should set initialize values, and not remove registered fields', () => {
     const state = reducer(fromJS({
       foo: {
-        registeredFields: [
-          { name: 'username', type: 'Field' },
-          { name: 'password', type: 'Field' }
-        ],
+        registeredFields: {
+          username: { name: 'username', type: 'Field', count: 1 },
+          password: { name: 'password', type: 'Field', count: 1 }
+        },
         values: {
           username: 'dirtyValue'
         },
@@ -157,10 +157,10 @@ const describeInitialize = (reducer, expect, { fromJS }) => () => {
     expect(state)
       .toEqualMap({
         foo: {
-          registeredFields: [
-            { name: 'username', type: 'Field' },
-            { name: 'password', type: 'Field' }
-          ],
+          registeredFields: {
+            username: { name: 'username', type: 'Field', count: 1 },
+            password: { name: 'password', type: 'Field', count: 1 }
+          },
           values: {
             username: 'cleanValue',
             password: 'cleanPassword'
@@ -207,9 +207,9 @@ const describeInitialize = (reducer, expect, { fromJS }) => () => {
   it('should retain dirty values when keepDirty is set', () => {
     const state = reducer(fromJS({
       foo: {
-        registeredFields: [
-          { name: 'myField', type: 'Field' }
-        ],
+        registeredFields: {
+          myField: { name: 'myField', type: 'Field', count: 1 }
+        },
         values: {
           myField: 'dirtyValue'
         },
@@ -221,9 +221,9 @@ const describeInitialize = (reducer, expect, { fromJS }) => () => {
     expect(state)
       .toEqualMap({
         foo: {
-          registeredFields: [
-            { name: 'myField', type: 'Field' }
-          ],
+          registeredFields: {
+            myField: { name: 'myField', type: 'Field', count: 1 }
+          },
           values: {
             myField: 'dirtyValue'
           },
@@ -237,9 +237,9 @@ const describeInitialize = (reducer, expect, { fromJS }) => () => {
   it('should replace pristine values when keepDirty is set', () => {
     const state = reducer(fromJS({
       foo: {
-        registeredFields: [
-          { name: 'myField', type: 'Field' }
-        ],
+        registeredFields: {
+          myField: { name: 'myField', type: 'Field', count: 1 }
+        },
         values: {
           myField: 'initialValue'
         },
@@ -251,9 +251,9 @@ const describeInitialize = (reducer, expect, { fromJS }) => () => {
     expect(state)
       .toEqualMap({
         foo: {
-          registeredFields: [
-            { name: 'myField', type: 'Field' }
-          ],
+          registeredFields: {
+            myField: { name: 'myField', type: 'Field', count: 1 }
+          },
           values: {
             myField: 'newValue'
           },
@@ -267,9 +267,9 @@ const describeInitialize = (reducer, expect, { fromJS }) => () => {
   it('should treat a matching dirty value as pristine when keepDirty is set', () => {
     const state = reducer(fromJS({
       foo: {
-        registeredFields: [
-          { name: 'myField', type: 'Field' }
-        ],
+        registeredFields: {
+          myField: { name: 'myField', type: 'Field', count: 1 }
+        },
         values: {
           myField: 'newValue'
         },
@@ -281,9 +281,9 @@ const describeInitialize = (reducer, expect, { fromJS }) => () => {
     expect(state)
       .toEqualMap({
         foo: {
-          registeredFields: [
-            { name: 'myField', type: 'Field' }
-          ],
+          registeredFields: {
+            myField: { name: 'myField', type: 'Field', count: 1 }
+          },
           values: {
             myField: 'newValue'
           },
@@ -297,9 +297,9 @@ const describeInitialize = (reducer, expect, { fromJS }) => () => {
   it('allows passing keepDirty in options argument', () => {
     const state = reducer(fromJS({
       foo: {
-        registeredFields: [
-          { name: 'myField', type: 'Field' }
-        ],
+        registeredFields: {
+          myField: { name: 'myField', type: 'Field', count: 1 }
+        },
         values: {
           myField: 'dirtyValue'
         },
@@ -311,9 +311,9 @@ const describeInitialize = (reducer, expect, { fromJS }) => () => {
     expect(state)
       .toEqualMap({
         foo: {
-          registeredFields: [
-            { name: 'myField', type: 'Field' }
-          ],
+          registeredFields: {
+            myField: { name: 'myField', type: 'Field', count: 1 }
+          },
           values: {
             myField: 'dirtyValue'
           },

--- a/src/__tests__/reducer.registerField.spec.js
+++ b/src/__tests__/reducer.registerField.spec.js
@@ -8,7 +8,7 @@ const describeRegisterField = (reducer, expect, { fromJS }) => () => {
     expect(state)
       .toEqualMap({
         foo: {
-          registeredFields: [ { name: 'bar', type: 'Field' } ]
+          registeredFields: { bar: { name: 'bar', type: 'Field', count: 1 } }
         }
       })
   })
@@ -16,33 +16,16 @@ const describeRegisterField = (reducer, expect, { fromJS }) => () => {
   it('should add a field to registeredFields', () => {
     const state = reducer(fromJS({
       foo: {
-        registeredFields: [ { name: 'baz', type: 'FieldArray' } ]
+        registeredFields: { baz: { name: 'baz', type: 'FieldArray', count: 1 } }
       }
     }), registerField('foo', 'bar', 'Field' ))
     expect(state)
       .toEqualMap({
         foo: {
-          registeredFields: [
-            { name: 'baz', type: 'FieldArray' },
-            { name: 'bar', type: 'Field' }
-          ]
-        }
-      })
-  })
-
-  it('should remove count if the field is not destroyed on unmount', () => {
-    const initialState = fromJS({
-      foo: {
-        registeredFields: [ { name: 'bar', type: 'Field', count: 0 } ]
-      }
-    })
-    const state = reducer(initialState, registerField('foo', 'bar', 'Field'))
-    expect(state)
-      .toEqualMap({
-        foo: {
-          registeredFields: [
-            { name: 'bar', type: 'Field' }
-          ]
+          registeredFields: {
+            baz: { name: 'baz', type: 'FieldArray', count: 1 },
+            bar: { name: 'bar', type: 'Field', count: 1 }
+          }
         }
       })
   })
@@ -50,33 +33,16 @@ const describeRegisterField = (reducer, expect, { fromJS }) => () => {
   it('should increase count if the field already exists', () => {
     const initialState = fromJS({
       foo: {
-        registeredFields: [ { name: 'bar', type: 'Field' } ]
+        registeredFields: { bar: { name: 'bar', type: 'Field', count: 1 } }
       }
     })
     const state = reducer(initialState, registerField('foo', 'bar', 'Field'))
     expect(state)
       .toEqualMap({
         foo: {
-          registeredFields: [
-            { name: 'bar', type: 'Field', count: 2 }
-          ]
-        }
-      })
-  })
-
-  it('should increase count if the field is registered multiple times', () => {
-    const initialState = fromJS({
-      foo: {
-        registeredFields: [ { name: 'bar', type: 'Field', count: 7 } ]
-      }
-    })
-    const state = reducer(initialState, registerField('foo', 'bar', 'Field' ))
-    expect(state)
-      .toEqualMap({
-        foo: {
-          registeredFields: [
-            { name: 'bar', type: 'Field', count: 8 }
-          ]
+          registeredFields: {
+            bar: { name: 'bar', type: 'Field', count: 2 }
+          }
         }
       })
   })

--- a/src/__tests__/reducer.registerField.spec.js
+++ b/src/__tests__/reducer.registerField.spec.js
@@ -30,15 +30,55 @@ const describeRegisterField = (reducer, expect, { fromJS }) => () => {
       })
   })
 
-  it('should do nothing if the field already exists', () => {
+  it('should remove count if the field is not destroyed on unmount', () => {
     const initialState = fromJS({
       foo: {
-        registeredFields: [ { name: 'bar', type: 'FieldArray' } ]
+        registeredFields: [ { name: 'bar', type: 'Field', count: 0 } ]
+      }
+    })
+    const state = reducer(initialState, registerField('foo', 'bar', 'Field'))
+    expect(state)
+      .toEqualMap({
+        foo: {
+          registeredFields: [
+            { name: 'bar', type: 'Field' }
+          ]
+        }
+      })
+  })
+
+  it('should increase count if the field already exists', () => {
+    const initialState = fromJS({
+      foo: {
+        registeredFields: [ { name: 'bar', type: 'Field' } ]
+      }
+    })
+    const state = reducer(initialState, registerField('foo', 'bar', 'Field'))
+    expect(state)
+      .toEqualMap({
+        foo: {
+          registeredFields: [
+            { name: 'bar', type: 'Field', count: 2 }
+          ]
+        }
+      })
+  })
+
+  it('should increase count if the field is registered multiple times', () => {
+    const initialState = fromJS({
+      foo: {
+        registeredFields: [ { name: 'bar', type: 'Field', count: 7 } ]
       }
     })
     const state = reducer(initialState, registerField('foo', 'bar', 'Field' ))
     expect(state)
-      .toEqual(initialState)
+      .toEqualMap({
+        foo: {
+          registeredFields: [
+            { name: 'bar', type: 'Field', count: 8 }
+          ]
+        }
+      })
   })
 }
 

--- a/src/__tests__/reducer.unregisterField.spec.js
+++ b/src/__tests__/reducer.unregisterField.spec.js
@@ -37,6 +37,48 @@ const describeUnregisterField = (reducer, expect, { fromJS }) => () => {
         }
       })
   })
+
+  it('should set count to zero when not destroyOnUnmount', () => {
+    const state = reducer(fromJS({
+      foo: {
+        registeredFields: [ { name: 'bar', type: 'field' } ]
+      }
+    }), unregisterField('foo', 'bar', false))
+    expect(state)
+      .toEqualMap({
+        foo: {
+          registeredFields: [ { name: 'bar', type: 'field', count: 0 } ]
+        }
+      })
+  })
+
+  it('should remove field count when field is registered twice', () => {
+    const state = reducer(fromJS({
+      foo: {
+        registeredFields: [ { name: 'bar', type: 'field', count: 2 } ]
+      }
+    }), unregisterField('foo', 'bar'))
+    expect(state)
+      .toEqualMap({
+        foo: {
+          registeredFields: [ { name: 'bar', type: 'field' } ]
+        }
+      })
+  })
+
+  it('should decrease count if the field is registered multiple times', () => {
+    const state = reducer(fromJS({
+      foo: {
+        registeredFields: [ { name: 'bar', type: 'field', count: 8 } ]
+      }
+    }), unregisterField('foo', 'bar'))
+    expect(state)
+      .toEqualMap({
+        foo: {
+          registeredFields: [ { name: 'bar', type: 'field', count: 7 } ]
+        }
+      })
+  })
 }
 
 export default describeUnregisterField

--- a/src/__tests__/reducer.unregisterField.spec.js
+++ b/src/__tests__/reducer.unregisterField.spec.js
@@ -4,7 +4,7 @@ const describeUnregisterField = (reducer, expect, { fromJS }) => () => {
   it('should remove a field from registeredFields', () => {
     const state = reducer(fromJS({
       foo: {
-        registeredFields: [ { name: 'bar', type: 'field' } ]
+        registeredFields: { bar: { name: 'bar', type: 'field', count: 1 } }
       }
     }), unregisterField('foo', 'bar'))
     expect(state)
@@ -25,15 +25,15 @@ const describeUnregisterField = (reducer, expect, { fromJS }) => () => {
   it('should do nothing if the field is not registered', () => {
     const state = reducer(fromJS({
       foo: {
-        registeredFields: [ 
-          { name: 'bar', type: 'field' }
-        ]
+        registeredFields: {
+          bar: { name: 'bar', type: 'Field', count: 1 }
+        }
       }
     }), unregisterField('foo', 'baz'))
     expect(state)
       .toEqualMap({
         foo: {
-          registeredFields: [ { name: 'bar', type: 'field' } ]
+          registeredFields: { bar: { name: 'bar', type: 'Field', count: 1 } }
         }
       })
   })
@@ -41,27 +41,13 @@ const describeUnregisterField = (reducer, expect, { fromJS }) => () => {
   it('should set count to zero when not destroyOnUnmount', () => {
     const state = reducer(fromJS({
       foo: {
-        registeredFields: [ { name: 'bar', type: 'field' } ]
+        registeredFields: { bar: { name: 'bar', type: 'field', count: 1 } }
       }
     }), unregisterField('foo', 'bar', false))
     expect(state)
       .toEqualMap({
         foo: {
-          registeredFields: [ { name: 'bar', type: 'field', count: 0 } ]
-        }
-      })
-  })
-
-  it('should remove field count when field is registered twice', () => {
-    const state = reducer(fromJS({
-      foo: {
-        registeredFields: [ { name: 'bar', type: 'field', count: 2 } ]
-      }
-    }), unregisterField('foo', 'bar'))
-    expect(state)
-      .toEqualMap({
-        foo: {
-          registeredFields: [ { name: 'bar', type: 'field' } ]
+          registeredFields: { bar: { name: 'bar', type: 'field', count: 0 } }
         }
       })
   })
@@ -69,13 +55,13 @@ const describeUnregisterField = (reducer, expect, { fromJS }) => () => {
   it('should decrease count if the field is registered multiple times', () => {
     const state = reducer(fromJS({
       foo: {
-        registeredFields: [ { name: 'bar', type: 'field', count: 8 } ]
+        registeredFields: { bar: { name: 'bar', type: 'field', count: 8 } }
       }
     }), unregisterField('foo', 'bar'))
     expect(state)
       .toEqualMap({
         foo: {
-          registeredFields: [ { name: 'bar', type: 'field', count: 7 } ]
+          registeredFields: { bar: { name: 'bar', type: 'field', count: 7 } }
         }
       })
   })

--- a/src/__tests__/reduxForm.spec.js
+++ b/src/__tests__/reduxForm.spec.js
@@ -476,7 +476,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
           testForm: {
             initial: initialValues,
             values: initialValues,
-            registeredFields: [ { name: 'deep.foo', type: 'Field' } ]
+            registeredFields: { 'deep.foo': { name: 'deep.foo', type: 'Field', count: 1 } }
           }
         }
       })
@@ -541,7 +541,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [ { name: 'deep.foo', type: 'Field' } ]
+            registeredFields: { 'deep.foo': { name: 'deep.foo', type: 'Field', count: 1 } }
           }
         }
       })
@@ -565,12 +565,9 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [
-              {
-                name: 'deep.foo',
-                type: 'Field'
-              }
-            ],
+            registeredFields: {
+              'deep.foo': { name: 'deep.foo', type: 'Field', count: 1 }
+            },
             initial: initialValues,
             values: initialValues
           }
@@ -634,7 +631,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [ { name: 'deep.foo', type: 'Field' } ],
+            registeredFields: { 'deep.foo': { name: 'deep.foo', type: 'Field', count: 1 } },
             initial: initialValues1,
             values: initialValues1
           }
@@ -660,12 +657,9 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [
-              {
-                name: 'deep.foo',
-                type: 'Field'
-              }
-            ],
+            registeredFields: {
+              'deep.foo': { name: 'deep.foo', type: 'Field', count: 1 }
+            },
             initial: initialValues1,
             values: initialValues1
           }
@@ -739,7 +733,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [ { name: 'deep.foo', type: 'Field' } ],
+            registeredFields: { 'deep.foo': { name: 'deep.foo', type: 'Field', count: 1 } },
             initial: initialValues1,
             values: initialValues1
           }
@@ -778,12 +772,9 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [
-              {
-                name: 'deep.foo',
-                type: 'Field'
-              }
-            ],
+            registeredFields: {
+              'deep.foo': { name: 'deep.foo', type: 'Field', count: 1 }
+            },
             initial: initialValues2,
             values: initialValues2
           }
@@ -854,7 +845,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [ { name: 'deep.foo', type: 'Field' } ],
+            registeredFields: { 'deep.foo': { name: 'deep.foo', type: 'Field', count: 1 } },
             initial: initialValues1,
             values: initialValues1
           }
@@ -888,12 +879,9 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [
-              {
-                name: 'deep.foo',
-                type: 'Field'
-              }
-            ],
+            registeredFields: {
+              'deep.foo': { name: 'deep.foo', type: 'Field', count: 1 }
+            },
             initial: initialValues2,
             values: {
               deep: {
@@ -964,7 +952,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [ { name: 'deep.foo', type: 'Field' } ],
+            registeredFields: { 'deep.foo': { name: 'deep.foo', type: 'Field', count: 1 } },
             initial: initialValues1,
             values: initialValues1
           }
@@ -998,12 +986,9 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [
-              {
-                name: 'deep.foo',
-                type: 'Field'
-              }
-            ],
+            registeredFields: {
+              'deep.foo': { name: 'deep.foo', type: 'Field', count: 1 }
+            },
             initial: initialValues2,
             values: initialValues2
           }
@@ -1133,7 +1118,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [ { name: 'deep.foo', type: 'Field' } ],
+            registeredFields: { 'deep.foo': { name: 'deep.foo', type: 'Field', count: 1 } },
             initial: initialValues1,
             values: initialValues1
           }
@@ -1167,12 +1152,9 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [
-              {
-                name: 'deep.foo',
-                type: 'Field'
-              }
-            ],
+            registeredFields: {
+              'deep.foo': { name: 'deep.foo', type: 'Field', count: 1 }
+            },
             initial: initialValues2,
             values: initialValues2
           }
@@ -1228,7 +1210,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
      expect(store.getState()).toEqualMap({
      form: {
      testForm: {
-     registeredFields: [ { name: 'deep.foo', type: 'Field' } ],
+     registeredFields: { 'deep.foo': { name: 'deep.foo', type: 'Field', count: 1 } },
      initial: initialValues1,
      values: initialValues1
      }
@@ -1247,12 +1229,9 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
      expect(store.getState()).toEqualMap({
      form: {
      testForm: {
-     registeredFields: [
-     {
-     name: 'deep.foo',
-     type: 'Field'
-     }
-     ],
+     registeredFields: {
+     'deep.foo': { name: 'deep.foo', type: 'Field', count: 1 }
+     },
      initial: initialValues1,
      values: initialValues1
      }
@@ -1266,12 +1245,9 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
      expect(store.getState()).toEqualMap({
      form: {
      testForm: {
-     registeredFields: [
-     {
-     name: 'deep.foo',
-     type: 'Field'
-     }
-     ],
+     registeredFields: {
+     'deep.foo': { name: 'deep.foo', type: 'Field', count: 1 }
+     },
      initial: initialValues2,
      values: initialValues2
      }
@@ -1333,7 +1309,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [ { name: 'deep.foo', type: 'Field' } ]
+            registeredFields: { 'deep.foo': { name: 'deep.foo', type: 'Field', count: 1 } }
           }
         }
       }, 'Form data in Redux did not get destroyed')
@@ -1363,7 +1339,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
                 foo: 'bob'
               }
             },
-            registeredFields: [ { name: 'deep.foo', type: 'Field' } ]
+            registeredFields: { 'deep.foo': { name: 'deep.foo', type: 'Field', count: 1 } }
           }
         }
       })
@@ -1436,7 +1412,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [ { name: 'deep.foo', type: 'Field' } ]
+            registeredFields: { 'deep.foo': { name: 'deep.foo', type: 'Field', count: 1 } }
           }
         }
       }, 'Form data in Redux did not get destroyed')
@@ -1466,7 +1442,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
                 foo: 'bob'
               }
             },
-            registeredFields: [ { name: 'deep.foo', type: 'Field' } ]
+            registeredFields: { 'deep.foo': { name: 'deep.foo', type: 'Field', count: 1 } }
           }
         }
       })
@@ -1485,7 +1461,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
                 foo: 'bob'
               }
             },
-            registeredFields: [ { name: 'deep.foo', type: 'Field', count: 0 } ]
+            registeredFields: { 'deep.foo': { name: 'deep.foo', type: 'Field', count: 0 } }
           }
         }
       })
@@ -1536,13 +1512,13 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       )
 
       const stub = TestUtils.findRenderedComponentWithType(dom, Decorated)
-      expect(stub.fieldList).toEqual(fromJS([ 'foo', 'fooArray' ]))
+      expect(stub.fieldList).toContainExactly([ 'foo', 'fooArray' ])
 
       // switch fields
       const button = TestUtils.findRenderedDOMComponentWithTag(dom, 'button')
       TestUtils.Simulate.click(button)
 
-      expect(stub.fieldList).toEqual(fromJS([ 'bar', 'barArray' ]))
+      expect(stub.fieldList).toContainExactly([ 'bar', 'barArray' ])
     })
 
     it('should keep a list of registered fields inside a FormSection', () => {
@@ -1579,13 +1555,13 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       )
 
       const stub = TestUtils.findRenderedComponentWithType(dom, Decorated)
-      expect(stub.fieldList).toEqual(fromJS([ 'sec.foo', 'sec.fooArray' ]))
+      expect(stub.fieldList).toContainExactly([ 'sec.foo', 'sec.fooArray' ])
 
       // switch fields
       const button = TestUtils.findRenderedDOMComponentWithTag(dom, 'button')
       TestUtils.Simulate.click(button)
 
-      expect(stub.fieldList).toEqual(fromJS([ 'sec.bar', 'sec.barArray' ]))
+      expect(stub.fieldList).toContainExactly([ 'sec.bar', 'sec.barArray' ])
     })
 
     it('should provide valid/invalid/values/dirty/pristine getters', () => {
@@ -1660,10 +1636,10 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [
-              { name: 'username', type: 'Field' },
-              { name: 'password', type: 'Field' }
-            ]
+            registeredFields: {
+              username: { name: 'username', type: 'Field', count: 1 },
+              password: { name: 'password', type: 'Field', count: 1 }
+            }
           }
         }
       })
@@ -1680,10 +1656,10 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [
-              { name: 'username', type: 'Field' },
-              { name: 'password', type: 'Field' }
-            ],
+            registeredFields: {
+              username: { name: 'username', type: 'Field', count: 1 },
+              password: { name: 'password', type: 'Field', count: 1 }
+            },
             anyTouched: true,
             fields: {
               username: {
@@ -2464,7 +2440,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [ { name: 'deep.foo', type: 'Field' } ]
+            registeredFields: { 'deep.foo': { name: 'deep.foo', type: 'Field', count: 1 } }
           }
         }
       })
@@ -2772,7 +2748,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [ { name: 'deep.foo', type: 'Field' } ]
+            registeredFields: { 'deep.foo': { name: 'deep.foo', type: 'Field', count: 1 } }
           }
         }
       })
@@ -2799,7 +2775,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
                 foo: 'bar'
               }
             },
-            registeredFields: [ { name: 'deep.foo', type: 'Field' } ]
+            registeredFields: { 'deep.foo': { name: 'deep.foo', type: 'Field', count: 1 } }
           }
         }
       })
@@ -2832,7 +2808,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
                   }
                 }
               },
-              registeredFields: [ { name: 'deep.foo', type: 'Field' } ],
+              registeredFields: { 'deep.foo': { name: 'deep.foo', type: 'Field', count: 1 } },
               asyncErrors
             }
           }
@@ -3031,7 +3007,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [ { name: 'foo', type: 'Field' } ]
+            registeredFields: { foo: { name: 'foo', type: 'Field', count: 1 } }
           }
         }
       })
@@ -3230,7 +3206,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
           testForm: {
             initial: { foo: 'fooInitial' },
             values: { foo: 'fooInitial' },
-            registeredFields: [ { name: 'foo', type: 'Field' } ]
+            registeredFields: { foo: { name: 'foo', type: 'Field', count: 1 } }
           }
         }
       })
@@ -3249,7 +3225,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
           testForm: {
             initial: { foo: 'fooInitial' },
             values: { foo: 'fooChanged' },
-            registeredFields: [ { name: 'foo', type: 'Field' } ]
+            registeredFields: { foo: { name: 'foo', type: 'Field', count: 1 } }
           }
         }
       })
@@ -3268,7 +3244,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
           testForm: {
             initial: { foo: 'fooInitial' },
             values: { foo: 'fooChanged' },
-            registeredFields: [ { name: 'foo', type: 'Field', count: 0 } ]
+            registeredFields: { foo: { name: 'foo', type: 'Field', count: 0 } }
           }
         }
       })
@@ -3282,7 +3258,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
           testForm: {
             initial: { foo: 'fooInitial' },
             values: { foo: 'fooChanged' },
-            registeredFields: [ { name: 'foo', type: 'Field' } ]
+            registeredFields: { foo: { name: 'foo', type: 'Field', count: 1 } }
           }
         }
       })
@@ -3317,7 +3293,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [ { name: 'foo', type: 'Field' } ]
+            registeredFields: { foo: { name: 'foo', type: 'Field', count: 1 } }
           }
         }
       })
@@ -3331,7 +3307,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [ { name: 'foo', type: 'Field' } ],
+            registeredFields: { foo: { name: 'foo', type: 'Field', count: 1 } },
             values: { foo: 'newValue' },
             fields: { foo: { touched: true } },
             anyTouched: true
@@ -3368,7 +3344,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [ { name: 'foo', type: 'Field' } ]
+            registeredFields: { foo: { name: 'foo', type: 'Field', count: 1 } }
           }
         }
       })
@@ -3382,7 +3358,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
-            registeredFields: [ { name: 'foo', type: 'Field' } ],
+            registeredFields: { foo: { name: 'foo', type: 'Field', count: 1 } },
             values: { foo: 'newValue' }
           }
         }
@@ -3437,12 +3413,9 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
                   touched: true
                 }
               },
-              registeredFields: [
-                {
-                  name: 'foo',
-                  type: 'Field'
-                }
-              ],
+              registeredFields: {
+                foo: { name: 'foo', type: 'Field', count: 1 }
+              },
               submitSucceeded: true
             }
           }
@@ -3490,12 +3463,9 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
                 touched: true
               }
             },
-            registeredFields: [
-              {
-                name: 'foo',
-                type: 'Field'
-              }
-            ],
+            registeredFields: {
+              foo: { name: 'foo', type: 'Field', count: 1 }
+            },
             submitting: true,
             submitSucceeded: true
           }

--- a/src/__tests__/reduxForm.spec.js
+++ b/src/__tests__/reduxForm.spec.js
@@ -1485,7 +1485,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
                 foo: 'bob'
               }
             },
-            registeredFields: [ { name: 'deep.foo', type: 'Field' } ]
+            registeredFields: [ { name: 'deep.foo', type: 'Field', count: 0 } ]
           }
         }
       })
@@ -3268,7 +3268,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
           testForm: {
             initial: { foo: 'fooInitial' },
             values: { foo: 'fooChanged' },
-            registeredFields: [ { name: 'foo', type: 'Field' } ]
+            registeredFields: [ { name: 'foo', type: 'Field', count: 0 } ]
           }
         }
       })

--- a/src/actions.js
+++ b/src/actions.js
@@ -129,8 +129,8 @@ export const setSubmitSucceeded = (form, ...fields) =>
 export const touch = (form, ...fields) =>
   ({ type: TOUCH, meta: { form, fields } })
 
-export const unregisterField = (form, name) =>
-  ({ type: UNREGISTER_FIELD, meta: { form }, payload: { name } })
+export const unregisterField = (form, name, destroyOnUnmount = true) =>
+  ({ type: UNREGISTER_FIELD, meta: { form }, payload: { name, destroyOnUnmount } })
 
 export const untouch = (form, ...fields) =>
   ({ type: UNTOUCH, meta: { form, fields } })

--- a/src/reduxForm.js
+++ b/src/reduxForm.js
@@ -96,8 +96,6 @@ const createReduxForm =
       }
 
       return WrappedComponent => {
-        let instances = 0
-
         class Form extends Component {
           constructor(props) {
             super(props)
@@ -113,8 +111,6 @@ const createReduxForm =
             this.lastFieldValidatorKeys = []
             this.fieldWarners = {}
             this.lastFieldWarnerKeys = []
-
-            instances++
           }
 
           getChildContext() {
@@ -258,10 +254,6 @@ const createReduxForm =
               this.destroyed = true
               destroy()
             }
-
-            this.unmounted = true
-
-            instances--
           }
 
           getValues() {
@@ -287,10 +279,14 @@ const createReduxForm =
           }
 
           unregister(name) {
-            if ((this.props.destroyOnUnmount || this.props.forceUnregisterOnUnmount) && !this.destroyed && (!this.unmounted || !instances)) {
-              this.props.unregisterField(name)
-              delete this.fieldValidators[ name ]
-              delete this.fieldWarners[ name ]
+            if (!this.destroyed) {
+              if (this.props.destroyOnUnmount || this.props.forceUnregisterOnUnmount) {
+                this.props.unregisterField(name)
+                delete this.fieldValidators[name]
+                delete this.fieldWarners[name]
+              } else {
+                this.props.unregisterField(name, false)
+              }
             }
           }
 

--- a/src/reduxForm.js
+++ b/src/reduxForm.js
@@ -77,7 +77,7 @@ const checkSubmit = submit => {
  */
 const createReduxForm =
   structure => {
-    const { deepEqual, empty, getIn, setIn, fromJS } = structure
+    const { deepEqual, empty, getIn, setIn, keys, fromJS } = structure
     const isValid = createIsValid(structure)
     return initialConfig => {
       const config = {
@@ -291,7 +291,16 @@ const createReduxForm =
           }
 
           getFieldList() {
-            return this.props.registeredFields.map((field) => getIn(field, 'name'))
+            let registeredFields = this.props.registeredFields
+            let list = []
+            if (!registeredFields) {
+              return list
+            }
+            let keySeq = keys(registeredFields)
+            return fromJS(keySeq.reduce((acc, key) => {
+              acc.push(key)
+              return acc
+            }, list))
           }
 
           generateValidator() {
@@ -552,7 +561,7 @@ const createReduxForm =
             const asyncErrors = getIn(formState, 'asyncErrors')
             const syncErrors = getIn(formState, 'syncErrors') || {}
             const syncWarnings = getIn(formState, 'syncWarnings') || {}
-            const registeredFields = getIn(formState, 'registeredFields') || []
+            const registeredFields = getIn(formState, 'registeredFields')
             const valid = isValid(form, getFormState, false)(state)
             const validExceptSubmit = isValid(form, getFormState, true)(state)
             const anyTouched = !!getIn(formState, 'anyTouched')

--- a/src/selectors/__tests__/isInvalid.spec.js
+++ b/src/selectors/__tests__/isInvalid.spec.js
@@ -46,10 +46,10 @@ const describeIsInvalid = (name, structure, expect) => {
               dog: 'Odie',
               cat: 'Garfield'
             },
-            registeredFields: [
-              { name: 'dog', type: 'Field' },
-              { name: 'cat', type: 'Field' }
-            ],
+            registeredFields: {
+              dog: { name: 'dog', type: 'Field', count: 1 },
+              cat: { name: 'cat', type: 'Field', count: 1 }
+            },
             syncErrors: {
               horse: 'Too old'
             }
@@ -68,10 +68,10 @@ const describeIsInvalid = (name, structure, expect) => {
               dog: 'Odie',
               cat: 'Garfield'
             },
-            registeredFields: [
-              { name: 'dog', type: 'Field' },
-              { name: 'cat', type: 'Field' }
-            ]
+            registeredFields: {
+              dog: { name: 'dog', type: 'Field', count: 1 },
+              cat: { name: 'cat', type: 'Field', count: 1 }
+            }
           }
         }
       }), 'form.foo.syncErrors', {
@@ -87,10 +87,10 @@ const describeIsInvalid = (name, structure, expect) => {
               dog: 'Odie',
               cats: [ 'Garfield' ]
             },
-            registeredFields: [
-              { name: 'dog', type: 'Field' },
-              { name: 'cats', type: 'FieldArray' }
-            ]
+            registeredFields: {
+              dog: { name: 'dog', type: 'Field', count: 1 },
+              cats: { name: 'cats', type: 'FieldArray', count: 1 }
+            }
           }
         }
       }), 'form.foo.syncErrors', {
@@ -110,10 +110,10 @@ const describeIsInvalid = (name, structure, expect) => {
             },
             error: 'Bad Data',
             syncError: true,
-            registeredFields: [
-              { name: 'dog', type: 'Field' },
-              { name: 'cat', type: 'Field' }
-            ]
+            registeredFields: {
+              dog: { name: 'dog', type: 'Field', count: 1 },
+              cat: { name: 'cat', type: 'Field', count: 1 }
+            }
           }
         }
       }))).toBe(true)
@@ -127,10 +127,10 @@ const describeIsInvalid = (name, structure, expect) => {
               dog: 'Odie',
               cat: 'Garfield'
             },
-            registeredFields: [
-              { name: 'dog', type: 'Field' },
-              { name: 'cat', type: 'Field' }
-            ],
+            registeredFields: {
+              dog: { name: 'dog', type: 'Field', count: 1 },
+              cat: { name: 'cat', type: 'Field', count: 1 }
+            },
             asyncErrors: {
               horse: 'Too old'
             }
@@ -147,10 +147,10 @@ const describeIsInvalid = (name, structure, expect) => {
               dog: 'Odie',
               cat: 'Garfield'
             },
-            registeredFields: [
-              { name: 'dog', type: 'Field' },
-              { name: 'cat', type: 'Field' }
-            ],
+            registeredFields: {
+              dog: { name: 'dog', type: 'Field', count: 1 },
+              cat: { name: 'cat', type: 'Field', count: 1 }
+            },
             asyncErrors: {
               dog: 'Too old'
             }
@@ -167,10 +167,10 @@ const describeIsInvalid = (name, structure, expect) => {
               dog: 'Odie',
               cats: [ 'Garfield' ]
             },
-            registeredFields: [
-              { name: 'dog', type: 'Field' },
-              { name: 'cats', type: 'FieldArray' }
-            ],
+            registeredFields: {
+              dog: { name: 'dog', type: 'Field', count: 1 },
+              cats: { name: 'cats', type: 'FieldArray', count: 1 }
+            },
             asyncErrors: {
               cats: {
                 _error: 'Too many cats'
@@ -189,10 +189,10 @@ const describeIsInvalid = (name, structure, expect) => {
               dog: 'Odie',
               cat: 'Garfield'
             },
-            registeredFields: [
-              { name: 'dog', type: 'Field' },
-              { name: 'cat', type: 'Field' }
-            ],
+            registeredFields: {
+              dog: { name: 'dog', type: 'Field', count: 1 },
+              cat: { name: 'cat', type: 'Field', count: 1 }
+            },
             submitErrors: {
               horse: 'Too old'
             }
@@ -209,10 +209,10 @@ const describeIsInvalid = (name, structure, expect) => {
               dog: 'Odie',
               cat: 'Garfield'
             },
-            registeredFields: [
-              { name: 'dog', type: 'Field' },
-              { name: 'cat', type: 'Field' }
-            ],
+            registeredFields: {
+              dog: { name: 'dog', type: 'Field', count: 1 },
+              cat: { name: 'cat', type: 'Field', count: 1 }
+            },
             submitErrors: {
               dog: 'Too old'
             }
@@ -229,10 +229,10 @@ const describeIsInvalid = (name, structure, expect) => {
               dog: 'Odie',
               cats: [ 'Garfield' ]
             },
-            registeredFields: [
-              { name: 'dog', type: 'Field' },
-              { name: 'cats', type: 'FieldArray' }
-            ],
+            registeredFields: {
+              dog: { name: 'dog', type: 'Field', count: 1 },
+              cats: { name: 'cats', type: 'FieldArray', count: 1 }
+            },
             submitErrors: {
               cats: {
                 _error: 'Too many cats'
@@ -251,10 +251,10 @@ const describeIsInvalid = (name, structure, expect) => {
               dog: 'Odie',
               cat: 'Garfield'
             },
-            registeredFields: [
-              { name: 'dog', type: 'Field' },
-              { name: 'cat', type: 'Field' }
-            ],
+            registeredFields: {
+              dog: { name: 'dog', type: 'Field', count: 1 },
+              cat: { name: 'cat', type: 'Field', count: 1 }
+            },
             submitErrors: {
               dog: 'That dog is ugly'
             }

--- a/src/selectors/__tests__/isValid.spec.js
+++ b/src/selectors/__tests__/isValid.spec.js
@@ -46,10 +46,10 @@ const describeIsValid = (name, structure, expect) => {
               dog: 'Odie',
               cat: 'Garfield'
             },
-            registeredFields: [
-              { name: 'dog', type: 'Field' },
-              { name: 'cat', type: 'Field' }
-            ],
+            registeredFields: {
+              dog: { name: 'dog', type: 'Field', count: 1 },
+              cat: { name: 'cat', type: 'Field', count: 1 }
+            },
             syncErrors: {
               horse: 'Too old'
             }
@@ -68,10 +68,10 @@ const describeIsValid = (name, structure, expect) => {
               dog: 'Odie',
               cat: 'Garfield'
             },
-            registeredFields: [
-              { name: 'dog', type: 'Field' },
-              { name: 'cat', type: 'Field' }
-            ]
+            registeredFields: {
+              dog: { name: 'dog', type: 'Field', count: 1 },
+              cat: { name: 'cat', type: 'Field', count: 1 }
+            }
           }
         }
       }), 'form.foo.syncErrors', {
@@ -87,10 +87,10 @@ const describeIsValid = (name, structure, expect) => {
               dog: 'Odie',
               cats: [ 'Garfield' ]
             },
-            registeredFields: [
-              { name: 'dog', type: 'Field' },
-              { name: 'cats', type: 'FieldArray' }
-            ]
+            registeredFields: {
+              dog: { name: 'dog', type: 'Field', count: 1 },
+              cats: { name: 'cats', type: 'FieldArray', count: 1 }
+            }
           }
         }
       }), 'form.foo.syncErrors', {
@@ -110,10 +110,10 @@ const describeIsValid = (name, structure, expect) => {
             },
             error: 'Bad data',
             syncError: true,
-            registeredFields: [
-              { name: 'dog', type: 'Field' },
-              { name: 'cat', type: 'Field' }
-            ]
+            registeredFields: {
+              dog: { name: 'dog', type: 'Field', count: 1 },
+              cat: { name: 'cat', type: 'Field', count: 1 }
+            }
           }
         }
       }))).toBe(false)
@@ -127,10 +127,10 @@ const describeIsValid = (name, structure, expect) => {
               dog: 'Odie',
               cat: 'Garfield'
             },
-            registeredFields: [
-              { name: 'dog', type: 'Field' },
-              { name: 'cat', type: 'Field' }
-            ],
+            registeredFields: {
+              dog: { name: 'dog', type: 'Field', count: 1 },
+              cat: { name: 'cat', type: 'Field', count: 1 }
+            },
             asyncErrors: {
               horse: 'Too old'
             }
@@ -147,10 +147,10 @@ const describeIsValid = (name, structure, expect) => {
               dog: 'Odie',
               cat: 'Garfield'
             },
-            registeredFields: [
-              { name: 'dog', type: 'Field' },
-              { name: 'cat', type: 'Field' }
-            ],
+            registeredFields: {
+              dog: { name: 'dog', type: 'Field', count: 1 },
+              cat: { name: 'cat', type: 'Field', count: 1 }
+            },
             asyncErrors: {
               dog: 'Too old'
             }
@@ -167,10 +167,10 @@ const describeIsValid = (name, structure, expect) => {
               dog: 'Odie',
               cats: [ 'Garfield' ]
             },
-            registeredFields: [
-              { name: 'dog', type: 'Field' },
-              { name: 'cats', type: 'FieldArray' }
-            ],
+            registeredFields: {
+              dog: { name: 'dog', type: 'Field', count: 1 },
+              cats: { name: 'cats', type: 'FieldArray', count: 1 }
+            },
             asyncErrors: {
               cats: {
                 _error: 'Too many cats'
@@ -189,10 +189,10 @@ const describeIsValid = (name, structure, expect) => {
               dog: 'Odie',
               cat: 'Garfield'
             },
-            registeredFields: [
-              { name: 'dog', type: 'Field' },
-              { name: 'cat', type: 'Field' }
-            ],
+            registeredFields: {
+              dog: { name: 'dog', type: 'Field', count: 1 },
+              cat: { name: 'cat', type: 'Field', count: 1 }
+            },
             submitErrors: {
               horse: 'Too old'
             }
@@ -209,10 +209,10 @@ const describeIsValid = (name, structure, expect) => {
               dog: 'Odie',
               cat: 'Garfield'
             },
-            registeredFields: [
-              { name: 'dog', type: 'Field' },
-              { name: 'cat', type: 'Field' }
-            ],
+            registeredFields: {
+              dog: { name: 'dog', type: 'Field', count: 1 },
+              cat: { name: 'cat', type: 'Field', count: 1 }
+            },
             submitErrors: {
               dog: 'Too old'
             }
@@ -229,10 +229,10 @@ const describeIsValid = (name, structure, expect) => {
               dog: 'Odie',
               cats: [ 'Garfield' ]
             },
-            registeredFields: [
-              { name: 'dog', type: 'Field' },
-              { name: 'cats', type: 'FieldArray' }
-            ],
+            registeredFields: {
+              dog: { name: 'dog', type: 'Field', count: 1 },
+              cats: { name: 'cats', type: 'FieldArray', count: 1 }
+            },
             submitErrors: {
               cats: {
                 _error: 'Too many cats'
@@ -251,10 +251,10 @@ const describeIsValid = (name, structure, expect) => {
               dog: 'Odie',
               cat: 'Garfield'
             },
-            registeredFields: [
-              { name: 'dog', type: 'Field' },
-              { name: 'cat', type: 'Field' }
-            ],
+            registeredFields: {
+              dog: { name: 'dog', type: 'Field', count: 1 },
+              cat: { name: 'cat', type: 'Field', count: 1 }
+            },
             error: 'Form wide'
           }
         }
@@ -269,10 +269,10 @@ const describeIsValid = (name, structure, expect) => {
               dog: 'Odie',
               cat: 'Garfield'
             },
-            registeredFields: [
-              { name: 'dog', type: 'Field' },
-              { name: 'cat', type: 'Field' }
-            ],
+            registeredFields: {
+              dog: { name: 'dog', type: 'Field', count: 1 },
+              cat: { name: 'cat', type: 'Field', count: 1 }
+            },
             submitErrors: {
               dog: 'Too old'
             }
@@ -289,10 +289,10 @@ const describeIsValid = (name, structure, expect) => {
               dog: 'Odie',
               cat: 'Garfield'
             },
-            registeredFields: [
-              { name: 'dog', type: 'Field' },
-              { name: 'cat', type: 'Field' }
-            ],
+            registeredFields: {
+              dog: { name: 'dog', type: 'Field', count: 1 },
+              cat: { name: 'cat', type: 'Field', count: 1 }
+            },
             error: 'Form wide'
           }
         }
@@ -307,10 +307,10 @@ const describeIsValid = (name, structure, expect) => {
               dog: 'Odie',
               cat: 'Garfield'
             },
-            registeredFields: [
-              { name: 'dog', type: 'Field' },
-              { name: 'cat', type: 'Field' }
-            ],
+            registeredFields: {
+              dog: { name: 'dog', type: 'Field', count: 1 },
+              cat: { name: 'cat', type: 'Field', count: 1 }
+            },
             submitErrors: {
               dog: 'That dog is ugly'
             }

--- a/src/selectors/isValid.js
+++ b/src/selectors/isValid.js
@@ -1,7 +1,7 @@
 import createHasError from '../hasError'
 
 const createIsValid = structure => {
-  const { getIn } = structure
+  const { getIn, keys } = structure
   const hasError = createHasError(structure)
   return (form, getFormState = state => getIn(state, 'form'), ignoreSubmitErrors = false) =>
     state => {
@@ -25,8 +25,14 @@ const createIsValid = structure => {
         return true
       }
 
-      const registeredFields = getIn(formState, `${form}.registeredFields`) || []
-      return !registeredFields.some(field => hasError(field, syncErrors, asyncErrors, submitErrors))
+      const registeredFields = getIn(formState, `${form}.registeredFields`)
+      if (!registeredFields) {
+        return true
+      }
+      
+      return !keys(registeredFields).filter(
+        name => getIn(registeredFields, `['${name}'].count`) > 0).some(
+          name => hasError(getIn(registeredFields, `['${name}']`), syncErrors, asyncErrors, submitErrors))
     }
 }
 

--- a/src/structure/immutable/__tests__/setIn.spec.js
+++ b/src/structure/immutable/__tests__/setIn.spec.js
@@ -31,6 +31,23 @@ describe('structure.immutable.setIn', () => {
       .toBeA(List)
       .toEqual(fromJS([ 'success' ]))
   })
+  it('should handle nested array paths', () => {
+    const result = setIn(new Map(), 'a.b[2][1]', 'success')
+
+    const a = result.get('a')
+    expect(a).toExist('a missing')
+
+    const b = a.get('b')
+    expect(b)
+      .toExist('b missing')
+      .toBeA(List)
+
+    const b2 = b.get(2)
+    expect(b2)
+      .toExist('b[2] missing')
+      .toBeA(List)
+      .toEqual(fromJS([ undefined, 'success' ]))
+  })
   it('should handle array paths with successive sets', () => {
     let result = setIn(new Map(), 'a.b[2]', 'success')
     result = setIn(result, 'a.b[0]', 'success')

--- a/src/structure/immutable/expectations.js
+++ b/src/structure/immutable/expectations.js
@@ -48,6 +48,18 @@ const api = {
       this.actual
     )
     return this
+  },
+
+  toContainExactly(expected) {
+    const expectedItems = expected.map(expectedItem => fromJS(expectedItem))
+    expect.assert(
+      this.actual.count() === expected.length && this.actual.every(
+          actualItem => expectedItems.some(expectedItem => deepEqualValues(actualItem, expectedItem))),
+      'expected...\n%s\n...but found...\n%s',
+      this.actual,
+      expected
+    )
+    return this
   }
 }
 

--- a/src/structure/immutable/index.js
+++ b/src/structure/immutable/index.js
@@ -20,7 +20,6 @@ const structure = {
     Iterable.isIndexed(value) ? value.toList() : value.toMap()),
   keys,
   size: list => list ? list.size : 0,
-  some: (iterable, callback) => Iterable.isIterable(iterable) ? iterable.some(callback) : false,
   splice,
   toJS: value => Iterable.isIterable(value) ? value.toJS() : value
 }

--- a/src/structure/plain/__tests__/setIn.spec.js
+++ b/src/structure/plain/__tests__/setIn.spec.js
@@ -23,6 +23,14 @@ describe('structure.plain.setIn', () => {
       .toBe('second')
   })
 
+  it('should handle nested array paths', () => {
+    const result = setIn({}, 'a.b[2][1]', 'success')
+    const b = []
+    b[2] = []
+    b[2][1] = 'success'
+    expect(result).toEqual({ a: { b } })
+  })
+
   it('should set and shallow keys without mutating state', () => {
     const state = { foo: 'bar' }
     expect(setIn(state, 'foo', 'baz'))

--- a/src/structure/plain/expectations.js
+++ b/src/structure/plain/expectations.js
@@ -32,6 +32,14 @@ const expectations = {
 
   toEqualMap(expected) {
     return expect(this.actual).toEqual(expected)
+  },
+
+  toContainExactly(expected) {
+    const sortedActual = this.actual.slice()
+    sortedActual.sort()
+    const sortedExpected = expected.slice()
+    sortedExpected.sort()
+    return expect(sortedActual).toEqual(sortedExpected)
   }
 }
 

--- a/src/structure/plain/index.js
+++ b/src/structure/plain/index.js
@@ -4,7 +4,6 @@ import setIn from './setIn'
 import deepEqual from './deepEqual'
 import deleteIn from './deleteIn'
 import keys from './keys'
-import { some } from 'lodash'
 
 const structure = {
   empty: {},
@@ -16,7 +15,6 @@ const structure = {
   fromJS: value => value,
   keys,
   size: array => array ? array.length : 0,
-  some,
   splice,
   toJS: value => value
 }


### PR DESCRIPTION
For backward compatibility, when registration count is one, the registeredFields will not have the count property. Undo #2040. Fixes #2016, #2223, #1705. Partially fixes #1990.