### PR TITLE
failing test case for: should only respond to form specified

### DIFF
--- a/src/__tests__/reducer.plugin.spec.js
+++ b/src/__tests__/reducer.plugin.spec.js
@@ -90,7 +90,7 @@ const describePlugin = (
       return state
     }
 
-    const reducer = vanillaReducer.plugin({foo: plugin})
+    const reducer = vanillaReducer.plugin({ foo: plugin, bar: plugin })
 
     const state2 = reducer(state1, {type: 'MILK', form: 'foo'})
     expect(state2).toBe(state1) // no change


### PR DESCRIPTION
reducer plugins are supposed to be run against the form specified but turns are they are run against every form plugin.

Proper fix is not trivial because of the design discussion made here so i want to start the conversation. Currently the signature for the plugin reducers is `(formState, action, startingState) => nextState;` startingState is rather odd and do we really need to support that?

Refer:
https://github.com/erikras/redux-form/blob/37ab5ae7647be6d178c2d2bb871cd6c638762f4c/src/__tests__/reducer.plugin.spec.js#L138-L154

cc @erikras 