### PR TITLE
Do not clear errors unless field is being removed from the form

### DIFF
--- a/src/__tests__/reducer.unregisterField.spec.js
+++ b/src/__tests__/reducer.unregisterField.spec.js
@@ -32,6 +32,28 @@ const describeUnregisterField = (reducer, expect, { fromJS }) => () => {
     })
   })
 
+  it('should not remove sync errors if the field is registered multiple times', () => {
+    const state = reducer(
+      fromJS({
+        foo: {
+          registeredFields: { bar: { name: 'bar', type: 'field', count: 2 } },
+          syncErrors: {
+            bar: 'Your bar needs more beer'
+          }
+        }
+      }),
+      unregisterField('foo', 'bar')
+    )
+    expect(state).toEqualMap({
+      foo: {
+        registeredFields: { bar: { name: 'bar', type: 'field', count: 1 } },
+        syncErrors: {
+          bar: 'Your bar needs more beer'
+        }
+      }
+    })
+  })
+
   it('should remove submit errors', () => {
     const state = reducer(
       fromJS({
@@ -46,6 +68,28 @@ const describeUnregisterField = (reducer, expect, { fromJS }) => () => {
     )
     expect(state).toEqualMap({
       foo: {}
+    })
+  })
+
+  it('should not remove submit errors if the field is registered multiple times', () => {
+    const state = reducer(
+      fromJS({
+        foo: {
+          registeredFields: { bar: { name: 'bar', type: 'field', count: 2 } },
+          submitErrors: {
+            bar: 'Your bar needs more beer'
+          }
+        }
+      }),
+      unregisterField('foo', 'bar')
+    )
+    expect(state).toEqualMap({
+      foo: {
+        registeredFields: { bar: { name: 'bar', type: 'field', count: 1 } },
+        submitErrors: {
+          bar: 'Your bar needs more beer'
+        }
+      }
     })
   })
 
@@ -66,6 +110,28 @@ const describeUnregisterField = (reducer, expect, { fromJS }) => () => {
     })
   })
 
+  it('should not remove async errors if the field is registered multiple times', () => {
+    const state = reducer(
+      fromJS({
+        foo: {
+          registeredFields: { bar: { name: 'bar', type: 'field', count: 2 } },
+          asyncErrors: {
+            bar: 'Your bar needs more beer'
+          }
+        }
+      }),
+      unregisterField('foo', 'bar')
+    )
+    expect(state).toEqualMap({  
+      foo: {
+        registeredFields: { bar: { name: 'bar', type: 'field', count: 1 } },
+        asyncErrors: {
+          bar: 'Your bar needs more beer'
+        }
+      }
+    })
+  })
+
   it('should remove sync warnings', () => {
     const state = reducer(
       fromJS({
@@ -80,6 +146,28 @@ const describeUnregisterField = (reducer, expect, { fromJS }) => () => {
     )
     expect(state).toEqualMap({
       foo: {}
+    })
+  })
+
+  it('should not remove sync warnings if the field is registered multiple times', () => {
+    const state = reducer(
+      fromJS({
+        foo: {
+          registeredFields: { bar: { name: 'bar', type: 'field', count: 2 } },
+          syncWarnings: {
+            bar: 'Your bar needs more beer'
+          }
+        }
+      }),
+      unregisterField('foo', 'bar')
+    )
+    expect(state).toEqualMap({
+      foo: {
+        registeredFields: { bar: { name: 'bar', type: 'field', count: 1 } },
+        syncWarnings: {
+          bar: 'Your bar needs more beer'
+        }
+      }
     })
   })
 

--- a/src/createReducer.js
+++ b/src/createReducer.js
@@ -444,15 +444,13 @@ const createReducer = structure => {
         if (deepEqual(getIn(result, 'registeredFields'), empty)) {
           result = deleteIn(result, 'registeredFields')
         }
-      } else {
-        field = setIn(field, 'count', count)
-        result = setIn(result, key, field)
-      }
-      if (destroyOnUnmount) {
         result = deleteInWithCleanUp(result, `syncErrors.${name}`)
         result = deleteInWithCleanUp(result, `submitErrors.${name}`)
         result = deleteInWithCleanUp(result, `asyncErrors.${name}`)
         result = deleteInWithCleanUp(result, `syncWarnings.${name}`)
+      } else {
+        field = setIn(field, 'count', count)
+        result = setIn(result, key, field)
       }
       return result
     },


### PR DESCRIPTION
Currently errors will be cleared every time an `UNREGISTER` action is fired even if the count is greater than 1.

This would cause the errors to get cleared even when there is still a form field on the page.
_you can see a demo of the error [here](https://codesandbox.io/s/ADjL8EGD1)_

This PR changes the behavior so that errors will only be cleared if the count is <= 0 and the field is actually being removed from the `registeredFields`
