### PR TITLE
(v5) Changes to members of top-level array field should change instance identity

### DIFF
--- a/src/__tests__/readField.spec.js
+++ b/src/__tests__/readField.spec.js
@@ -570,7 +570,7 @@ describe('readField', () => {
     const afterArray = fields.foo;
     const after1 = fields.foo[0];
     const after2 = fields.foo[1];
-    expect(beforeArray).toBe(afterArray); // array should be same instance
+    expect(beforeArray).toNotBe(afterArray); // array should be different
     expect(before1).toNotBe(after1);      // field instance should be different
     expect(before2).toNotBe(after2);      // field instance should be different
   });

--- a/src/readField.js
+++ b/src/readField.js
@@ -69,7 +69,7 @@ const readField = (state, fieldName, pathToHere = '', fields, syncErrors, asyncV
       fields[key] = fields[key] ? [...fields[key]] : [];
       addMethods(fields[key]);
     }
-    const fieldArray = fields[key];
+    let fieldArray = fields[key];
     let changed = false;
     stateArray.forEach((fieldState, index) => {
       if (rest && !fieldArray[index]) {
@@ -96,7 +96,11 @@ const readField = (state, fieldName, pathToHere = '', fields, syncErrors, asyncV
       // remove extra items that aren't in state array
       fieldArray.splice(stateArray.length, fieldArray.length - stateArray.length);
     }
-    return changed ? addMethods([...fieldArray]) : fieldArray;
+    if (changed) {
+      fieldArray = addMethods([...fieldArray]);
+    }
+    fields[key] = fieldArray;
+    return fieldArray;
   }
   if (dotIndex > 0) {
     // subobject field


### PR DESCRIPTION
React components that take just the array field still need to re-render.
Existing tests covered this case, but explicitly asserted the incorrect
behavior.

Specifically "top-level" array fields, because array fields below the
top level change their identity based on the return value rather than
modifications to the fields object.

Copied the control flow from the object-field path, which Does The Right
Thing.