### PR TITLE
Chore/switch shallowequal to lodash isequalwith

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,7 @@
     "invariant": "^2.2.2",
     "is-promise": "^2.1.0",
     "lodash": "^4.17.3",
-    "lodash-es": "^4.17.3",
-    "shallowequal": "^0.2.2"
+    "lodash-es": "^4.17.3"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",

--- a/src/util/__tests__/shallowCompare.spec.js
+++ b/src/util/__tests__/shallowCompare.spec.js
@@ -1,0 +1,43 @@
+import expect from 'expect'
+import shallowCompare from '../shallowCompare'
+
+describe('shallowCompare', () => {
+  it('should shallow compare props and state', () => {
+    expect(shallowCompare({
+      props: {
+        a: 'a'
+      },
+      state: {
+        b: 'b'
+      }
+    }, { a: 'a' }, { b: 'b' })).toBe(false)
+  })
+
+  it('should shallow compare props and state', () => {
+    const aProp = new Date()
+    const bState = [ 1, 2, 3 ] 
+
+    expect(shallowCompare({
+      props:  {
+        a: aProp
+      },
+      state: {
+        b: bState
+      }
+    }, { a: aProp }, { b: bState })).toBe(false)
+  })
+
+  it('should shallow compare props and state', () => {
+    const aProp = new Date()
+    const bState = [ 1, 2, 3 ] 
+
+    expect(shallowCompare({
+      props:  {
+        a: aProp
+      },
+      state: {
+        b: bState
+      }
+    }, { a: aProp }, { b: [ 1, 2, 3 ] })).toBe(true)
+  })
+})

--- a/src/util/shallowCompare.js
+++ b/src/util/shallowCompare.js
@@ -1,9 +1,21 @@
-import shallowEqual from 'shallowequal'
+import { isEqualWith } from 'lodash'
+
+const customizer = (objectValue, otherValue, indexOrkey, object, other, stack) => {
+  // https://lodash.com/docs/4.17.4#isEqualWith
+  if (stack) {
+    // Shallow compares
+    // For 1st level, stack === undefined.
+    //   -> Do nothing (and implicitly return undefined so that it goes to compare 2nd level)
+    // For 2nd level and up, stack !== undefined.
+    //   -> Compare by === operator
+    return objectValue === otherValue
+  }
+}
 
 const shallowCompare = (instance, nextProps, nextState) => {
   return (
-    !shallowEqual(instance.props, nextProps) ||
-    !shallowEqual(instance.state, nextState)
+    !isEqualWith(instance.props, nextProps, customizer) ||
+    !isEqualWith(instance.state, nextState, customizer)
   )
 }
 


### PR DESCRIPTION
Replace `shallowequal` with `lodash/isEqualWith` + `customizer` function. This:

1. Reduces # of dependencies
2. Creates smaller bundle size
3. Allows re-usage of the `lodash` package for the consumer of `redux-form`

I also added three test cases to ensure our assumption toward `shallowCompare` is correct. But I'm afraid I missed something. Feel free to add more test cases to validate this.

### Diff

```diff
- redux-form.js  286 kB
+ redux-form.js  263 kB (-8%)
//
- redux-form.min.js  96.8 kB
+ redux-form.min.js  93.4 kB (-3.5%)
//
- gzip -9 -c ./dist/redux-form.min.js | wc -c
   21432
+ gzip -9 -c ./dist/redux-form.min.js | wc -c                                           
   20540 (-4.1%)
```
