### PR TITLE
add support for props with nested immutables

### DIFF
--- a/docs/api/ReduxForm.md
+++ b/docs/api/ReduxForm.md
@@ -68,6 +68,17 @@ will retain the value of dirty fields when reinitializing.
 where the `redux-form` reducer was mounted. This functionality is rarely needed, and defaults to
 assuming that the reducer is mounted under the `form` key.
 
+#### `immutableProps : Array<String>` [optional]
+
+> Prop names that only require strict-equals, not deep equals, to determine `shouldComponentUpdate`.
+Useful for performance and compatibility with 3rd party immutable libraries.
+Defaults to `[]`.
+
+#### `initialValues : Object<String, String>` [optional]
+
+> The values with which to initialize your form in `componentWillMount()`.
+The values should be in the form `{ field1: 'value1', field2: 'value2' }`.
+
 #### `keepDirtyOnReinitialize : boolean` [optional]
 
 > When set to `true` and `enableReinitialize` is also set, the form will retain the value
@@ -75,11 +86,6 @@ of dirty fields when reinitializing. When this option is not set (the default), 
 the form replaces all field values. This option is useful in situations where the form has
 live updates or continues to be editable after form submission; it prevents
 reinitialization from overwriting user changes. Defaults to `false`.
-
-#### `initialValues : Object<String, String>` [optional]
-
-> The values with which to initialize your form in `componentWillMount()`.
-The values should be in the form `{ field1: 'value1', field2: 'value2' }`.
 
 #### `onChange : Function` [optional]
 

--- a/src/__tests__/reduxForm.spec.js
+++ b/src/__tests__/reduxForm.spec.js
@@ -528,12 +528,10 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
         dom,
         'button'
       )
-        TestUtils.Simulate.click(initButton);
-
-      // no need to rerender form on initialize
+      
+      TestUtils.Simulate.click(initButton);
+      
       expect(formRender.calls.length).toBe(2)
-
-      // check rerendered input
       expect(inputRender.calls.length).toBe(1)
     })
     

--- a/src/__tests__/reduxForm.spec.js
+++ b/src/__tests__/reduxForm.spec.js
@@ -475,6 +475,68 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       expect(spy.calls.length).toBe(9)
     })
 
+    it('should strict equals props in immutableProps', () => {
+      const store = makeStore({})
+      const inputRender = createSpy(props => (
+        <input {...props.input} />
+      )).andCallThrough()
+      const formRender = createSpy()
+
+      class Form extends Component {
+        render() {
+          formRender(this.props)
+          return (
+            <form>
+              <Field name="deep.foo" component={inputRender} type="text" />
+            </form>
+          )
+        }
+      }
+      const Decorated = reduxForm({form: 'testForm', immutableProps: ['foo']})(Form)
+
+      class Container extends Component {
+        constructor(props) {
+          super(props)
+          this.state = {
+            foo: {get no() {throw new Error('props inside an immutableProps object should not be looked at')}}
+          }
+        }
+
+        render() {
+          return (
+            <div>
+              <Provider store={store}>
+                <Decorated {...this.state} foo={this.state.foo}/>
+              </Provider>
+              <button onClick={() => this.setState({foo: {no: undefined}})}>
+                Init
+              </button>
+            </div>
+          )
+        }
+      }
+
+      const dom = TestUtils.renderIntoDocument(<Container />)
+      expect(formRender).toHaveBeenCalled()
+      expect(formRender.calls.length).toBe(1)
+
+      expect(inputRender).toHaveBeenCalled()
+      expect(inputRender.calls.length).toBe(1)
+
+      // initialize
+      const initButton = TestUtils.findRenderedDOMComponentWithTag(
+        dom,
+        'button'
+      )
+        TestUtils.Simulate.click(initButton);
+
+      // no need to rerender form on initialize
+      expect(formRender.calls.length).toBe(2)
+
+      // check rerendered input
+      expect(inputRender.calls.length).toBe(1)
+    })
+    
     it('should initialize values with initialValues on first render', () => {
       const store = makeStore({})
       const inputRender = createSpy(props => (

--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -305,15 +305,17 @@ const createReduxForm = structure => {
 
         shouldComponentUpdate(nextProps) {
           if (!this.props.pure) return true
-          const {immutables = []} = initialConfig
+          const {immutableProps = []} = initialConfig
           return Object.keys(nextProps).some(prop => {
             // useful to debug rerenders
             // if (!plain.deepEqual(this.props[ prop ], nextProps[ prop ])) {
             //   console.info(prop, 'changed', this.props[ prop ], '==>', nextProps[ prop ])
             // }
+            if (~immutableProps.indexOf(prop)) {
+              return this.props[prop] !== nextProps[prop]
+            }
             return (
               !~propsToNotUpdateFor.indexOf(prop) &&
-              !~immutables.indexOf(prop) &&
               !deepEqual(this.props[prop], nextProps[prop])
             )
           })

--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -305,6 +305,7 @@ const createReduxForm = structure => {
 
         shouldComponentUpdate(nextProps) {
           if (!this.props.pure) return true
+          const {immutables = []} = initialConfig
           return Object.keys(nextProps).some(prop => {
             // useful to debug rerenders
             // if (!plain.deepEqual(this.props[ prop ], nextProps[ prop ])) {
@@ -312,6 +313,7 @@ const createReduxForm = structure => {
             // }
             return (
               !~propsToNotUpdateFor.indexOf(prop) &&
+              !~immutables.indexOf(prop) &&
               !deepEqual(this.props[prop], nextProps[prop])
             )
           })


### PR DESCRIPTION
Background:
Sometimes, a prop might be a POJO that contains a nested immutable structure. Draft-js' `editorState` is a great example. Within sCU, the plain `deepEqual` function is used on it & breaks. 
 
Why this is needed:
- Per #2798 the only way to make this work with draft-js is to serialize the editorState.
- The beauty of immutables is that we don't have to do a deep equals, comparing references is enough
- folks may use different immutable libraries so there is no safe way to ducktype an immutable
- folks may have large POJOs that they want to exclude from being deep equaled in sCU. This is a cheap, unobtrusive way to add performance. 

Example:
`reduxForm({form: 'linkChanger', immutables: ['editorState']})`

can bump the docs if you like it