### PR TITLE
Export formPropTypes as an alias for propTypes

### DIFF
--- a/src/__tests__/immutable.spec.js
+++ b/src/__tests__/immutable.spec.js
@@ -43,6 +43,7 @@ import {
   hasSubmitSucceeded,
   hasSubmitFailed,
   propTypes,
+  formPropTypes,
   reducer,
   reduxForm,
   registerField,
@@ -184,6 +185,9 @@ describe('immutable', () => {
   })
   it('should export propTypes', () => {
     expect(propTypes).toEqual(expectedPropTypes)
+  })
+  it('should export formPropTypes', () => {
+    expect(formPropTypes).toEqual(expectedPropTypes)
   })
   it('should export reducer', () => {
     expect(reducer).toExist().toBeA('function')

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -44,6 +44,7 @@ import {
   hasSubmitSucceeded,
   hasSubmitFailed,
   propTypes,
+  formPropTypes,
   reducer,
   reduxForm,
   registerField,
@@ -188,6 +189,9 @@ describe('index', () => {
   })
   it('should export propTypes', () => {
     expect(propTypes).toEqual(expectedPropTypes)
+  })
+  it('should export formPropTypes', () => {
+    expect(formPropTypes).toEqual(expectedPropTypes)
   })
   it('should export reducer', () => {
     expect(reducer).toExist().toBeA('function')

--- a/src/immutable.js
+++ b/src/immutable.js
@@ -10,7 +10,8 @@ export {
   default as propTypes,
   fieldInputPropTypes,
   fieldMetaPropTypes,
-  fieldPropTypes
+  fieldPropTypes,
+  formPropTypes // alias for propTypes
 } from './propTypes'
 export {default as Field} from './immutable/Field'
 export {default as Fields} from './immutable/Fields'

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,8 @@ export {
   default as propTypes,
   fieldInputPropTypes,
   fieldMetaPropTypes,
-  fieldPropTypes
+  fieldPropTypes,
+  formPropTypes // alias for propTypes
 } from './propTypes'
 export {default as Field} from './Field'
 export {default as Fields} from './Fields'

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 
 const {any, bool, func, shape, string, oneOfType, object} = PropTypes
 
-const propTypes = {
+export const formPropTypes = {
   // State:
   anyTouched: bool.isRequired, // true if any of the fields have been marked as touched
   asyncValidating: oneOfType([bool, string]).isRequired, // true if async validation is running, a string if a field triggered async validation
@@ -86,4 +86,4 @@ export const fieldPropTypes = {
   custom: object.isRequired
 }
 
-export default propTypes
+export default formPropTypes


### PR DESCRIPTION
These propTypes are those for the form component and labelling them as such
disambiguates the variable for all importers, saving them from having to
redefine the name 'as' something in the base case.