### PR TITLE
Submit - Avoid strack trace using native submit

### DIFF
--- a/src/__tests__/reduxForm.spec.js
+++ b/src/__tests__/reduxForm.spec.js
@@ -29,6 +29,7 @@ import plain from '../structure/plain'
 import plainExpectations from '../structure/plain/expectations'
 import SubmissionError from '../SubmissionError'
 import addExpectations from './addExpectations'
+import FormWrapper from '../Form';
 
 const propsAtNthRender = (spy, callNumber) => spy.calls[callNumber].arguments[0]
 const propsAtLastRender = spy => propsAtNthRender(spy, spy.calls.length - 1)
@@ -2376,6 +2377,46 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       TestUtils.Simulate.submit(form)
 
       expect(submit).toHaveBeenCalled()
+    })
+
+    it('should submit when using Form Wrapper and "submit" button is clicked with onSubmit provided as config param', () => {
+      const store = makeStore({
+        testForm: {
+          values: {
+            bar: 'foo'
+          }
+        }
+      })
+
+      const Form = ({handleSubmit}) => (
+        <FormWrapper onSubmit={handleSubmit}>
+          <Field name="bar" component="textarea" />
+          <input type="submit" value="Submit" />
+        </FormWrapper>
+      )
+
+      const submit = createSpy()
+      const Decorated = reduxForm({
+        form: 'testForm',
+        onSubmit: submit
+      })(Form)
+
+      const dom = TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <Decorated />
+        </Provider>
+      )
+
+      const form = TestUtils.findRenderedDOMComponentWithTag(dom, 'form')
+
+      expect(submit).toNotHaveBeenCalled()
+
+      TestUtils.Simulate.submit(form)
+
+      expect(submit).toHaveBeenCalled()
+
+      // avoid recursive stack trace
+      expect(submit.calls.length).toEqual(1)
     })
 
     it('should no resubmit if async submit is in progress', () => {

--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -489,7 +489,8 @@ const createReduxForm = structure => {
           if (!submitOrEvent || silenceEvent(submitOrEvent)) {
             // submitOrEvent is an event: fire submit if not already submitting
             if (!this.submitPromise) {
-              if (this.innerOnSubmit) {
+              // avoid recursive stack trace if use Form with onSubmit as handleSubmit
+              if (this.innerOnSubmit && this.innerOnSubmit !== this.submit) {
                 // will call "submitOrEvent is the submit function" block below
                 return this.innerOnSubmit()
               } else {


### PR DESCRIPTION
Using the new `Form` wrapper, I catch a problem that if you're using the wrapper but you want to use the native submit passing `onSubmit` into config param, will enter in a stack trace.

Here a code example:

```
import {Form} from 'redux-form';

class MyComponent extends React.Component {
  render() {
    const {handleSubmit} = this.props;
    return (
       <Form onSubmit={handleSubmit}>
         <input type="submit" value="aaa" />
       </Form>
    );
  }
}

reduxForm({
  form: 'test',
  onSubmit: (value) => value
})(MyComponent);
```

I just added a verification to not call `innerSubmit` if is already the `submit` function.