### PR TITLE
[onBlur] Breaking: do not emit value in onBlur

### DIFF
--- a/src/ConnectedField.js
+++ b/src/ConnectedField.js
@@ -95,15 +95,7 @@ const createConnectedField = ({ deepEqual, getIn, toJS }) => {
     }
 
     handleBlur(event) {
-      const { name, dispatch, parse, normalize, onBlur, _reduxForm, _value, value: previousValue } = this.props
-      let newValue = onChangeValue(event, { name, parse, normalize })
-
-      // for checkbox and radio, if the value property of checkbox or radio equals
-      // the value passed by blur event, then fire blur action with previousValue.
-      if (newValue === _value && _value !== undefined) {
-        newValue = previousValue
-      }
-
+      const { name, dispatch, onBlur, _reduxForm, _value, value: previousValue } = this.props
       let defaultPrevented = false
       if (onBlur) {
         onBlur({
@@ -112,16 +104,16 @@ const createConnectedField = ({ deepEqual, getIn, toJS }) => {
             defaultPrevented = true
             return event.preventDefault()
           }
-        }, newValue, previousValue)
+        })
       }
 
       if (!defaultPrevented) {
         // dispatch blur action
-        dispatch(_reduxForm.blur(name, newValue))
+        dispatch(_reduxForm.blur(name))
 
         // call post-blur callback
         if (_reduxForm.asyncValidate) {
-          _reduxForm.asyncValidate(name, newValue)
+          _reduxForm.asyncValidate(name, previousValue)
         }
       }
     }

--- a/src/__tests__/Field.spec.js
+++ b/src/__tests__/Field.spec.js
@@ -861,61 +861,6 @@ const describeField = (name, structure, combineReducers, expect) => {
       expect(renderUsername.calls[ 1 ].arguments[ 0 ].input.value).toBe('erikras')
     })
 
-    it('should call normalize function on blur', () => {
-      const store = makeStore({
-        testForm: {
-          values: {
-            title: 'Redux Form',
-            author: 'Erik Rasmussen',
-            username: 'oldusername'
-          }
-        }
-      })
-      const renderUsername = createSpy(props => <input {...props.input}/>).andCallThrough()
-      const normalize = createSpy(value => value.toLowerCase()).andCallThrough()
-      class Form extends Component {
-        render() {
-          return (
-            <div>
-              <Field name="title" component="input"/>
-              <Field name="author" component="input"/>
-              <Field name="username" component={renderUsername} normalize={normalize}/>
-            </div>
-          )
-        }
-      }
-      const TestForm = reduxForm({ form: 'testForm' })(Form)
-      TestUtils.renderIntoDocument(
-        <Provider store={store}>
-          <TestForm/>
-        </Provider>
-      )
-
-      expect(normalize).toNotHaveBeenCalled()
-
-      expect(renderUsername.calls[ 0 ].arguments[ 0 ].input.value).toBe('oldusername')
-      renderUsername.calls[ 0 ].arguments[ 0 ].input.onBlur('ERIKRAS')
-
-      expect(normalize)
-        .toHaveBeenCalled()
-        .toHaveBeenCalledWith(
-          'ERIKRAS',
-          'oldusername',
-          fromJS({
-            title: 'Redux Form',
-            author: 'Erik Rasmussen',
-            username: 'ERIKRAS'
-          }), fromJS({
-            title: 'Redux Form',
-            author: 'Erik Rasmussen',
-            username: 'oldusername'
-          })
-        )
-      expect(normalize.calls.length).toBe(1)
-
-      expect(renderUsername.calls[ 1 ].arguments[ 0 ].input.value).toBe('erikras')
-    })
-
     it('should call asyncValidate function on blur', () => {
       const store = makeStore({
         testForm: {
@@ -946,7 +891,7 @@ const describeField = (name, structure, combineReducers, expect) => {
         </Provider>
       )
 
-      renderUsername.calls[ 0 ].arguments[ 0 ].input.onBlur('ERIKRAS')
+      renderUsername.calls[ 0 ].arguments[ 0 ].input.onBlur()
 
       expect(asyncValidate).toHaveBeenCalled()
     })
@@ -979,45 +924,6 @@ const describeField = (name, structure, combineReducers, expect) => {
       renderTitle.calls[ 0 ].arguments[ 0 ].input.onFocus()
       expect(renderTitle.calls[ 1 ].arguments[ 0 ].meta.visited).toBe(true)
     })
-
-    it('should not change the value of a radio when blur', () => {
-      const store = makeStore({
-        testForm: {
-          values: {
-            title: 'Redux Form',
-            author: 'Erik Rasmussen',
-            sex: 'male'
-          }
-        }
-      })
-      const renderSex = createSpy(props => <input {...props.input}/>).andCallThrough()
-      class Form extends Component {
-        render() {
-          return (
-            <div>
-              <Field name="title" component="input"/>
-              <Field name="author" component="input"/>
-              <Field name="sex" value="female" type="radio" component={renderSex} />
-              <Field name="sex" value="male" type="radio" component={renderSex} />
-            </div>
-          )
-        }
-      }
-      const TestForm = reduxForm({ form: 'testForm' })(Form)
-      TestUtils.renderIntoDocument(
-        <Provider store={store}>
-          <TestForm/>
-        </Provider>
-      )
-
-      expect(renderSex.calls[ 0 ].arguments[ 0 ].input.checked).toBe(false)
-      expect(renderSex.calls[ 1 ].arguments[ 0 ].input.checked).toBe(true)
-      renderSex.calls[ 0 ].arguments[ 0 ].input.onBlur('female')
-
-      expect(renderSex.calls[ 2 ].arguments[ 0 ].input.checked).toBe(false)
-      expect(renderSex.calls[ 3 ].arguments[ 0 ].input.checked).toBe(true)
-    })
-
 
     it('should call handle on drag start with value', () => {
       const store = makeStore({
@@ -1182,47 +1088,6 @@ const describeField = (name, structure, combineReducers, expect) => {
       expect(input.calls[ 0 ].arguments[ 0 ].input.value).toBe('redux form')
 
       input.calls[ 0 ].arguments[ 0 ].input.onChange('REDUX FORM ROCKS')
-
-      expect(parse).toHaveBeenCalled()
-      expect(parse.calls.length).toBe(1)
-      expect(parse.calls[ 0 ].arguments).toEqual([ 'REDUX FORM ROCKS', 'name' ])
-
-      expect(input.calls.length).toBe(2)
-      expect(input.calls[ 1 ].arguments[ 0 ].input.value).toBe('redux form rocks')
-    })
-
-    it('should call parse function on blur', () => {
-      const store = makeStore({
-        testForm: {
-          values: {
-            name: 'redux form'
-          }
-        }
-      })
-      const input = createSpy(props => <input {...props.input}/>).andCallThrough()
-      const parse = createSpy(value => value.toLowerCase()).andCallThrough()
-      class Form extends Component {
-        render() {
-          return (
-            <div>
-              <Field name="name" component={input} parse={parse}/>
-            </div>
-          )
-        }
-      }
-      const TestForm = reduxForm({ form: 'testForm' })(Form)
-      TestUtils.renderIntoDocument(
-        <Provider store={store}>
-          <TestForm/>
-        </Provider>
-      )
-
-      expect(parse).toNotHaveBeenCalled()
-
-      expect(input.calls.length).toBe(1)
-      expect(input.calls[ 0 ].arguments[ 0 ].input.value).toBe('redux form')
-
-      input.calls[ 0 ].arguments[ 0 ].input.onBlur('REDUX FORM ROCKS')
 
       expect(parse).toHaveBeenCalled()
       expect(parse.calls.length).toBe(1)
@@ -1756,7 +1621,6 @@ const describeField = (name, structure, combineReducers, expect) => {
       )
 
       const input = TestUtils.findRenderedDOMComponentWithTag(dom, 'input')
-      input.value = 'bar'
 
       expect(callback).toNotHaveBeenCalled()
 
@@ -1770,12 +1634,6 @@ const describeField = (name, structure, combineReducers, expect) => {
       expect(callback).toHaveBeenCalled()
       expect(callback.calls.length).toBe(1)
       expect(callback.calls[ 0 ].arguments[ 0 ]).toExist()  // event
-      expect(callback.calls[ 0 ].arguments[ 1 ]).toBe('bar')
-      expect(callback.calls[ 0 ].arguments[ 2 ]).toBe(undefined)
-
-      // value changed
-      expect(renderInput.calls.length).toBe(2)
-      expect(renderInput.calls[ 1 ].arguments[ 0 ].input.value).toBe('bar')
     })
 
     it('should allow onBlur callback to prevent blur', () => {
@@ -1797,7 +1655,6 @@ const describeField = (name, structure, combineReducers, expect) => {
       )
 
       const input = TestUtils.findRenderedDOMComponentWithTag(dom, 'input')
-      input.value = 'bar'
 
       expect(callback).toNotHaveBeenCalled()
 
@@ -1811,12 +1668,6 @@ const describeField = (name, structure, combineReducers, expect) => {
       expect(callback).toHaveBeenCalled()
       expect(callback.calls.length).toBe(1)
       expect(callback.calls[ 0 ].arguments[ 0 ]).toExist()
-      expect(callback.calls[ 0 ].arguments[ 1 ]).toBe('bar')
-      expect(callback.calls[ 0 ].arguments[ 2 ]).toBe(undefined)
-
-      // value NOT changed
-      expect(renderInput.calls.length).toBe(1)
-      expect(renderInput.calls[ 0 ].arguments[ 0 ].input.value).toBe('')
     })
 
     it('should allow onFocus callback', () => {

--- a/src/__tests__/Fields.spec.js
+++ b/src/__tests__/Fields.spec.js
@@ -750,7 +750,7 @@ const describeFields = (name, structure, combineReducers, expect) => {
           testForm: {
             registeredFields: {
               'foo.foo': { name: 'foo.foo', type: 'Field', count: 1 },
-              'foo.bar': { name: 'foo.bar', type: 'Field', count: 1 }              
+              'foo.bar': { name: 'foo.bar', type: 'Field', count: 1 }
             }
           }
         }
@@ -984,47 +984,6 @@ const describeFields = (name, structure, combineReducers, expect) => {
       expect(input.calls[ 0 ].arguments[ 0 ].name.input.value).toBe('redux form')
 
       input.calls[ 0 ].arguments[ 0 ].name.input.onChange('REDUX FORM ROCKS')
-
-      expect(parse).toHaveBeenCalled()
-      expect(parse.calls.length).toBe(1)
-      expect(parse.calls[ 0 ].arguments).toEqual([ 'REDUX FORM ROCKS', 'name' ])
-
-      expect(input.calls.length).toBe(2)
-      expect(input.calls[ 1 ].arguments[ 0 ].name.input.value).toBe('redux form rocks')
-    })
-
-    it('should call parse function on blur', () => {
-      const store = makeStore({
-        testForm: {
-          values: {
-            name: 'redux form'
-          }
-        }
-      })
-      const input = createSpy(props => <input {...props.input}/>).andCallThrough()
-      const parse = createSpy(value => value.toLowerCase()).andCallThrough()
-      class Form extends Component {
-        render() {
-          return (
-            <div>
-              <Fields names={[ 'name' ]} component={input} parse={parse}/>
-            </div>
-          )
-        }
-      }
-      const TestForm = reduxForm({ form: 'testForm' })(Form)
-      TestUtils.renderIntoDocument(
-        <Provider store={store}>
-          <TestForm/>
-        </Provider>
-      )
-
-      expect(parse).toNotHaveBeenCalled()
-
-      expect(input.calls.length).toBe(1)
-      expect(input.calls[ 0 ].arguments[ 0 ].name.input.value).toBe('redux form')
-
-      input.calls[ 0 ].arguments[ 0 ].name.input.onBlur('REDUX FORM ROCKS')
 
       expect(parse).toHaveBeenCalled()
       expect(parse.calls.length).toBe(1)
@@ -1388,7 +1347,7 @@ const describeFields = (name, structure, combineReducers, expect) => {
         constructor(props) {
           super(props)
           this.state = { names: [ 'foo', 'bar', 'deep.dive', 'array[0]' ] }
-          this.changeNames = this.changeNames.bind(this) 
+          this.changeNames = this.changeNames.bind(this)
         }
         changeNames() {
           this.setState({ names: [ 'fighter', 'fly.high', 'array[1]' ] })
@@ -1502,12 +1461,12 @@ const describeFields = (name, structure, combineReducers, expect) => {
       expect(renderFields.calls[2].arguments[0].foo.input.value).toBe('erikras')
 
       // blur foo
-      renderFields.calls[2].arguments[0].foo.input.onBlur('@erikras')
+      renderFields.calls[2].arguments[0].foo.input.onBlur()
 
       // foo is blurred
       expect(renderFields.calls.length).toBe(4)
       expect(renderFields.calls[3].arguments[0].foo.meta.active).toBe(false)
-      expect(renderFields.calls[3].arguments[0].foo.input.value).toBe('@erikras')
+      expect(renderFields.calls[3].arguments[0].foo.input.value).toBe('erikras')
 
       // swap out fields
       TestUtils.Simulate.click(button)
@@ -1537,12 +1496,12 @@ const describeFields = (name, structure, combineReducers, expect) => {
       expect(renderFields.calls[6].arguments[0].fighter.input.value).toBe('reduxForm')
 
       // blur fighter
-      renderFields.calls[6].arguments[0].fighter.input.onBlur('@reduxForm')
+      renderFields.calls[6].arguments[0].fighter.input.onBlur()
 
       // fighter is blurred
       expect(renderFields.calls.length).toBe(8)
       expect(renderFields.calls[7].arguments[0].fighter.meta.active).toBe(false)
-      expect(renderFields.calls[7].arguments[0].fighter.input.value).toBe('@reduxForm')
+      expect(renderFields.calls[7].arguments[0].fighter.input.value).toBe('reduxForm')
     })
   })
 }

--- a/src/__tests__/actions.spec.js
+++ b/src/__tests__/actions.spec.js
@@ -260,7 +260,7 @@ describe('actions', () => {
   })
 
   it('should create blur action', () => {
-    expect(blur('myForm', 'myField', 'bar', false))
+    expect(blur('myForm', 'myField', false))
       .toEqual({
         type: BLUR,
         meta: {
@@ -268,10 +268,9 @@ describe('actions', () => {
           field: 'myField',
           touch: false
         },
-        payload: 'bar'
       })
       .toPass(isFSA)
-    expect(blur('myForm', 'myField', 7, true))
+    expect(blur('myForm', 'myField', true))
       .toEqual({
         type: BLUR,
         meta: {
@@ -279,7 +278,6 @@ describe('actions', () => {
           field: 'myField',
           touch: true
         },
-        payload: 7
       })
       .toPass(isFSA)
   })

--- a/src/__tests__/reducer.blur.spec.js
+++ b/src/__tests__/reducer.blur.spec.js
@@ -1,27 +1,12 @@
 import { blur } from '../actions'
 
 const describeBlur = (reducer, expect, { fromJS, setIn }) => () => {
-  it('should set value on blur with empty state', () => {
-    const state = reducer(undefined, blur('foo', 'myField', 'myValue'))
-    expect(state)
-      .toEqualMap({
-        foo: {
-          values: {
-            myField: 'myValue'
-          }
-        }
-      })
-  })
-
-  it('should set value on blur and touch with empty state', () => {
-    const state = reducer(undefined, blur('foo', 'myField', 'myValue', true))
+  it('should touch on blur', () => {
+    const state = reducer(undefined, blur('foo', 'myField', true))
     expect(state)
       .toEqualMap({
         foo: {
           anyTouched: true,
-          values: {
-            myField: 'myValue'
-          },
           fields: {
             myField: {
               touched: true
@@ -31,7 +16,7 @@ const describeBlur = (reducer, expect, { fromJS, setIn }) => () => {
       })
   })
 
-  it('should set value on blur and touch with initial value', () => {
+  it('should touch on blur with initial value', () => {
     const state = reducer(fromJS({
       foo: {
         values: {
@@ -47,13 +32,13 @@ const describeBlur = (reducer, expect, { fromJS, setIn }) => () => {
         },
         active: 'myField'
       }
-    }), blur('foo', 'myField', 'myValue', true))
+    }), blur('foo', 'myField', true))
     expect(state)
       .toEqualMap({
         foo: {
           anyTouched: true,
           values: {
-            myField: 'myValue'
+            myField: 'initialValue'
           },
           initial: {
             myField: 'initialValue'
@@ -83,7 +68,7 @@ const describeBlur = (reducer, expect, { fromJS, setIn }) => () => {
         },
         active: 'myField'
       }
-    }), blur('foo', 'myField', undefined, true))
+    }), blur('foo', 'myField', true))
     expect(state)
       .toEqualMap({
         foo: {
@@ -113,7 +98,7 @@ const describeBlur = (reducer, expect, { fromJS, setIn }) => () => {
         },
         active: 'myField'
       }
-    }), blur('foo', 'myField', undefined, true))
+    }), blur('foo', 'myField', true))
     expect(state)
       .toEqualMap({
         foo: {
@@ -125,197 +110,6 @@ const describeBlur = (reducer, expect, { fromJS, setIn }) => () => {
           }
         }
       })
-  })
-
-  it('should remove a value if on blur is set with \'\'', () => {
-    const state = reducer(fromJS({
-      foo: {
-        values: {
-          myField: 'initialValue'
-        }
-      }
-    }), blur('foo', 'myField', '', true))
-    expect(state)
-      .toEqualMap({
-        foo: {
-          anyTouched: true,
-          fields: {
-            myField: {
-              touched: true
-            }
-          }
-        }
-      })
-  })
-
-  it('should allow setting an initialized field to \'\'', () => {
-    const state = reducer(fromJS({
-      foo: {
-        values: {
-          myField: 'initialValue'
-        },
-        initial: {
-          myField: 'initialValue'
-        }
-      }
-    }), blur('foo', 'myField', '', true))
-    expect(state)
-      .toEqualMap({
-        foo: {
-          anyTouched: true,
-          values: {
-            myField: ''
-          },
-          initial: {
-            myField: 'initialValue'
-          },
-          fields: {
-            myField: {
-              touched: true
-            }
-          }
-        }
-      })
-  })
-
-  it('should NOT remove a value if on blur is set with \'\' if it\'s an array field', () => {
-    const state = reducer(fromJS({
-      foo: {
-        values: {
-          myField: [ 'initialValue' ]
-        }
-      }
-    }), blur('foo', 'myField[0]', '', true))
-    expect(state)
-      .toEqualMap({
-        foo: {
-          anyTouched: true,
-          values: {
-            myField: [ undefined ]
-          },
-          fields: {
-            myField: [
-              {
-                touched: true
-              }
-            ]
-          }
-        }
-      })
-  })
-
-  it('should remove nested value container if on blur clears all values', () => {
-    const state = reducer(fromJS({
-      foo: {
-        values: {
-          nested: {
-            myField: 'initialValue'
-          }
-        }
-      }
-    }), blur('foo', 'nested.myField', '', true))
-    expect(state)
-      .toEqualMap({
-        foo: {
-          anyTouched: true,
-          fields: {
-            nested: {
-              myField: {
-                touched: true
-              }
-            }
-          }
-        }
-      })
-  })
-
-  it('should set nested value on blur', () => {
-    const state = reducer(fromJS({
-      foo: {
-        fields: {
-          myField: {
-            mySubField: {
-              active: true
-            }
-          }
-        },
-        active: 'myField.mySubField'
-      }
-    }), blur('foo', 'myField.mySubField', 'hello', true))
-    expect(state)
-      .toEqualMap({
-        foo: {
-          anyTouched: true,
-          values: {
-            myField: {
-              mySubField: 'hello'
-            }
-          },
-          fields: {
-            myField: {
-              mySubField: {
-                touched: true
-              }
-            }
-          }
-        }
-      })
-  })
-
-  it('should set array value on blur', () => {
-    const state = reducer(fromJS({
-      foo: {
-        values: {
-          myArray: []
-        },
-        fields: {
-          myArray: [
-            { active: true }
-          ]
-        },
-        active: 'myArray[0]'
-      }
-    }), blur('foo', 'myArray[0]', 'hello', true))
-    expect(state)
-      .toEqualMap({
-        foo: {
-          anyTouched: true,
-          values: {
-            myArray: [ 'hello' ]
-          },
-          fields: {
-            myArray: [
-              {
-                touched: true
-              }
-            ]
-          }
-        }
-      })
-  })
-
-  it('should set complex value on blur', () => {
-    const state = reducer(fromJS({
-      foo: {
-        fields: {
-          myComplexField: {
-            active: true
-          }
-        },
-        active: 'myComplexField'
-      }
-    }), blur('foo', 'myComplexField', { id: 42, name: 'Bobby' }, true))
-    expect(state)
-      .toEqualMap(setIn(fromJS({ // must use setIn to make sure complex value is js object
-        foo: {
-          anyTouched: true,
-          fields: {
-            myComplexField: {
-              touched: true
-            }
-          }
-        }
-      }), 'foo.values.myComplexField', { id: 42, name: 'Bobby' }))
   })
 
   it('should NOT remove active field if the blurred field is not active', () => {
@@ -351,7 +145,7 @@ const describeBlur = (reducer, expect, { fromJS, setIn }) => () => {
           myArray: [ {} ]
         }
       }
-    }), blur('foo', 'myArray[0].foo', '', true))
+    }), blur('foo', 'myArray[0].foo', true))
     expect(state)
       .toEqualMap({
         foo: {

--- a/src/__tests__/reduxForm.spec.js
+++ b/src/__tests__/reduxForm.spec.js
@@ -3450,7 +3450,7 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(propsAtNthRender(inputRender, 2).input.value).toBe('fooChanged')
     })
 
-    it('should provide dispatch-bound blur() that modifies values', () => {
+    it('should provide dispatch-bound blur() that does not modify values', () => {
       const store = makeStore({})
       const formRender = createSpy()
 
@@ -3483,14 +3483,13 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(formRender.calls.length).toBe(1)
 
       expect(formRender.calls[ 0 ].arguments[ 0 ].blur).toBeA('function')
-      formRender.calls[ 0 ].arguments[ 0 ].blur('foo', 'newValue')
+      formRender.calls[ 0 ].arguments[ 0 ].blur('foo')
 
       // check modified state
       expect(store.getState()).toEqualMap({
         form: {
           testForm: {
             registeredFields: { foo: { name: 'foo', type: 'Field', count: 1 } },
-            values: { foo: 'newValue' },
             fields: { foo: { touched: true } },
             anyTouched: true
           }

--- a/src/actions.js
+++ b/src/actions.js
@@ -56,8 +56,8 @@ export const arrayUnshift = (form, field, value) =>
 export const autofill = (form, field, value) =>
   ({ type: AUTOFILL, meta: { form, field }, payload: value })
 
-export const blur = (form, field, value, touch) =>
-  ({ type: BLUR, meta: { form, field, touch }, payload: value })
+export const blur = (form, field, touch) =>
+  ({ type: BLUR, meta: { form, field, touch } })
 
 export const change = (form, field, value, touch, persistentSubmitErrors) =>
   ({ type: CHANGE, meta: { form, field, touch, persistentSubmitErrors }, payload: value })

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -133,14 +133,8 @@ const createReducer = structure => {
       result = setIn(result, `values.${field}`, payload)
       return result
     },
-    [BLUR](state, { meta: { field, touch }, payload }) {
+    [BLUR](state, { meta: { field, touch } }) {
       let result = state
-      const initial = getIn(result, `initial.${field}`)
-      if (initial === undefined && payload === '') {
-        result = deleteInWithCleanUp(result, `values.${field}`)
-      } else if (payload !== undefined) {
-        result = setIn(result, `values.${field}`, payload)
-      }
       if (field === getIn(result, 'active')) {
         result = deleteIn(result, 'active')
       }

--- a/src/reduxForm.js
+++ b/src/reduxForm.js
@@ -645,7 +645,7 @@ const createReduxForm =
             // Bind the first parameter on `props.form`
             const boundFormACs = mapValues(formActions, bindForm)
             const boundArrayACs = mapValues(arrayActions, bindForm)
-            const boundBlur = (field, value) => blur(initialProps.form, field, value, !!initialProps.touchOnBlur)
+            const boundBlur = (field) => blur(initialProps.form, field, !!initialProps.touchOnBlur)
             const boundChange = (field, value) => change(initialProps.form, field, value, !!initialProps.touchOnChange, !!initialProps.persistentSubmitErrors)
             const boundFocus = bindForm(focus)
 


### PR DESCRIPTION
Fixes https://github.com/erikras/redux-form/issues/2768.

Some Complex fields cannot emit DOMevent with correct value of e.target. 
Also, we couldn't identify a use-case where changing value on blur makes sense.

This PR cleans up `blur` action and removes value from the payload.  It also removes a bunch of tests. For asyncValidate it always emits with the last rendered value of the input field assuming that there was `onChange` preceding `onBlur`.

to: @erikras 



