### PR TITLE
Remove meta.touched prop from FieldArray

### DIFF
--- a/examples/fieldArrays/src/FieldArraysForm.js
+++ b/examples/fieldArrays/src/FieldArraysForm.js
@@ -34,11 +34,11 @@ const renderHobbies = ({ fields, meta: { error } }) => (
   </ul>
 )
 
-const renderMembers = ({ fields, meta: { touched, error, submitFailed } }) => (
+const renderMembers = ({ fields, meta: { error, submitFailed } }) => (
   <ul>
     <li>
       <button type="button" onClick={() => fields.push({})}>Add Member</button>
-      {(touched || submitFailed) && error && <span>{error}</span>}
+      {submitFailed && error && <span>{error}</span>}
     </li>
     {fields.map((member, index) =>
       <li key={index}>

--- a/src/__tests__/FieldArray.spec.js
+++ b/src/__tests__/FieldArray.spec.js
@@ -110,26 +110,6 @@ const describeFieldArray = (name, structure, combineReducers, expect) => {
       expect(props.meta.form).toBe('testForm')
     })
 
-    it('should get touched from Redux state', () => {
-      const props1 = testProps({
-        values: {
-          foo: 'bar'
-        }
-      })
-      expect(props1.meta.touched).toBe(false)
-      const props2 = testProps({
-        values: {
-          foo: 'bar'
-        },
-        fields: {
-          foo: {
-            touched: true
-          }
-        }
-      })
-      expect(props2.meta.touched).toBe(true)
-    })
-
     it('should not pass api props into custom', () => {
       const store = makeStore()
       const renderSpy = createSpy()

--- a/src/createFieldArrayProps.js
+++ b/src/createFieldArrayProps.js
@@ -45,7 +45,6 @@ const createFieldArrayProps = (getIn, name, form, sectionPrefix, getValue,
       pristine,
       submitting,
       submitFailed,
-      touched: !!(state && getIn(state, 'touched')),
       valid: !error
     },
     ...props,


### PR DESCRIPTION
Fixes #2830.

It had never ever been set to anything, was never documented, and was only causing confusion.