### PR TITLE
Update asyncValidating PropType to match documentation

### DIFF
--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -8,7 +8,6 @@ const propTypes = {
     bool, 
     string
   ]).isRequired,                      // true if async validation is running, a string if a field triggered async validation
-  asyncValidating: bool.isRequired,   // true if async validation is running
   dirty: bool.isRequired,             // true if any values are different from initialValues
   error: any,                         // form-wide error from '_error' key in validation result
   form: string.isRequired,            // the name of the form

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -1,9 +1,12 @@
 import { PropTypes } from 'react'
-const { any, bool, func, shape } = PropTypes
+const { any, bool, func, shape, string, oneOfType } = PropTypes
 
 const propTypes = {
   // State:
-  asyncValidating: bool.isRequired,   // true if async validation is running
+  asyncValidating: oneOfType([
+    bool, 
+    string
+  ]).isRequired,                      // true if async validation is running, a string if a field triggered async validation
   dirty: bool.isRequired,             // true if any values are different from initialValues
   error: any,                         // form-wide error from '_error' key in validation result
   warning: any,                       // form-wide warning from '_warning' key in validation result


### PR DESCRIPTION
This is currently set to `bool` whereas it is a string if a field triggers async validation.

See
http://redux-form.com/6.5.0/docs/api/Props.md/#-asyncvalidating-string-boolean-

Current PropType violation:
![propType violation](https://www.dropbox.com/s/urj8orehj10goph/Screenshot%202017-02-14%2014.42.53.png?dl=1)
