### PR TITLE
Extend React Peer dependency to version 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "webpack-bundle-analyzer": "^2.7.0"
   },
   "peerDependencies": {
-    "react": "^15.0.0",
+    "react": "^15.0.0-0 || ^16.0.0-0",
     "react-redux": "^4.3.0 || ^5.0.0",
     "redux": "^3.0.0"
   },


### PR DESCRIPTION
Redux-form creates a duplicate react install in react-native due to the React 15 peer dependency

Taken from [react-redux](https://github.com/reactjs/react-redux/blob/master/package.json#L112)

Tested on React Native 45

Ciaran

