### PR TITLE
Fix shouldComponentUpdate in FieldArray

### DIFF
--- a/src/ConnectedFieldArray.js
+++ b/src/ConnectedFieldArray.js
@@ -33,6 +33,16 @@ const createConnectedFieldArray = ({ deepEqual, getIn, size }) => {
     }
 
     shouldComponentUpdate(nextProps) {
+      // Update if the elements of the value array was updated.
+      const thisValue = this.props.value
+      const nextValue = nextProps.value
+
+      if (thisValue && nextValue) {
+        if (thisValue.length != nextValue.length || thisValue.every(val => nextValue.some(next => deepEqual(val, next)))) {
+          return true
+        }
+      }
+
       const nextPropsKeys = Object.keys(nextProps)
       const thisPropsKeys = Object.keys(this.props)
       return nextPropsKeys.length !== thisPropsKeys.length || nextPropsKeys.some(prop => {


### PR DESCRIPTION
This fixes what is mentioned in #2466.

Because of fixes introduced in #1578, FieldArray does not re-render when the `value` changes. However this causes the FieldArray to not render updates for swapping, insertion, or other operations on the `value`, which is undesired behaviour.