### PR TITLE
Fix initialize with keepDirty and empty array creates an empty object in form values (#3095)

### DIFF
--- a/src/__tests__/reducer.initialize.spec.js
+++ b/src/__tests__/reducer.initialize.spec.js
@@ -446,6 +446,52 @@ const describeInitialize = (reducer, expect, { fromJS }) => () => {
     })
   })
 
+  it('should not create empty object if new initial value is an empty array and keepDirty is set', () => {
+    const before = {
+      myForm: {
+        registeredFields: {
+          myList: { name: 'myList', type: 'Field', count: 0 },
+          'myList.0.name': { name: 'myList.0.name', type: 'Field', count: 0 }
+        },
+        values: {
+          myList: []
+        },
+        initial: {
+          myList: [{ name: '' }]
+        }
+      }
+    }
+
+    const actionInitialValues = {
+      myList: []
+    }
+    const actionKeepDirty = true
+
+    const state = reducer(
+      fromJS(before),
+      initialize('myForm', actionInitialValues, actionKeepDirty)
+    )
+
+    expect(state).toEqualMap(
+      {
+        myForm: {
+          registeredFields: {
+            myList: { name: 'myList', type: 'Field', count: 0 },
+            'myList.0.name': { name: 'myList.0.name', type: 'Field', count: 0 }
+          },
+          values: {
+            myList: []
+          },
+          initial: {
+            myList: []
+          }
+        }
+      },
+      null,
+      2
+    )
+  })
+
   it('should add new pristine values at the root level', () => {
     const newInitial = {
       oldField: 'oldValue',

--- a/src/createReducer.js
+++ b/src/createReducer.js
@@ -301,7 +301,13 @@ const createReducer = structure => {
             if (deepEqual(previousValue, previousInitialValue)) {
               // Overwrite the old pristine value with the new pristine value
               const newInitialValue = getIn(newInitialValues, name)
-              newValues = setIn(newValues, name, newInitialValue)
+
+              // This check prevents any 'setIn' call that would create useless
+              // nested objects, since the path to the new field value would
+              // evaluate to the same (especially for undefined values)
+              if (getIn(newValues, name) !== newInitialValue) {
+                newValues = setIn(newValues, name, newInitialValue)
+              }
             }
           })
 


### PR DESCRIPTION
Hi, I made this fix for #3095.

It prevents the initialize action with keepDirty set to true to create 'empty objects' `{}` uselessly if the field to keep pristine has to change to `undefined`. This happens because of the `setIn` function that creates all the objects required for the nested path.

Example : the initialize action in the new test sets the value of `myList.0.myField` to same as the one in `{myList: []}`.
Before the fix, it created an empty object in the values `{myList: [{}]}`, which for ReduxForm is the same as `{myList: [{myField: undefined}]}`.
Now it leaves the values like this `{myList: []}`
   