### PR TITLE
Don't clear all asyncErrors on stopAsyncValidation

### DIFF
--- a/src/__tests__/reducer.stopAsyncValidation.spec.js
+++ b/src/__tests__/reducer.stopAsyncValidation.spec.js
@@ -111,56 +111,6 @@ const describeStopAsyncValidation = (reducer, expect, { fromJS }) => () => {
     })
   })
 
-  it('should unset field async errors on stopAsyncValidation', () => {
-    const state = reducer(
-      fromJS({
-        foo: {
-          values: {
-            bar: ['dirtyValue', 'otherDirtyValue']
-          },
-          initial: {
-            bar: ['initialValue', 'otherInitialValue']
-          },
-          asyncErrors: {
-            bar: ['async error 1', 'async error 2']
-          },
-          fields: {
-            bar: [
-              {
-                touched: true
-              },
-              {
-                touched: true
-              }
-            ]
-          },
-          asyncValidating: true
-        }
-      }),
-      stopAsyncValidation('foo')
-    )
-    expect(state).toEqualMap({
-      foo: {
-        values: {
-          bar: ['dirtyValue', 'otherDirtyValue']
-        },
-        initial: {
-          bar: ['initialValue', 'otherInitialValue']
-        },
-        fields: {
-          bar: [
-            {
-              touched: true
-            },
-            {
-              touched: true
-            }
-          ]
-        }
-      }
-    })
-  })
-
   it('should allow multiple errors on same field', () => {
     const state = reducer(
       fromJS({

--- a/src/createReducer.js
+++ b/src/createReducer.js
@@ -368,12 +368,9 @@ const createReducer = structure => {
         }
         if (Object.keys(fieldErrors).length) {
           result = setIn(result, 'asyncErrors', fromJS(fieldErrors))
-        } else {
-          result = deleteIn(result, 'asyncErrors')
         }
       } else {
         result = deleteIn(result, 'error')
-        result = deleteIn(result, 'asyncErrors')
       }
       return result
     },


### PR DESCRIPTION
Fixes https://github.com/erikras/redux-form/issues/2953

The reason this makes sense to do, is that the field specific asyncErrors are cleared already by events like CHANGE, so it's not necessary to clear all asyncErrors in the STOP_ASYNC_VALIDATION action.

This allows us to have more than one field with async validation in the same form. When one field fails async validation but then another field passes, it no longer clears asyncErrors for the whole form, therefore setting the first field to a valid state incorrectly.