### PR TITLE
Fix for issue 2567

### DIFF
--- a/src/reduxForm.js
+++ b/src/reduxForm.js
@@ -238,7 +238,7 @@ const createReduxForm =
           }
 
           shouldComponentUpdate(nextProps) {
-            if (!config.pure) return true
+            if (!this.props.pure) return true
             return Object.keys(nextProps).some(prop => {
               // useful to debug rerenders
               // if (!plain.deepEqual(this.props[ prop ], nextProps[ prop ])) {


### PR DESCRIPTION
reduxForm.js ShouldComponetUpdate now uses this.props.pure instead of config.pure to decide whether to not update.

Fixes #2567.