### PR TITLE
Use same empty object for syncErrors and syncWarnings

### DIFF
--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -700,8 +700,8 @@ const createReduxForm = structure => {
 
           const pristine = shouldResetValues || deepEqual(initial, values)
           const asyncErrors = getIn(formState, 'asyncErrors')
-          const syncErrors = getIn(formState, 'syncErrors') || {}
-          const syncWarnings = getIn(formState, 'syncWarnings') || {}
+          const syncErrors = getIn(formState, 'syncErrors') || empty
+          const syncWarnings = getIn(formState, 'syncWarnings') || empty
           const registeredFields = getIn(formState, 'registeredFields')
           const valid = isValid(form, getFormState, false)(state)
           const validExceptSubmit = isValid(form, getFormState, true)(state)


### PR DESCRIPTION
I noticed that my form and its fields were unnecessarily re-rendering upon any changes to my store. I realized that React Redux's shallow comparison was failing when comparing `syncWarnings` between states. This is because Redux Form's connector returns a new object every time when there are no `syncWarnings` or `syncErrors`.

Changing this code to use the `empty` object makes shallow comparison work properly, reducing unnecessary re-renders significantly.