### PR TITLE
add support for plain objects in keys extractor from immutable structure

### DIFF
--- a/src/structure/immutable/__tests__/keys.spec.js
+++ b/src/structure/immutable/__tests__/keys.spec.js
@@ -25,4 +25,15 @@ describe('structure.immutable.keys', () => {
       List(['a', 'b', 'c'])
     )
   })
+
+  it('should return keys from plain object', () => {
+    expectEqual(
+      keys({
+        a: 1,
+        b: 2,
+        c: 3
+      }),
+      List(['a', 'b', 'c'])
+    )
+  })
 })

--- a/src/structure/immutable/keys.js
+++ b/src/structure/immutable/keys.js
@@ -1,7 +1,14 @@
 import {Iterable, List} from 'immutable'
+import plainKeys from '../plain/keys'
 
 const empty = List()
 
-const keys = value => (Iterable.isIterable(value) ? value.keySeq() : empty)
+const keys = value => {
+  if (Iterable.isIterable(value)) {
+    return value.keySeq()
+  }
+
+  return value ? List(plainKeys(value)) : empty
+}
 
 export default keys


### PR DESCRIPTION
Reason for this change is that for immutable structure `valid` prop  from `reduxForm()` is always `false` 

That is happening because `isValid` selector in this place
https://github.com/erikras/redux-form/blob/master/src/createReduxForm.js#L705
is using `getFormState` that returns plain object so `registeredFields` here
https://github.com/erikras/redux-form/blob/master/src/selectors/isValid.js#L36
are plain object and `keys(registeredFields)` returns empty list from https://github.com/erikras/redux-form/blob/master/src/structure/immutable/keys.js#L3

After this change it seams to work as expected. 