### PR TITLE
Correct grammatical error in API README.md

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -41,7 +41,7 @@
 
 ## [`Fields`](Fields.md)
 
-> The component that can to connect multiple inputs to `redux-form`.
+> The component that can connect multiple inputs to `redux-form`.
 
 > [`View source on GitHub`](https://github.com/erikras/redux-form/blob/master/src/Fields.js)
 


### PR DESCRIPTION
Fixing an extraneous _to_ that was squirreled away under the descriptive text for `Fields`.