### PR TITLE
Add a selector to get touched and visited props from state

### DIFF
--- a/docs/api/Selectors.md
+++ b/docs/api/Selectors.md
@@ -20,6 +20,7 @@ import {
   getFormValues,
   getFormInitialValues,
   getFormSyncErrors,
+  getFormMeta,
   getFormAsyncErrors,
   getFormSyncWarnings,
   getFormSubmitErrors,
@@ -38,6 +39,7 @@ MyComponent = connect(
     values: getFormValues('myForm')(state),
     initialValues: getFormInitialValues('myForm')(state),
     syncErrors: getFormSyncErrors('myForm')(state),
+    fields: getFormMeta('myForm')(state),
     asyncErrors: getFormAsyncErrors('myForm')(state),
     syncWarnings: getFormSyncWarnings('myForm')(state),
     submitErrors: getFormSubmitErrors('myForm')(state),
@@ -66,6 +68,10 @@ MyComponent = connect(
 ### `getFormSyncErrors(formName:String)` returns `(state) => formSyncErrors:Object`
 
 > Returns the form synchronous validation errors.
+
+### `getFormMeta(formName:String)` returns `(state) => formMeta:Object`
+
+> Returns the form's fields meta data, namely `touched` and `visited`.
 
 ### `getFormAsyncErrors(formName:String)` returns `(state) => formAsyncErrors:Object`
 

--- a/src/__tests__/immutable.spec.js
+++ b/src/__tests__/immutable.spec.js
@@ -28,6 +28,7 @@ import {
   getFormValues,
   getFormInitialValues,
   getFormSyncErrors,
+  getFormMeta,
   getFormAsyncErrors,
   getFormSyncWarnings,
   getFormSubmitErrors,
@@ -136,6 +137,9 @@ describe('immutable', () => {
   })
   it('should export getFormSyncErrors', () => {
     expect(getFormSyncErrors).toExist().toBeA('function')
+  })
+  it('should export getFormMeta', () => {
+    expect(getFormMeta).toExist().toBeA('function')
   })
   it('should export getFormAsyncErrors', () => {
     expect(getFormAsyncErrors).toExist().toBeA('function')

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -29,6 +29,7 @@ import {
   getFormValues,
   getFormInitialValues,
   getFormSyncErrors,
+  getFormMeta,
   getFormAsyncErrors,
   getFormSyncWarnings,
   getFormSubmitErrors,
@@ -140,6 +141,9 @@ describe('index', () => {
   })
   it('should export getFormSyncErrors', () => {
     expect(getFormSyncErrors).toExist().toBeA('function')
+  })
+  it('should export getFormMeta', () => {
+    expect(getFormMeta).toExist().toBeA('function')
   })
   it('should export getFormAsyncErrors', () => {
     expect(getFormAsyncErrors).toExist().toBeA('function')

--- a/src/createAll.js
+++ b/src/createAll.js
@@ -9,6 +9,7 @@ import createGetFormNames from './selectors/getFormNames'
 import createGetFormValues from './selectors/getFormValues'
 import createGetFormInitialValues from './selectors/getFormInitialValues'
 import createGetFormSyncErrors from './selectors/getFormSyncErrors'
+import createGetFormMeta from './selectors/getFormMeta'
 import createGetFormAsyncErrors from './selectors/getFormAsyncErrors'
 import createGetFormSyncWarnings from './selectors/getFormSyncWarnings'
 import createGetFormSubmitErrors from './selectors/getFormSubmitErrors'
@@ -40,6 +41,7 @@ const createAll = structure => ({
   getFormValues: createGetFormValues(structure),
   getFormInitialValues: createGetFormInitialValues(structure),
   getFormSyncErrors: createGetFormSyncErrors(structure),
+  getFormMeta: createGetFormMeta(structure),
   getFormAsyncErrors: createGetFormAsyncErrors(structure),
   getFormSyncWarnings : createGetFormSyncWarnings(structure),
   getFormSubmitErrors: createGetFormSubmitErrors(structure),

--- a/src/immutable.js
+++ b/src/immutable.js
@@ -29,6 +29,7 @@ export const {
   getFormValues,
   getFormInitialValues,
   getFormSyncErrors,
+  getFormMeta,
   getFormAsyncErrors,
   getFormSyncWarnings,
   getFormSubmitErrors,

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ export const {
   getFormValues,
   getFormInitialValues,
   getFormSyncErrors,
+  getFormMeta,
   getFormAsyncErrors,
   getFormSyncWarnings,
   getFormSubmitErrors,

--- a/src/selectors/__tests__/getFormMeta.spec.js
+++ b/src/selectors/__tests__/getFormMeta.spec.js
@@ -1,0 +1,85 @@
+import createGetFormMeta from '../getFormMeta'
+import plain from '../../structure/plain'
+import plainExpectations from '../../structure/plain/expectations'
+import immutable from '../../structure/immutable'
+import immutableExpectations from '../../structure/immutable/expectations'
+import addExpectations from '../../__tests__/addExpectations'
+
+const describeGetFormMeta = (name, structure, expect) => {
+  const getFormMeta = createGetFormMeta(structure)
+
+  const {fromJS, getIn} = structure
+
+  describe(name, () => {
+    it('should return a function', () => {
+      expect(createGetFormMeta('foo')).toBeA('function')
+    })
+
+    it('should get the form values from state', () => {
+      expect(getFormMeta('foo')(fromJS({
+        form: {
+          foo: {
+            fields: {
+              dog: {
+                visited: true,
+                touched: false
+              },
+              cat: {
+                visited: false,
+                touched: true
+              }
+            }
+          }
+        }
+      }))).toEqualMap({
+        dog: {
+          visited: true,
+          touched: false
+        },
+        cat: {
+          visited: false,
+          touched: true
+        }
+      })
+    })
+
+    it('should return undefined if there are no fields', () => {
+      expect(getFormMeta('foo')(fromJS({
+        form: {
+          foo: {}
+        }
+      }))).toEqual(undefined)
+    })
+
+    it('should use getFormState if provided', () => {
+      expect(getFormMeta('foo', state => getIn(state, 'someOtherSlice'))(fromJS({
+        someOtherSlice: {
+          foo: {
+            fields: {
+              dog: {
+                visited: true,
+                touched: false
+              },
+              cat: {
+                visited: false,
+                touched: true
+              }
+            }
+          }
+        }
+      }))).toEqualMap({
+        dog: {
+          visited: true,
+          touched: false
+        },
+        cat: {
+          visited: false,
+          touched: true
+        }
+      })
+    })
+  })
+}
+
+describeGetFormMeta('getFormMeta.plain', plain, addExpectations(plainExpectations))
+describeGetFormMeta('getFormMeta.immutable', immutable, addExpectations(immutableExpectations))

--- a/src/selectors/getFormMeta.js
+++ b/src/selectors/getFormMeta.js
@@ -1,0 +1,5 @@
+const createGetFormMeta = ({ getIn }) =>
+  (form, getFormState = state => getIn(state, 'form')) =>
+    state => getIn(getFormState(state), `${form}.fields`)
+
+export default createGetFormMeta


### PR DESCRIPTION
Same as other selectors, but returns the slice form.${formName}.fields of state. Can be useful f.e. for [#2585](https://github.com/erikras/redux-form/issues/2585)