### PR TITLE
Change the form-level onChange to accept the same args as onSubmit

### DIFF
--- a/docs/api/ReduxForm.md
+++ b/docs/api/ReduxForm.md
@@ -86,6 +86,20 @@ The values should be in the form `{ field1: 'value1', field2: 'value2' }`.
 > A callback function that will be called with all the form values any time any of the form
 values change.
 
+> `onChange` will be called with the following parameters:
+
+> ##### `values : Object`
+
+> The changed field values in the form of `{ field1: 'value1', field2: 'value2' }`.
+
+> ##### `dispatch : Function`
+
+> The Redux `dispatch` function.
+
+> ##### `props : Object`
+
+> The props passed into your decorated component.
+
 #### `onSubmit : Function` [optional]
 
 > The function to call with the form data when the `handleSubmit()` is fired from within the

--- a/src/__tests__/Form.spec.js
+++ b/src/__tests__/Form.spec.js
@@ -109,6 +109,8 @@ const describeForm = (name, structure, combineReducers, expect) => {
       expect(onSubmit).toHaveBeenCalled()
       expect(onSubmit.calls.length).toBe(1)
       expect(onSubmit.calls[0].arguments[0]).toEqualMap({ foo: 42 })
+      expect(onSubmit.calls[0].arguments[1]).toBeA('function')
+      expect(onSubmit.calls[0].arguments[2].values).toEqualMap({ foo: 42 })
     })
 
     it('should call the onSubmit given to <Form> when SUBMIT action is dispatched', () => {
@@ -143,6 +145,8 @@ const describeForm = (name, structure, combineReducers, expect) => {
       expect(onSubmit).toHaveBeenCalled()
       expect(onSubmit.calls.length).toBe(1)
       expect(onSubmit.calls[0].arguments[0]).toEqualMap({ foo: 42 })
+      expect(onSubmit.calls[0].arguments[1]).toBeA('function')
+      expect(onSubmit.calls[0].arguments[2].values).toEqualMap({ foo: 42 })
     })
 
     it('should properly handle submission errors', () => {
@@ -184,6 +188,8 @@ const describeForm = (name, structure, combineReducers, expect) => {
       expect(onSubmit).toHaveBeenCalled()
       expect(onSubmit.calls.length).toBe(1)
       expect(onSubmit.calls[0].arguments[0]).toEqualMap({ foo: 42 })
+      expect(onSubmit.calls[0].arguments[1]).toBeA('function')
+      expect(onSubmit.calls[0].arguments[2].values).toEqualMap({ foo: 42 })
 
       expect(formRender.calls.length).toBe(3)
       expect(formRender.calls[2].arguments[0].error).toBe('Invalid')

--- a/src/__tests__/reduxForm.spec.js
+++ b/src/__tests__/reduxForm.spec.js
@@ -2903,6 +2903,8 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(onChange.calls.length).toBe(1)
 
       expect(onChange.calls[0].arguments[0]).toEqualMap({ foo: 'dog' })
+      expect(onChange.calls[0].arguments[1]).toBeA('function')
+      expect(onChange.calls[0].arguments[2].values).toEqualMap({ foo: 'dog' })
 
       changeBar('cat')
 
@@ -2911,19 +2913,25 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
         foo: 'dog',
         bar: 'cat'
       })
+      expect(onChange.calls[1].arguments[1]).toBeA('function')
+      expect(onChange.calls[1].arguments[2].values).toEqualMap({
+        foo: 'dog',
+        bar: 'cat'
+      })
 
       changeFoo('dog')
 
       // onChange NOT called since value did not change
       expect(onChange.calls.length).toBe(2)
-      expect(onChange.calls[1].arguments[0]).toEqualMap({
-        foo: 'dog',
-        bar: 'cat'
-      })
 
       changeFoo('doggy')
       expect(onChange.calls.length).toBe(3)
       expect(onChange.calls[2].arguments[0]).toEqualMap({
+        foo: 'doggy',
+        bar: 'cat'
+      })
+      expect(onChange.calls[2].arguments[1]).toBeA('function')
+      expect(onChange.calls[2].arguments[2].values).toEqualMap({
         foo: 'doggy',
         bar: 'cat'
       })
@@ -3227,6 +3235,8 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(onSubmit).toHaveBeenCalled()
       expect(onSubmit.calls.length).toBe(1)
       expect(onSubmit.calls[ 0 ].arguments[ 0 ]).toEqualMap({})
+      expect(onSubmit.calls[ 0 ].arguments[ 1 ]).toBeA('function')
+      expect(onSubmit.calls[ 0 ].arguments[ 2 ].values).toEqualMap({})
       expect(renderInput.calls.length).toBe(2)  // touched by submit
 
       // autofill field
@@ -3242,6 +3252,8 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       TestUtils.Simulate.submit(form)
       expect(onSubmit.calls.length).toBe(2)
       expect(onSubmit.calls[ 1 ].arguments[ 0 ]).toEqualMap({ myField: 'autofilled value' })
+      expect(onSubmit.calls[ 1 ].arguments[ 1 ]).toBeA('function')
+      expect(onSubmit.calls[ 1 ].arguments[ 2 ].values).toEqualMap({ myField: 'autofilled value' })
 
       // user edits field
       renderInput.calls[ 1 ].arguments[ 0 ].input.onChange('user value')
@@ -3256,6 +3268,8 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       TestUtils.Simulate.submit(form)
       expect(onSubmit.calls.length).toBe(3)
       expect(onSubmit.calls[ 2 ].arguments[ 0 ]).toEqualMap({ myField: 'user value' })
+      expect(onSubmit.calls[ 2 ].arguments[ 1 ]).toBeA('function')
+      expect(onSubmit.calls[ 2 ].arguments[ 2 ].values).toEqualMap({ myField: 'user value' })
     })
 
     it('should not reinitialize values on remount if destroyOnMount is false', () => {
@@ -3697,6 +3711,8 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(onSubmit).toHaveBeenCalled()
       expect(onSubmit.calls.length).toBe(1)
       expect(onSubmit.calls[ 0 ].arguments[ 0 ]).toEqualMap({ foo: 'hello' })
+      expect(onSubmit.calls[ 0 ].arguments[ 1 ]).toBeA('function')
+      expect(onSubmit.calls[ 0 ].arguments[ 2 ].values).toEqualMap({ foo: 'hello' })
     })
 
     it('submits (via prop) when the SUBMIT action is dispatched', () => {
@@ -3759,6 +3775,8 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(onSubmit).toHaveBeenCalled()
       expect(onSubmit.calls.length).toBe(1)
       expect(onSubmit.calls[ 0 ].arguments[ 0 ]).toEqualMap({ foo: 'hello' })
+      expect(onSubmit.calls[ 0 ].arguments[ 1 ]).toBeA('function')
+      expect(onSubmit.calls[ 0 ].arguments[ 2 ].values).toEqualMap({ foo: 'hello' })
     })
   })
 }

--- a/src/reduxForm.js
+++ b/src/reduxForm.js
@@ -237,7 +237,7 @@ const createReduxForm =
             this.submitIfNeeded(nextProps)
             if (nextProps.onChange) {
               if (!deepEqual(nextProps.values, this.props.values)) {
-                nextProps.onChange(nextProps.values)
+                nextProps.onChange(nextProps.values, nextProps.dispatch, nextProps)
               }
             }
           }


### PR DESCRIPTION
This enables common use cases such as submitting the form on change, and
specifically re-using the same action for submit and change.