### PR TITLE
Fix initial submitError state for FieldArrays

### DIFF
--- a/src/__tests__/reducer.arraySplice.spec.js
+++ b/src/__tests__/reducer.arraySplice.spec.js
@@ -13,6 +13,63 @@ const describeArraySplice = (reducer, expect, { fromJS }) => () => {
       })
   })
 
+  it('should work with existing form errors', () => {
+    const state = reducer(fromJS({
+      foo: {
+        values: {
+          myField: {
+            subField: [ 'a' ]
+          }
+        },
+        fields: {
+          myField: {
+            subField: [
+              { touched: true }
+            ]
+          }
+        },
+        submitErrors: {
+          myField: {
+            subField: [ 'invalid value' ]
+          }
+        },
+        asyncErrors: {
+          myField: {
+            subField: [ 'invalid format' ]
+          }
+        }
+      }
+    }), arraySplice('foo', 'myField.subField', 0, 0, 'myValue'))
+    expect(state)
+      .toEqualMap({
+        foo: {
+          values: {
+            myField: {
+              subField: [ 'myValue', 'a' ]
+            }
+          },
+          fields: {
+            myField: {
+              subField: [
+                { },
+                { touched: true }
+              ]
+            }
+          },
+          submitErrors: {
+            myField: {
+              subField: [ undefined, 'invalid value' ]
+            }
+          },
+          asyncErrors: {
+            myField: {
+              subField: [ undefined, 'invalid format' ]
+            }
+          }
+        }
+      })
+  })
+
   it('should insert at beginning', () => {
     const state = reducer(fromJS({
       foo: {

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -59,8 +59,8 @@ const createReducer = structure => {
     const nonValuesValue = value != null ? empty : undefined
     result = doSplice(result, 'values', field, index, removeNum, value, true)
     result = doSplice(result, 'fields', field, index, removeNum, nonValuesValue)
-    result = doSplice(result, 'submitErrors', field, index, removeNum, nonValuesValue)
-    result = doSplice(result, 'asyncErrors', field, index, removeNum, nonValuesValue)
+    result = doSplice(result, 'submitErrors', field, index, removeNum, undefined)
+    result = doSplice(result, 'asyncErrors', field, index, removeNum, undefined)
     return result
   }
 


### PR DESCRIPTION
When adding a new field to a `FieldArray` (which already has a field with a `submitError`), the `submitError` for the new field is initialised with `empty`.

This breaks form validation, as the new field has not been submitted yet and therefore should not have an initial `submitError`.

Therefore changing the initial value for `submitError` and `asyncError` of new fields to `undefined`.

Issue: https://github.com/erikras/redux-form/issues/2667