### PR TITLE
updated PropTypes for initialValues to support an array or an object

### DIFF
--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -648,7 +648,10 @@ const createReduxForm = structure => {
         destroyOnUnmount: PropTypes.bool,
         forceUnregisterOnUnmount: PropTypes.bool,
         form: PropTypes.string.isRequired,
-        initialValues: PropTypes.object,
+        initialValues: PropTypes.oneOfType([
+          PropTypes.array,
+          PropTypes.object
+        ]),
         getFormState: PropTypes.func,
         onSubmitFail: PropTypes.func,
         onSubmitSuccess: PropTypes.func,


### PR DESCRIPTION
initialValues can be an array or an object.  For example a form with fields: 
`<Field name="0.firstName />
<Field name="1.firstName" />`