### PR TITLE
Migrate from React.PropTypes to prop-types (v5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "jsdom": "^8.4.1",
     "mocha": "^2.4.5",
     "mocha-lcov-reporter": "^1.1.0",
+    "prop-types": "^15.5.8",
     "react": "^15.0.0",
     "react-addons-test-utils": "^15.0.0",
     "react-dom": "^15.0.0",

--- a/src/__tests__/createReduxForm.spec.js
+++ b/src/__tests__/createReduxForm.spec.js
@@ -1,6 +1,7 @@
 /* eslint react/no-multi-comp:0 */
 import expect, {createSpy} from 'expect';
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
@@ -17,7 +18,7 @@ const createRestorableSpy = (fn) => {
 };
 
 describe('createReduxForm', () => {
-  const reduxForm = createReduxForm(false, React, connect);
+  const reduxForm = createReduxForm(false, React, PropTypes, connect);
   const makeStore = (initialState = {}) => createStore(combineReducers({
     form: reducer
   }), { form: initialState });

--- a/src/createAll.js
+++ b/src/createAll.js
@@ -44,7 +44,7 @@ const touchWithKey = boundActions.touchWithKey;
 const untouch = boundActions.untouch;
 const untouchWithKey = boundActions.untouchWithKey;
 
-export default function createAll(isReactNative, React, connect) {
+export default function createAll(isReactNative, React, PropTypes, connect) {
   return {
     actionTypes,
     addArrayValue,
@@ -58,8 +58,8 @@ export default function createAll(isReactNative, React, connect) {
     getValues,
     initialize,
     initializeWithKey,
-    propTypes: createPropTypes(React),
-    reduxForm: createReduxForm(isReactNative, React, connect),
+    propTypes: createPropTypes(PropTypes),
+    reduxForm: createReduxForm(isReactNative, React, PropTypes, connect),
     reducer,
     removeArrayValue,
     reset,

--- a/src/createHigherOrderComponent.js
+++ b/src/createHigherOrderComponent.js
@@ -20,13 +20,14 @@ import createInitialState from './createInitialState';
 const createHigherOrderComponent = (config,
                                     isReactNative,
                                     React,
+                                    PropTypes,
                                     connect,
                                     WrappedComponent,
                                     mapStateToProps,
                                     mapDispatchToProps,
                                     mergeProps,
                                     options) => {
-  const {Component, PropTypes} = React;
+  const {Component} = React;
   return (reduxMountPoint, formName, formKey, getFormState) => {
     const { withRef = false } = (options || {});
     class ReduxForm extends Component {

--- a/src/createPropTypes.js
+++ b/src/createPropTypes.js
@@ -1,4 +1,4 @@
-const createPropTypes = ({PropTypes: {any, bool, string, func, object}}) => ({
+const createPropTypes = ({any, bool, string, func, object}) => ({
   // State:
   active: string,                     // currently active field
   asyncValidating: bool.isRequired,   // true if async validation is running

--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -6,9 +6,9 @@ import invariant from 'invariant';
  * The decorator that is the main API to redux-form
  */
 const createReduxForm =
-  (isReactNative, React, connect) => {
+  (isReactNative, React, PropTypes, connect) => {
     const {Component} = React;
-    const reduxFormConnector = createReduxFormConnector(isReactNative, React, connect);
+    const reduxFormConnector = createReduxFormConnector(isReactNative, React, PropTypes, connect);
     return (config, mapStateToProps, mapDispatchToProps, mergeProps, options) =>
       WrappedComponent => {
         const ReduxFormConnector = reduxFormConnector(WrappedComponent, mapStateToProps, mapDispatchToProps, mergeProps, options);

--- a/src/createReduxFormConnector.js
+++ b/src/createReduxFormConnector.js
@@ -7,9 +7,9 @@ import createHigherOrderComponent from './createHigherOrderComponent';
  * but if they do, the connected components below it need to be redefined.
  */
 const createReduxFormConnector =
-  (isReactNative, React, connect) =>
+  (isReactNative, React, PropTypes, connect) =>
     (WrappedComponent, mapStateToProps, mapDispatchToProps, mergeProps, options) => {
-      const {Component, PropTypes} = React;
+      const {Component} = React;
       const { withRef = false } = (options || {});
       class ReduxFormConnector extends Component {
         constructor(props) {
@@ -23,7 +23,7 @@ const createReduxFormConnector =
                 'formKey',
                 'getFormState'
               ],
-              fn: createHigherOrderComponent(props, isReactNative, React, connect, WrappedComponent,
+              fn: createHigherOrderComponent(props, isReactNative, React, PropTypes, connect, WrappedComponent,
                 mapStateToProps, mapDispatchToProps, mergeProps, options)
             }
           });

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import createAll from './createAll';
 
@@ -35,4 +36,4 @@ export const {
   touchWithKey,
   untouch,
   untouchWithKey
-} = createAll(isNative, React, connect);
+} = createAll(isNative, React, PropTypes, connect);

--- a/src/native.js
+++ b/src/native.js
@@ -1,4 +1,5 @@
 import React from 'react-native';
+import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import createAll from './createAll';
 

--- a/src/native.js
+++ b/src/native.js
@@ -29,4 +29,4 @@ export const {
   touchWithKey,
   untouch,
   untouchWithKey
-} = createAll(true, React, connect);
+} = createAll(true, React, PropTypes, connect);


### PR DESCRIPTION
PR should eliminate annoying warning in console about migration to prop-types package https://github.com/reactjs/prop-types/blob/master/README.md#difference-from-reactproptypes-dont-call-validator-functions