### PR TITLE
Fix: hasError used plain.getIn(syncErrors, key) for Immutable instead of getIn(syncErrors, key)

### DIFF
--- a/src/hasError.js
+++ b/src/hasError.js
@@ -1,5 +1,3 @@
-import plainGetIn from './structure/plain/getIn'
-
 const getErrorKeys = (name, type) => {
   switch (type) {
     case 'Field':
@@ -20,7 +18,7 @@ const createHasError = ({ getIn }) => {
     const name = getIn(field, 'name')
     const type = getIn(field, 'type')
     return getErrorKeys(name, type).some(key =>
-      plainGetIn(syncErrors, key) ||
+      getIn(syncErrors, key) ||
       getIn(asyncErrors, key) ||
       getIn(submitErrors, key))
   }


### PR DESCRIPTION
Because of using `plain.getIn`, the syncErrors are not respected during the form submit operation and form is submitted even if it is not valid.

Can we release it ASAP?