### PR TITLE
Getting started clarification

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -28,7 +28,7 @@ const reducer = combineReducers(reducers)
 const store = createStore(reducer)
 ```
 
-*note that the key used to pass the redux-form reducer to `combineReducers` **must be named form***
+*note that the key used to pass the `redux-form` reducer to `combineReducers` must be named* **form**
 
 ### Step #2
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -28,7 +28,7 @@ const reducer = combineReducers(reducers)
 const store = createStore(reducer)
 ```
 
-*note that the key used to pass the `redux-form` reducer to `combineReducers` must be named* **form**
+*note that the key used to pass the `redux-form` reducer to `combineReducers` must be named* **`form`**
 
 ### Step #2
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -28,7 +28,7 @@ const reducer = combineReducers(reducers)
 const store = createStore(reducer)
 ```
 
-*note that, by default, the key used to pass the `redux-form` reducer to `combineReducers` should be named* **`form`**. *Although there is support for custom key names, see [`getFormState` config](http://redux-form.com/6.5.0/docs/api/ReduxForm.md/#-getformstate-function-optional-) for more details.*
+*Note that, by default, the key used to pass the `redux-form` reducer to `combineReducers` should be named* **`form`**. *Although there is support for custom key names, see [`getFormState` config](http://redux-form.com/6.5.0/docs/api/ReduxForm.md/#-getformstate-function-optional-) for more details.*
 
 ### Step #2
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -28,7 +28,7 @@ const reducer = combineReducers(reducers)
 const store = createStore(reducer)
 ```
 
-*note that the key used to pass the `redux-form` reducer to `combineReducers` must be named* **`form`**
+*note that, by default, the key used to pass the `redux-form` reducer to `combineReducers` should be named* **`form`**. *Although there is support for custom key names, see [`getFormState` config](http://redux-form.com/6.5.0/docs/api/ReduxForm.md/#-getformstate-function-optional-) for more details.*
 
 ### Step #2
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -28,6 +28,8 @@ const reducer = combineReducers(reducers)
 const store = createStore(reducer)
 ```
 
+*note that the key used to pass the redux-form reducer to `combineReducers` **must be named form***
+
 ### Step #2
 
 Decorate your form component with `reduxForm()`. This will provide your component with props that


### PR DESCRIPTION
This is a minor addition to the Getting Started docs that would have helped me immensely.  Searching on stack overflow reveals I'm not the only one who was confused by the fact that the key being passed to `combineReducers` **must be `form`**, and cannot be a custom name  (I had used `forms`!)

More details, and the answer that helped me solve my issue – http://stackoverflow.com/a/40923003/1084257

This tiny addition to the docs may help others avoid the same problem.