### PR TITLE
Fix minor incorrect doc sentence

### DIFF
--- a/docs/api/FieldArray.md
+++ b/docs/api/FieldArray.md
@@ -212,7 +212,7 @@ is tracking for you.
 ## Iteration
 
 When you iterate through a field array with either `forEach()` or `map()`, your callback will be
-passed two parameters:
+passed following parameters:
 
 #### `name : String`
 


### PR DESCRIPTION
There are three parameters that get passed, not two. Anyways, to make it less prone to be out of date, changed the wording to "following parameters".