### PR TITLE
deleteInWithCleanUp needs to check if there is a value in the state before deleting.

### DIFF
--- a/src/deleteInWithCleanUp.js
+++ b/src/deleteInWithCleanUp.js
@@ -9,7 +9,12 @@ const createDeleteInWithCleanUp = ({ deepEqual, empty, getIn, deleteIn, setIn })
       const parent = getIn(state, pathTokens.join('.'))
       return parent ? setIn(state, path, undefined) : state
     }
-    const result = deleteIn(state, path)
+
+    let result = state
+    if (typeof getIn(state, path) !== 'undefined') {
+      result = deleteIn(state, path)
+    }
+
     const dotIndex = path.lastIndexOf('.')
     if (dotIndex > 0) {
       const parentPath = path.substring(0, dotIndex)

--- a/src/deleteInWithCleanUp.js
+++ b/src/deleteInWithCleanUp.js
@@ -11,7 +11,7 @@ const createDeleteInWithCleanUp = ({ deepEqual, empty, getIn, deleteIn, setIn })
     }
 
     let result = state
-    if (typeof getIn(state, path) !== 'undefined') {
+    if (getIn(state, path) !== undefined) {
       result = deleteIn(state, path)
     }
 


### PR DESCRIPTION
This is related to #2875. I'm not sure if this is the best way of fixing the issue, but it solves the problem atleast. Adds a check to see if there is anything in the state before calling `deleteIn` when `deleteInWithCleanUp` is called. With this code I no longer get `Invalid KeyPath` errors when using Immutable.js and editing FieldArrays after submit has failed.