### PR TITLE
destroy action creator documentation was wrong

### DIFF
--- a/docs/api/ActionCreators.md
+++ b/docs/api/ActionCreators.md
@@ -61,9 +61,9 @@ insert, so the item already at the `to` position will be bumped to a higher inde
 
 > Saves the value to the field.
 
-### `destroy(form:String)`
+### `destroy(...forms:String)`
 
-> Destroys the form, removing all its state.
+> Destroys the forms, removing all of their state.
 
 ### `focus(form:String, field:String)`
 


### PR DESCRIPTION
the `destroy` action creator is actually variadic so I updated the documentation.

This caught me off guard when updating from `6.2.0` to `6.5.0` because one of my reducers using this action type.