### PR TITLE
Added selector for getFormSyncWarnings.

### DIFF
--- a/docs/api/Selectors.md
+++ b/docs/api/Selectors.md
@@ -21,6 +21,7 @@ import {
   getFormInitialValues,
   getFormSyncErrors,
   getFormAsyncErrors,
+  getFormSyncWarnings,
   getFormSubmitErrors,
   getFormNames,
   isDirty,
@@ -38,6 +39,7 @@ MyComponent = connect(
     initialValues: getFormInitialValues('myForm')(state),
     syncErrors: getFormSyncErrors('myForm')(state),
     asyncErrors: getFormAsyncErrors('myForm')(state),
+    syncWarnings: getFormSyncWarnings('myForm')(state),
     submitErrors: getFormSubmitErrors('myForm')(state),
     names: getFormNames('myForm')(state),
     dirty: isDirty('myForm')(state),
@@ -68,6 +70,10 @@ MyComponent = connect(
 ### `getFormAsyncErrors(formName:String)` returns `(state) => formAsyncErrors:Object`
 
 > Returns the form asynchronous validation errors.
+
+### `getFormSyncWarnings(formName:String)` returns `(state) => formSyncWarnings:Object`
+
+> Returns the form synchronous warnings.
 
 ### `getFormSubmitErrors(formName:String)` returns `(state) => formSubmitErrors:Object`
 

--- a/src/__tests__/immutable.spec.js
+++ b/src/__tests__/immutable.spec.js
@@ -28,6 +28,7 @@ import {
   getFormInitialValues,
   getFormSyncErrors,
   getFormAsyncErrors,
+  getFormSyncWarnings,
   getFormSubmitErrors,
   initialize,
   isDirty,
@@ -134,6 +135,9 @@ describe('immutable', () => {
   })
   it('should export getFormAsyncErrors', () => {
     expect(getFormAsyncErrors).toExist().toBeA('function')
+  })
+  it('should export getFormSyncWarnings', () => {
+    expect(getFormSyncWarnings).toExist().toBeA('function')
   })
   it('should export getFormSubmitErrors', () => {
     expect(getFormSubmitErrors).toExist().toBeA('function')

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -29,6 +29,7 @@ import {
   getFormInitialValues,
   getFormSyncErrors,
   getFormAsyncErrors,
+  getFormSyncWarnings,
   getFormSubmitErrors,
   initialize,
   isDirty,
@@ -138,6 +139,9 @@ describe('index', () => {
   })
   it('should export getFormAsyncErrors', () => {
     expect(getFormAsyncErrors).toExist().toBeA('function')
+  })
+  it('should export getFormSyncWarnings', () => {
+    expect(getFormSyncWarnings).toExist().toBeA('function')
   })
   it('should export getFormSubmitErrors', () => {
     expect(getFormSubmitErrors).toExist().toBeA('function')

--- a/src/createAll.js
+++ b/src/createAll.js
@@ -10,6 +10,7 @@ import createGetFormValues from './selectors/getFormValues'
 import createGetFormInitialValues from './selectors/getFormInitialValues'
 import createGetFormSyncErrors from './selectors/getFormSyncErrors'
 import createGetFormAsyncErrors from './selectors/getFormAsyncErrors'
+import createGetFormSyncWarnings from './selectors/getFormSyncWarnings'
 import createGetFormSubmitErrors from './selectors/getFormSubmitErrors'
 import createIsDirty from './selectors/isDirty'
 import createIsInvalid from './selectors/isInvalid'
@@ -40,6 +41,7 @@ const createAll = structure => ({
   getFormInitialValues: createGetFormInitialValues(structure),
   getFormSyncErrors: createGetFormSyncErrors(structure),
   getFormAsyncErrors: createGetFormAsyncErrors(structure),
+  getFormSyncWarnings : createGetFormSyncWarnings(structure),
   getFormSubmitErrors: createGetFormSubmitErrors(structure),
   isDirty: createIsDirty(structure),
   isInvalid: createIsInvalid(structure),

--- a/src/immutable.js
+++ b/src/immutable.js
@@ -29,6 +29,7 @@ export const {
   getFormInitialValues,
   getFormSyncErrors,
   getFormAsyncErrors,
+  getFormSyncWarnings,
   getFormSubmitErrors,
   initialize,
   isDirty,

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ export const {
   getFormInitialValues,
   getFormSyncErrors,
   getFormAsyncErrors,
+  getFormSyncWarnings,
   getFormSubmitErrors,
   initialize,
   isDirty,

--- a/src/selectors/__tests__/getFormSyncWarnings.spec.js
+++ b/src/selectors/__tests__/getFormSyncWarnings.spec.js
@@ -1,0 +1,61 @@
+import createGetFormSyncErrors from '../getFormSyncWarnings'
+import plain from '../../structure/plain'
+import plainExpectations from '../../structure/plain/expectations'
+import immutable from '../../structure/immutable'
+import immutableExpectations from '../../structure/immutable/expectations'
+import addExpectations from '../../__tests__/addExpectations'
+
+const describeGetFormSyncErrors = (name, structure, expect) => {
+  const getFormSyncWarnings = createGetFormSyncErrors(structure)
+
+  const { fromJS, getIn } = structure
+
+  describe(name, () => {
+    it('should return a function', () => {
+      expect(createGetFormSyncErrors('foo')).toBeA('function')
+    })
+
+    it('should get the form values from state', () => {
+      expect(getFormSyncWarnings('foo')(fromJS({
+        form: {
+          foo: {
+            syncWarnings: {
+              dog: 'Snoopy',
+              cat: 'Garfield'
+            }
+          }
+        }
+      }))).toEqualMap({
+        dog: 'Snoopy',
+        cat: 'Garfield'
+      })
+    })
+
+    it('should return undefined if there are no syncWarnings', () => {
+      expect(getFormSyncWarnings('foo')(fromJS({
+        form: {
+          foo: {}
+        }
+      }))).toEqual(undefined)
+    })
+
+    it('should use getFormState if provided', () => {
+      expect(getFormSyncWarnings('foo', state => getIn(state, 'someOtherSlice'))(fromJS({
+        someOtherSlice: {
+          foo: {
+            syncWarnings: {
+              dog: 'Snoopy',
+              cat: 'Garfield'
+            }
+          }
+        }
+      }))).toEqualMap({
+        dog: 'Snoopy',
+        cat: 'Garfield'
+      })
+    })
+  })
+}
+
+describeGetFormSyncErrors('getFormSyncWarnings.plain', plain, addExpectations(plainExpectations))
+describeGetFormSyncErrors('getFormSyncWarnings.immutable', immutable, addExpectations(immutableExpectations))

--- a/src/selectors/getFormSyncWarnings.js
+++ b/src/selectors/getFormSyncWarnings.js
@@ -1,0 +1,5 @@
+const createGetFormSyncWarnings = ({ getIn }) =>
+  (form, getFormState = state => getIn(state, 'form')) =>
+    state => getIn(getFormState(state), `${form}.syncWarnings`)
+
+export default createGetFormSyncWarnings


### PR DESCRIPTION
Added a new selector to the list: `getFormSyncWarnings` as suggested [here](https://github.com/erikras/redux-form/issues/2176). Implementation is the same as `getFormSyncErrors`.