### PR TITLE
Remove custom prop from fieldPropTypes

### DIFF
--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -83,8 +83,7 @@ export const fieldMetaPropTypes = {
 
 export const fieldPropTypes = {
   input: shape(fieldInputPropTypes).isRequired,
-  meta: shape(fieldMetaPropTypes).isRequired,
-  custom: object.isRequired
+  meta: shape(fieldMetaPropTypes).isRequired
 }
 
 export default formPropTypes


### PR DESCRIPTION
The `custom` object is not included in the props given to a decorated form component; instead custom props are included directly in the props object. As `custom` is nevertheless marked with `isRequired` in `fieldPropTypes`, the proptype isn't actually usable as it'll always fail.