### PR TITLE
Add selector for form error (_error)

### DIFF
--- a/src/selectors/__tests__/getFormError.spec.js
+++ b/src/selectors/__tests__/getFormError.spec.js
@@ -1,0 +1,69 @@
+import plain from '../../structure/plain'
+import immutable from '../../structure/immutable'
+import addExpectations from '../../__tests__/addExpectations'
+import plainExpectations from '../../structure/plain/expectations'
+import createGetFormError from '../getFormError'
+import immutableExpectations from '../../structure/immutable/expectations'
+
+const describeGetFormError = (name, structure, expect) => {
+  const getFormError = createGetFormError(structure)
+
+  const { fromJS, getIn } = structure
+
+  describe(name, () => {
+    it('should return a function', () => {
+      expect(createGetFormError('foo')).toBeA('function')
+    })
+
+    it('should get the form value from state', () => {
+      expect(
+        getFormError('foo')(
+          fromJS({
+            form: {
+              foo: {
+                _error: 'scary form error'
+              }
+            }
+          })
+        )
+      ).toEqualMap('scary form error')
+    })
+
+    it('should return undefined if there is no form error', () => {
+      expect(
+        getFormError('foo')(
+          fromJS({
+            form: {
+              foo: {}
+            }
+          })
+        )
+      ).toEqual(undefined)
+    })
+
+    it('should use getFormState if provided', () => {
+      expect(
+        getFormError('foo', state => getIn(state, 'someOtherSlice'))(
+          fromJS({
+            someOtherSlice: {
+              foo: {
+                _error: 'big form error'
+              }
+            }
+          })
+        )
+      ).toEqualMap('big form error')
+    })
+  })
+}
+
+describeGetFormError(
+  'selector.getFormError.plain',
+  plain,
+  addExpectations(plainExpectations)
+)
+describeGetFormError(
+  'selector.getFormError.immutable',
+  immutable,
+  addExpectations(immutableExpectations)
+)

--- a/src/selectors/getFormError.js
+++ b/src/selectors/getFormError.js
@@ -1,0 +1,14 @@
+// @flow
+import type { Structure, GetFormState } from '../types'
+import type { GetFormAsyncErrorsInterface } from './getFormAsyncErrors.types.js.flow'
+
+const createGetFormError = ({ getIn }: Structure<*, *>) => (
+  form: string,
+  getFormState: ?GetFormState
+): GetFormAsyncErrorsInterface => (state: any) => {
+  const nonNullGetFormState: GetFormState = getFormState || (state => getIn(state, 'form'))
+
+  return getIn(nonNullGetFormState(state), `${form}._error`)
+}
+
+export default createGetFormError


### PR DESCRIPTION
Provides a selector to retrieve the "_error" key for a given form error.

This provides a solution to bug #2872