### PR TITLE
Migrate from React.PropTypes to prop-types

### DIFF
--- a/examples/wizard/package.json
+++ b/examples/wizard/package.json
@@ -13,6 +13,7 @@
     "html-loader": "^0.4.4",
     "json-loader": "0.5.4",
     "markdown-loader": "^2.0.0",
+    "prop-types": "^15.5.6",
     "raw-loader": "0.5.1",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",

--- a/examples/wizard/src/WizardForm.js
+++ b/examples/wizard/src/WizardForm.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types';
 import WizardFormFirstPage from './WizardFormFirstPage'
 import WizardFormSecondPage from './WizardFormSecondPage'
 import WizardFormThirdPage from './WizardFormThirdPage'

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "invariant": "^2.2.2",
     "is-promise": "^2.1.0",
     "lodash": "^4.17.3",
-    "lodash-es": "^4.17.3"
+    "lodash-es": "^4.17.3",
+    "prop-types": "^15.5.6"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",

--- a/src/ConnectedField.js
+++ b/src/ConnectedField.js
@@ -1,4 +1,5 @@
-import { Component, PropTypes, createElement } from 'react'
+import { Component, createElement } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux'
 import createFieldProps from './createFieldProps'
 import onChangeValue from './events/onChangeValue'

--- a/src/ConnectedFieldArray.js
+++ b/src/ConnectedFieldArray.js
@@ -1,4 +1,5 @@
-import { Component, PropTypes, createElement } from 'react'
+import { Component, createElement } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
 import createFieldArrayProps from './createFieldArrayProps'

--- a/src/ConnectedFields.js
+++ b/src/ConnectedFields.js
@@ -1,4 +1,5 @@
-import { Component, PropTypes, createElement } from 'react'
+import { Component, createElement } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux'
 import createFieldProps from './createFieldProps'
 import plain from './structure/plain'

--- a/src/Field.js
+++ b/src/Field.js
@@ -1,4 +1,5 @@
-import { Component, PropTypes, createElement } from 'react'
+import { Component, createElement } from 'react';
+import PropTypes from 'prop-types';
 import invariant from 'invariant'
 import createConnectedField from './ConnectedField'
 import shallowCompare from './util/shallowCompare'

--- a/src/FieldArray.js
+++ b/src/FieldArray.js
@@ -1,4 +1,5 @@
-import { Component, PropTypes, createElement } from 'react'
+import { Component, createElement } from 'react';
+import PropTypes from 'prop-types';
 import invariant from 'invariant'
 import createConnectedFieldArray from './ConnectedFieldArray'
 import prefixName from './util/prefixName'

--- a/src/Fields.js
+++ b/src/Fields.js
@@ -1,4 +1,5 @@
-import { Component, PropTypes, createElement } from 'react'
+import { Component, createElement } from 'react';
+import PropTypes from 'prop-types';
 import invariant from 'invariant'
 import createConnectedFields from './ConnectedFields'
 import shallowCompare from './util/shallowCompare'

--- a/src/Form.js
+++ b/src/Form.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class Form extends Component {
   constructor(props, context) {

--- a/src/FormSection.js
+++ b/src/FormSection.js
@@ -1,4 +1,5 @@
-import React, { createElement, Component, PropTypes } from 'react'
+import React, { createElement, Component } from 'react';
+import PropTypes from 'prop-types';
 import prefixName from './util/prefixName'
 
 class FormSection extends Component {

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -1,4 +1,5 @@
-import { PropTypes } from 'react'
+import PropTypes from 'prop-types';
+
 const { any, bool, func, shape, string, oneOfType, object } = PropTypes
 
 const propTypes = {

--- a/src/reduxForm.js
+++ b/src/reduxForm.js
@@ -1,7 +1,8 @@
 import hoistStatics from 'hoist-non-react-statics'
 import isPromise from 'is-promise'
 import { mapValues, merge } from 'lodash'
-import { Component, createElement, PropTypes } from 'react'
+import { Component, createElement } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
 import * as importedActions from './actions'


### PR DESCRIPTION
React 15.5+ warns when using `React.PropTypes`. This PR updates the source to use instead the `prop-types` package as suggested in https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html.