### PR TITLE
Docs: Add note indicating that FormValueSelector can only be used as mapStateToProps if selecting multiple fields

### DIFF
--- a/docs/api/FormValueSelector.md
+++ b/docs/api/FormValueSelector.md
@@ -80,7 +80,7 @@ connect(
 ### 3. Use the selector as `mapStateToProps`
 
 If you don't need any other props from the state, the selector itself works just fine as 
-`mapStateToProps`.
+`mapStateToProps` if you are selecting multiple fields.
 
 ```javascript
 connect(


### PR DESCRIPTION
Might help others avoid a bit of confusion like I encountered in #3184.