### PR TITLE
Don't use initialConfig when checking immutableProps

### DIFF
--- a/src/__tests__/reduxForm.spec.js
+++ b/src/__tests__/reduxForm.spec.js
@@ -100,6 +100,37 @@ const describeReduxForm = (name, structure, combineReducers, expect) => {
       }).toNotThrow()
     })
 
+    it('should update without error when there is no config', () => {
+      const store = makeStore()
+      const Form = () => <div />
+      const Decorated = reduxForm()(Form)
+
+      class Container extends Component {
+        constructor(props) {
+          super(props)
+          this.state = {}
+        }
+
+        render() {
+          return (
+            <Provider store={store}>
+              <div>
+                <Decorated form='formname' foo={this.state.foo} />
+                <button onClick={() => this.setState({ foo: 'bar' })} />
+              </div>
+            </Provider>
+          )
+        }
+      }
+
+      const dom = TestUtils.renderIntoDocument(<Container />)
+
+      expect(() => {
+        const button = TestUtils.findRenderedDOMComponentWithTag(dom, 'button')
+        TestUtils.Simulate.click(button)
+      }).toNotThrow()
+    })
+
     it('should provide the correct props', () => {
       const props = propChecker({})
       expect(Object.keys(props).sort()).toEqual([

--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -305,7 +305,7 @@ const createReduxForm = structure => {
 
         shouldComponentUpdate(nextProps) {
           if (!this.props.pure) return true
-          const { immutableProps = [] } = initialConfig
+          const { immutableProps = [] } = config
           return Object.keys(nextProps).some(prop => {
             // useful to debug rerenders
             // if (!plain.deepEqual(this.props[ prop ], nextProps[ prop ])) {


### PR DESCRIPTION
This parameter may be undefined, as all configs can be defined via props.

Fixes #3048