### PR TITLE
use immutable structure for selectors

### DIFF
--- a/src/immutable/getFormAsyncErrors.js
+++ b/src/immutable/getFormAsyncErrors.js
@@ -1,4 +1,4 @@
 import createGetFormAsyncErrors from '../selectors/getFormAsyncErrors'
-import plain from '../structure/plain'
+import immutable from '../structure/immutable'
 
-export default createGetFormAsyncErrors(plain)
+export default createGetFormAsyncErrors(immutable)

--- a/src/immutable/hasSubmitFailed.js
+++ b/src/immutable/hasSubmitFailed.js
@@ -1,4 +1,4 @@
 import createHasSubmitFailed from '../selectors/hasSubmitFailed'
-import plain from '../structure/plain'
+import immutable from '../structure/immutable'
 
-export default createHasSubmitFailed(plain)
+export default createHasSubmitFailed(immutable)


### PR DESCRIPTION
I'm not quire sure if this is bug or not because i'm not using this selectors for anything, but I'm assuming that they should use `immutable` structure like other selectors. 

I ran on it while debugging issue from this PR https://github.com/erikras/redux-form/pull/3022
