### PR TITLE
Fix fieldPropTypes to have shapes for input and meta

### DIFF
--- a/src/__tests__/immutable.spec.js
+++ b/src/__tests__/immutable.spec.js
@@ -1,6 +1,8 @@
 import expect from 'expect'
 import * as expectedActionTypes from '../actionTypes'
-import expectedPropTypes from '../propTypes'
+import expectedPropTypes, {
+  fieldPropTypes as expectedFieldPropTypes
+} from '../propTypes'
 import {
   actionTypes,
   arrayInsert,
@@ -42,6 +44,7 @@ import {
   isSubmitting,
   hasSubmitSucceeded,
   hasSubmitFailed,
+  fieldPropTypes,
   propTypes,
   reducer,
   reduxForm,
@@ -181,6 +184,9 @@ describe('immutable', () => {
   })
   it('should export hasSubmitFailed', () => {
     expect(hasSubmitFailed).toExist().toBeA('function')
+  })
+  it('should export fieldPropTypes', () => {
+    expect(fieldPropTypes).toEqual(expectedFieldPropTypes)
   })
   it('should export propTypes', () => {
     expect(propTypes).toEqual(expectedPropTypes)

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -1,6 +1,8 @@
 import expect from 'expect'
 import * as expectedActionTypes from '../actionTypes'
-import expectedPropTypes from '../propTypes'
+import expectedPropTypes, {
+  fieldPropTypes as expectedFieldPropTypes
+} from '../propTypes'
 import {
   actionTypes,
   arrayInsert,
@@ -43,6 +45,7 @@ import {
   isSubmitting,
   hasSubmitSucceeded,
   hasSubmitFailed,
+  fieldPropTypes,
   propTypes,
   reducer,
   reduxForm,
@@ -185,6 +188,9 @@ describe('index', () => {
   })
   it('should export hasSubmitFailed', () => {
     expect(hasSubmitFailed).toExist().toBeA('function')
+  })
+  it('should export fieldPropTypes', () => {
+    expect(fieldPropTypes).toEqual(expectedFieldPropTypes)
   })
   it('should export propTypes', () => {
     expect(propTypes).toEqual(expectedPropTypes)

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -81,8 +81,8 @@ export const fieldMetaPropTypes = {
 }
 
 export const fieldPropTypes = {
-  input: fieldInputPropTypes.isRequired,
-  meta: fieldMetaPropTypes.isRequired,
+  input: shape(fieldInputPropTypes).isRequired,
+  meta: shape(fieldMetaPropTypes).isRequired,
   custom: object.isRequired
 }
 


### PR DESCRIPTION
Otherwise we get errors on use, e.g.:
```
  Failed prop type: inputField: prop type `meta` is invalid;
  it must be a function, usually from React.PropTypes.
```