### PR TITLE
Fix deep equal on maps with different structures

### DIFF
--- a/src/structure/immutable/__tests__/deepEqual.spec.js
+++ b/src/structure/immutable/__tests__/deepEqual.spec.js
@@ -251,7 +251,25 @@ describe('structure.immutable.deepEqual', () => {
       }
     }), true)
   })
-  
+
+  it ('should check if key exists on both objects', () => {
+    testBothWays(fromJS({
+        a: false
+      }), fromJS({
+        b: 1
+      }), false)
+    testBothWays(fromJS({
+        a: ''
+      }), fromJS({
+        b: 1
+      }), false)
+    testBothWays(fromJS({
+        a: null
+      }), fromJS({
+        b: 1
+      }), false)
+  })
+
   it('should treat null and \'\' as equal', () => {
     testBothWays(fromJS({
       a: {
@@ -288,4 +306,3 @@ describe('structure.immutable.deepEqual', () => {
     }), true)
   })
 })
-

--- a/src/structure/immutable/deepEqual.js
+++ b/src/structure/immutable/deepEqual.js
@@ -9,7 +9,7 @@ const customizer = (obj, other) => {
 
   if (Iterable.isIterable(obj) && Iterable.isIterable(other)) {
     return obj.count() === other.count() && obj.every((value, key) => {
-      return isEqualWith(value, other.get(key), customizer)
+      return other.has(key) && isEqualWith(value, other.get(key), customizer)
     })
   }
 


### PR DESCRIPTION
Fixes issue #2882. Deep equal wasn't checking to see if the key exists on the map it was comparing itself to.