### PR TITLE
Revert "Async validation support for multiple fields"

### DIFF
--- a/examples/asyncValidation/src/AsyncValidation.md
+++ b/examples/asyncValidation/src/AsyncValidation.md
@@ -43,4 +43,3 @@ browser to view the example running locally on your machine.
 ## How to use the form below:
 
 * Usernames that will _fail_ validation: `john`, `paul`, `george` or `ringo`.
-* Company names that will _fail_ validation: `google`, `amazon` or `tesla`.

--- a/examples/asyncValidation/src/AsyncValidationForm.js
+++ b/examples/asyncValidation/src/AsyncValidationForm.js
@@ -34,12 +34,6 @@ const AsyncValidationForm = props => {
         label="Username"
       />
       <Field
-        name="companyname"
-        type="text"
-        component={renderField}
-        label="Companyname"
-      />
-      <Field
         name="password"
         type="password"
         component={renderField}
@@ -61,5 +55,5 @@ export default reduxForm({
   form: 'asyncValidation', // a unique identifier for this form
   validate,
   asyncValidate,
-  asyncBlurFields: ['username', 'companyname']
+  asyncBlurFields: ['username']
 })(AsyncValidationForm)

--- a/examples/asyncValidation/src/asyncValidate.js
+++ b/examples/asyncValidation/src/asyncValidate.js
@@ -1,33 +1,12 @@
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
 
-function composeAsyncValidators(validatorFns) {
-  return async (values, dispatch, props, field) => {
-    const validatorFn = validatorFns[field]
-    await validatorFn(values, dispatch, props, field);
-  };
+const asyncValidate = (values /*, dispatch */) => {
+  return sleep(1000).then(() => {
+    // simulate server latency
+    if (['john', 'paul', 'george', 'ringo'].includes(values.username)) {
+      throw { username: 'That username is taken' }
+    }
+  })
 }
 
-const usernameValidate = (values /*, dispatch */) => {
-  return sleep(1000).then(() => { // simulate server latency
-    console.log('asyncValidate username')
-    if (['john', 'paul', 'george', 'ringo'].includes(values.username)) {
-      throw { username: 'That username is taken' };
-    }
-  });
-};
-
-const companynameValidate = (values /*, dispatch */) => {
-  return sleep(1000).then(() => { // simulate server latency
-    console.log('asyncValidate companyname')
-    if (['google','amazon','tesla'].includes(values.companyname)) {
-      throw { companyname: 'That companyname is taken' };
-    }
-  });
-};
-
-const asyncValidate = composeAsyncValidators({
-  username:usernameValidate,
-  companyname:companynameValidate
-});
-
-export default asyncValidate;
+export default asyncValidate

--- a/src/createReducer.js
+++ b/src/createReducer.js
@@ -379,13 +379,8 @@ function createReducer<M, L>(structure: Structure<M, L>) {
         if (_error) {
           result = setIn(result, 'error', _error)
         }
-        const fields = Object.keys(fieldErrors)
-        if(fields.length) {
-            let asyncErrors = getIn(result, 'asyncErrors') || /* if undefined */ fromJS({})
-            fields.forEach(field => {
-              asyncErrors = setIn(asyncErrors, `${field}`, fromJS(fieldErrors[field]))
-            })
-            result = setIn(result, 'asyncErrors', asyncErrors)
+        if (Object.keys(fieldErrors).length) {
+          result = setIn(result, 'asyncErrors', fromJS(fieldErrors))
         }
       } else {
         result = deleteIn(result, 'error')


### PR DESCRIPTION
Reverts erikras/redux-form#3134

I changed my mind. It shouldn't do this, as this means there is no good way to _clear_ an async validation error.

The field-level async validation that #3134 was moving towards will require a separate action to set the errors.