### PR TITLE
Fix #2718 (Incorrect way of accessing syncErrors, syncWarnings in ConnectedField, ConnectedFieldArray, ConnectedFields for redux-form/immutable)

### DIFF
--- a/src/ConnectedField.js
+++ b/src/ConnectedField.js
@@ -1,7 +1,6 @@
 import { Component, PropTypes, createElement } from 'react'
 import { connect } from 'react-redux'
 import createFieldProps from './createFieldProps'
-import plain from './structure/plain'
 import onChangeValue from './events/onChangeValue'
 import { dataKey } from './util/eventConsts'
 
@@ -12,14 +11,14 @@ const propsToNotUpdateFor = [
 const createConnectedField = ({ deepEqual, getIn, toJS }) => {
 
   const getSyncError = (syncErrors, name) => {
-    const error = plain.getIn(syncErrors, name)
+    const error = getIn(syncErrors, name)
     // Because the error for this field might not be at a level in the error structure where
     // it can be set directly, it might need to be unwrapped from the _error property
     return error && error._error ? error._error : error
   }
 
   const getSyncWarning = (syncWarnings, name) => {
-    const warning = plain.getIn(syncWarnings, name)
+    const warning = getIn(syncWarnings, name)
     // Because the warning for this field might not be at a level in the warning structure where
     // it can be set directly, it might need to be unwrapped from the _warning property
     return warning && warning._warning ? warning._warning : warning

--- a/src/ConnectedFieldArray.js
+++ b/src/ConnectedFieldArray.js
@@ -3,7 +3,6 @@ import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
 import createFieldArrayProps from './createFieldArrayProps'
 import { mapValues } from 'lodash'
-import plain from './structure/plain'
 
 const propsToNotUpdateFor = [
   '_reduxForm',
@@ -16,14 +15,14 @@ const createConnectedFieldArray = ({ deepEqual, getIn, size }) => {
     // For an array, the error can _ONLY_ be under _error.
     // This is why this getSyncError is not the same as the
     // one in Field.
-    return plain.getIn(syncErrors, `${name}._error`)
+    return getIn(syncErrors, `${name}._error`)
   }
 
   const getSyncWarning = (syncWarnings, name) => {
     // For an array, the warning can _ONLY_ be under _warning.
     // This is why this getSyncError is not the same as the
     // one in Field.
-    return plain.getIn(syncWarnings, `${name}._warning`)
+    return getIn(syncWarnings, `${name}._warning`)
   }
 
   class ConnectedFieldArray extends Component {

--- a/src/ConnectedFields.js
+++ b/src/ConnectedFields.js
@@ -11,14 +11,14 @@ const propsToNotUpdateFor = [
 const createConnectedFields = ({ deepEqual, getIn, toJS, size }) => {
 
   const getSyncError = (syncErrors, name) => {
-    const error = plain.getIn(syncErrors, name)
+    const error = getIn(syncErrors, name)
     // Because the error for this field might not be at a level in the error structure where
     // it can be set directly, it might need to be unwrapped from the _error property
     return error && error._error ? error._error : error
   }
 
   const getSyncWarning = (syncWarnings, name) => {
-    const warning = plain.getIn(syncWarnings, name)
+    const warning = getIn(syncWarnings, name)
     // Because the warning for this field might not be at a level in the warning structure where
     // it can be set directly, it might need to be unwrapped from the _warning property
     return warning && warning._warning ? warning._warning : warning
@@ -70,7 +70,7 @@ const createConnectedFields = ({ deepEqual, getIn, toJS, size }) => {
         }, {})
       }
     }
-    
+
     shouldComponentUpdate(nextProps) {
       const nextPropsKeys = Object.keys(nextProps)
       const thisPropsKeys = Object.keys(this.props)
@@ -159,7 +159,7 @@ const createConnectedFields = ({ deepEqual, getIn, toJS, size }) => {
       return {
         _fields: names.reduce((accumulator, name) => {
           const initialState = getIn(formState, `initial.${name}`)
-          const initial = initialState !== undefined ? initialState : (initialValues && getIn(initialValues, name)) 
+          const initial = initialState !== undefined ? initialState : (initialValues && getIn(initialValues, name))
           const value = getIn(formState, `values.${name}`)
           const syncError = getSyncError(getIn(formState, 'syncErrors'), name)
           const syncWarning = getSyncWarning(getIn(formState, 'syncWarnings'), name)


### PR DESCRIPTION
Use `getIn` instead of `plain.getIn` in case we're using `redux-form/immutable`.

Ref. https://github.com/erikras/redux-form/issues/2718