### PR TITLE
Fix value type issues in 'Field Normaizing Example' page

### DIFF
--- a/examples/normalizing/src/FieldNormalizingForm.js
+++ b/examples/normalizing/src/FieldNormalizingForm.js
@@ -5,9 +5,9 @@ import normalizePhone from './normalizePhone'
 const upper = value => value && value.toUpperCase()
 const lower = value => value && value.toLowerCase()
 const lessThan = otherField =>
-  (value, previousValue, allValues) => value < allValues[otherField] ? value : previousValue
+  (value, previousValue, allValues) => parseFloat(value) < parseFloat(allValues[otherField]) ? value : previousValue
 const greaterThan = otherField =>
-  (value, previousValue, allValues) => value > allValues[otherField] ? value : previousValue
+  (value, previousValue, allValues) => parseFloat(value) > parseFloat(allValues[otherField]) ? value : previousValue
 
 const FieldNormalizingForm = (props) => {
   const { handleSubmit, pristine, reset, submitting } = props
@@ -82,5 +82,5 @@ const FieldNormalizingForm = (props) => {
 
 export default reduxForm({
   form: 'normalizing', // a unique identifier for this form
-  initialValues: { min: 1, max: 10 }
+  initialValues: { min: '1', max: '10' }
 })(FieldNormalizingForm)


### PR DESCRIPTION
Here is the steps for represent this bug:

1. Open [http://redux-form.com/6.5.0/examples/normalizing/](http://redux-form.com/6.5.0/examples/normalizing/)
2. Increase Max, and it will show 11
3. Increase Min

Expect:
Show 2 for Min

Fact:
Still show 1 for Min

I just did some debug and find these:

1. The field with type="number" will return a string value. So in step 2, the form value would be 
```
{
  "min": 1,
  "max": "11"
}
```
2. The functions `lessThan` and `greaterThan` just compare the values without parsing number 
```
const lessThan = otherField =>
  (value, previousValue, allValues) => value < allValues[otherField] ? value : previousValue
const greaterThan = otherField =>
  (value, previousValue, allValues) => value > allValues[otherField] ? value : previousValue
```

Solution:

1. Fixed the `initialValues`
2. Add parsing number for the functions `lessThan` and `greaterThan`
