### PR TITLE
GetIn Immutable State Support

### DIFF
--- a/src/structure/plain/__tests__/getIn.spec.js
+++ b/src/structure/plain/__tests__/getIn.spec.js
@@ -4,7 +4,7 @@ import { Map } from 'immutable';
 
 describe('structure.plain.getIn', () => {
 
-  describe('Immutable Tests', () => {
+  describe('Non-Immutable Object Tests', () => {
     it('should return undefined if state is undefined', () => {
       expect(getIn(undefined, 'dog')).toBe(undefined)
     })
@@ -80,7 +80,7 @@ describe('structure.plain.getIn', () => {
     })
   });
 
-  describe('Immutable Tests', () => {
+  describe('Immutable Object Tests', () => {
     it('should get shallow values', () => {
       expect(getIn(Map({foo: 'bar'}), 'foo')).toBe('bar')
       expect(getIn(Map({foo: 42}), 'foo')).toBe(42)

--- a/src/structure/plain/__tests__/getIn.spec.js
+++ b/src/structure/plain/__tests__/getIn.spec.js
@@ -1,78 +1,142 @@
 import expect from 'expect'
 import getIn from '../getIn'
+import { Map } from 'immutable';
 
 describe('structure.plain.getIn', () => {
-  it('should return undefined if state is undefined', () => {
-    expect(getIn(undefined, 'dog')).toBe(undefined)
-  })
 
-  it('should return undefined if any step on the path is undefined', () => {
-    expect(
-      getIn(
-        {
-          a: {
-            b: {}
-          }
-        },
-        'a.b.c'
-      )
-    ).toBe(undefined)
-  })
+  describe('Immutable Tests', () => {
+    it('should return undefined if state is undefined', () => {
+      expect(getIn(undefined, 'dog')).toBe(undefined)
+    })
 
-  it('should get shallow values', () => {
-    expect(getIn({ foo: 'bar' }, 'foo')).toBe('bar')
-    expect(getIn({ foo: 42 }, 'foo')).toBe(42)
-    expect(getIn({ foo: false }, 'foo')).toBe(false)
-  })
+    it('should return undefined if any step on the path is undefined', () => {
+      expect(
+        getIn(
+          {
+            a: {
+              b: {}
+            }
+          },
+          'a.b.c'
+        )
+      ).toBe(undefined)
+    })
 
-  it('should get deep values', () => {
-    const state = {
-      foo: {
-        bar: ['baz', { dog: 42 }]
+    it('should get shallow values', () => {
+      expect(getIn({foo: 'bar'}, 'foo')).toBe('bar')
+      expect(getIn({foo: 42}, 'foo')).toBe(42)
+      expect(getIn({foo: false}, 'foo')).toBe(false)
+    })
+
+    it('should get deep values', () => {
+      const state = {
+        foo: {
+          bar: ['baz', {dog: 42}]
+        }
       }
-    }
-    expect(getIn(state, 'foo.bar[0]')).toBe('baz')
-    expect(getIn(state, 'foo.bar[1].dog')).toBe(42)
-  })
+      expect(getIn(state, 'foo.bar[0]')).toBe('baz')
+      expect(getIn(state, 'foo.bar[1].dog')).toBe(42)
+    })
 
-  it('should get a value nested 1 level', () => {
-    expect(getIn({ foo: { bar: 42 } }, 'foo.bar')).toBe(42)
-  })
+    it('should get a value nested 1 level', () => {
+      expect(getIn({foo: {bar: 42}}, 'foo.bar')).toBe(42)
+    })
 
-  it('should get a value nested 2 levels', () => {
-    expect(getIn({ foo: { bar: { baz: 42 } } }, 'foo.bar.baz')).toBe(42)
-  })
+    it('should get a value nested 2 levels', () => {
+      expect(getIn({foo: {bar: {baz: 42}}}, 'foo.bar.baz')).toBe(42)
+    })
 
-  it('should get a value nested 3 levels', () => {
-    expect(
-      getIn({ foo: { bar: { baz: { yolanda: 42 } } } }, 'foo.bar.baz.yolanda')
-    ).toBe(42)
-  })
+    it('should get a value nested 3 levels', () => {
+      expect(
+        getIn({foo: {bar: {baz: {yolanda: 42}}}}, 'foo.bar.baz.yolanda')
+      ).toBe(42)
+    })
 
-  it('should return undefined if the requested level does not exist', () => {
-    expect(getIn({}, 'foo')).toBe(undefined)
-    expect(getIn({}, 'foo.bar')).toBe(undefined)
-    expect(getIn({}, 'foo.bar.baz')).toBe(undefined)
-    expect(getIn({}, 'foo.bar.baz.yolanda')).toBe(undefined)
-  })
+    it('should return undefined if the requested level does not exist', () => {
+      expect(getIn({}, 'foo')).toBe(undefined)
+      expect(getIn({}, 'foo.bar')).toBe(undefined)
+      expect(getIn({}, 'foo.bar.baz')).toBe(undefined)
+      expect(getIn({}, 'foo.bar.baz.yolanda')).toBe(undefined)
+    })
 
-  it('should return undefined for invalid/empty path', () => {
-    expect(getIn({ foo: 42 }, undefined)).toBe(undefined)
-    expect(getIn({ foo: 42 }, null)).toBe(undefined)
-    expect(getIn({ foo: 42 }, '')).toBe(undefined)
-  })
+    it('should return undefined for invalid/empty path', () => {
+      expect(getIn({foo: 42}, undefined)).toBe(undefined)
+      expect(getIn({foo: 42}, null)).toBe(undefined)
+      expect(getIn({foo: 42}, '')).toBe(undefined)
+    })
 
-  it('should get string keys on arrays', () => {
-    const array = [1, 2, 3]
-    array.stringKey = 'hello'
-    const state = {
-      foo: {
-        bar: array
+    it('should get string keys on arrays', () => {
+      const array = [1, 2, 3]
+      array.stringKey = 'hello'
+      const state = {
+        foo: {
+          bar: array
+        }
       }
-    }
-    expect(getIn(state, 'foo.bar[0]')).toBe(1)
-    expect(getIn(state, 'foo.bar[1]')).toBe(2)
-    expect(getIn(state, 'foo.bar[2]')).toBe(3)
-    expect(getIn(state, 'foo.bar.stringKey')).toBe('hello')
-  })
+      expect(getIn(state, 'foo.bar[0]')).toBe(1)
+      expect(getIn(state, 'foo.bar[1]')).toBe(2)
+      expect(getIn(state, 'foo.bar[2]')).toBe(3)
+      expect(getIn(state, 'foo.bar.stringKey')).toBe('hello')
+    })
+  });
+
+  describe('Immutable Tests', () => {
+    it('should get shallow values', () => {
+      expect(getIn(Map({foo: 'bar'}), 'foo')).toBe('bar')
+      expect(getIn(Map({foo: 42}), 'foo')).toBe(42)
+      expect(getIn(Map({foo: false}), 'foo')).toBe(false)
+    })
+
+    it('should get deep values', () => {
+      const state = Map({
+        foo: {
+          bar: ['baz', {dog: 42}]
+        }
+      })
+      expect(getIn(state, 'foo.bar[0]')).toBe('baz')
+      expect(getIn(state, 'foo.bar[1].dog')).toBe(42)
+    })
+
+    it('should get a value nested 1 level', () => {
+      expect(getIn(Map({foo: {bar: 42}}), 'foo.bar')).toBe(42)
+    })
+
+    it('should get a value nested 2 levels', () => {
+      expect(getIn(Map({foo: {bar: {baz: 42}}}), 'foo.bar.baz')).toBe(42)
+    })
+
+    it('should get a value nested 3 levels', () => {
+      expect(
+        getIn(Map({foo: {bar: {baz: {yolanda: 42}}}}), 'foo.bar.baz.yolanda')
+      ).toBe(42)
+    })
+
+    it('should return undefined if the requested level does not exist', () => {
+      expect(getIn(Map({}), 'foo')).toBe(undefined)
+      expect(getIn(Map({}), 'foo.bar')).toBe(undefined)
+      expect(getIn(Map({}), 'foo.bar.baz')).toBe(undefined)
+      expect(getIn(Map({}), 'foo.bar.baz.yolanda')).toBe(undefined)
+    })
+
+    it('should return undefined for invalid/empty path', () => {
+      expect(getIn(Map({foo: 42}), undefined)).toBe(undefined)
+      expect(getIn(Map({foo: 42}), null)).toBe(undefined)
+      expect(getIn(Map({foo: 42}), '')).toBe(undefined)
+    })
+
+    it('should get string keys on arrays', () => {
+      const array = [1, 2, 3]
+      array.stringKey = 'hello'
+      const state = Map({
+        foo: {
+          bar: array
+        }
+      })
+      expect(getIn(state, 'foo.bar[0]')).toBe(1)
+      expect(getIn(state, 'foo.bar[1]')).toBe(2)
+      expect(getIn(state, 'foo.bar[2]')).toBe(3)
+      expect(getIn(state, 'foo.bar.stringKey')).toBe('hello')
+    })
+  });
+
 })

--- a/src/structure/plain/__tests__/getIn.spec.js
+++ b/src/structure/plain/__tests__/getIn.spec.js
@@ -1,9 +1,8 @@
 import expect from 'expect'
 import getIn from '../getIn'
-import { Map } from 'immutable';
+import { Map } from 'immutable'
 
 describe('structure.plain.getIn', () => {
-
   describe('Non-Immutable Object Tests', () => {
     it('should return undefined if state is undefined', () => {
       expect(getIn(undefined, 'dog')).toBe(undefined)
@@ -23,15 +22,15 @@ describe('structure.plain.getIn', () => {
     })
 
     it('should get shallow values', () => {
-      expect(getIn({foo: 'bar'}, 'foo')).toBe('bar')
-      expect(getIn({foo: 42}, 'foo')).toBe(42)
-      expect(getIn({foo: false}, 'foo')).toBe(false)
+      expect(getIn({ foo: 'bar' }, 'foo')).toBe('bar')
+      expect(getIn({ foo: 42 }, 'foo')).toBe(42)
+      expect(getIn({ foo: false }, 'foo')).toBe(false)
     })
 
     it('should get deep values', () => {
       const state = {
         foo: {
-          bar: ['baz', {dog: 42}]
+          bar: ['baz', { dog: 42 }]
         }
       }
       expect(getIn(state, 'foo.bar[0]')).toBe('baz')
@@ -39,16 +38,16 @@ describe('structure.plain.getIn', () => {
     })
 
     it('should get a value nested 1 level', () => {
-      expect(getIn({foo: {bar: 42}}, 'foo.bar')).toBe(42)
+      expect(getIn({ foo: { bar: 42 } }, 'foo.bar')).toBe(42)
     })
 
     it('should get a value nested 2 levels', () => {
-      expect(getIn({foo: {bar: {baz: 42}}}, 'foo.bar.baz')).toBe(42)
+      expect(getIn({ foo: { bar: { baz: 42 } } }, 'foo.bar.baz')).toBe(42)
     })
 
     it('should get a value nested 3 levels', () => {
       expect(
-        getIn({foo: {bar: {baz: {yolanda: 42}}}}, 'foo.bar.baz.yolanda')
+        getIn({ foo: { bar: { baz: { yolanda: 42 } } } }, 'foo.bar.baz.yolanda')
       ).toBe(42)
     })
 
@@ -60,9 +59,9 @@ describe('structure.plain.getIn', () => {
     })
 
     it('should return undefined for invalid/empty path', () => {
-      expect(getIn({foo: 42}, undefined)).toBe(undefined)
-      expect(getIn({foo: 42}, null)).toBe(undefined)
-      expect(getIn({foo: 42}, '')).toBe(undefined)
+      expect(getIn({ foo: 42 }, undefined)).toBe(undefined)
+      expect(getIn({ foo: 42 }, null)).toBe(undefined)
+      expect(getIn({ foo: 42 }, '')).toBe(undefined)
     })
 
     it('should get string keys on arrays', () => {
@@ -78,19 +77,19 @@ describe('structure.plain.getIn', () => {
       expect(getIn(state, 'foo.bar[2]')).toBe(3)
       expect(getIn(state, 'foo.bar.stringKey')).toBe('hello')
     })
-  });
+  })
 
   describe('Immutable Object Tests', () => {
     it('should get shallow values', () => {
-      expect(getIn(Map({foo: 'bar'}), 'foo')).toBe('bar')
-      expect(getIn(Map({foo: 42}), 'foo')).toBe(42)
-      expect(getIn(Map({foo: false}), 'foo')).toBe(false)
+      expect(getIn(Map({ foo: 'bar' }), 'foo')).toBe('bar')
+      expect(getIn(Map({ foo: 42 }), 'foo')).toBe(42)
+      expect(getIn(Map({ foo: false }), 'foo')).toBe(false)
     })
 
     it('should get deep values', () => {
       const state = Map({
         foo: {
-          bar: ['baz', {dog: 42}]
+          bar: ['baz', { dog: 42 }]
         }
       })
       expect(getIn(state, 'foo.bar[0]')).toBe('baz')
@@ -98,16 +97,19 @@ describe('structure.plain.getIn', () => {
     })
 
     it('should get a value nested 1 level', () => {
-      expect(getIn(Map({foo: {bar: 42}}), 'foo.bar')).toBe(42)
+      expect(getIn(Map({ foo: { bar: 42 } }), 'foo.bar')).toBe(42)
     })
 
     it('should get a value nested 2 levels', () => {
-      expect(getIn(Map({foo: {bar: {baz: 42}}}), 'foo.bar.baz')).toBe(42)
+      expect(getIn(Map({ foo: { bar: { baz: 42 } } }), 'foo.bar.baz')).toBe(42)
     })
 
     it('should get a value nested 3 levels', () => {
       expect(
-        getIn(Map({foo: {bar: {baz: {yolanda: 42}}}}), 'foo.bar.baz.yolanda')
+        getIn(
+          Map({ foo: { bar: { baz: { yolanda: 42 } } } }),
+          'foo.bar.baz.yolanda'
+        )
       ).toBe(42)
     })
 
@@ -119,9 +121,9 @@ describe('structure.plain.getIn', () => {
     })
 
     it('should return undefined for invalid/empty path', () => {
-      expect(getIn(Map({foo: 42}), undefined)).toBe(undefined)
-      expect(getIn(Map({foo: 42}), null)).toBe(undefined)
-      expect(getIn(Map({foo: 42}), '')).toBe(undefined)
+      expect(getIn(Map({ foo: 42 }), undefined)).toBe(undefined)
+      expect(getIn(Map({ foo: 42 }), null)).toBe(undefined)
+      expect(getIn(Map({ foo: 42 }), '')).toBe(undefined)
     })
 
     it('should get string keys on arrays', () => {
@@ -137,6 +139,5 @@ describe('structure.plain.getIn', () => {
       expect(getIn(state, 'foo.bar[2]')).toBe(3)
       expect(getIn(state, 'foo.bar.stringKey')).toBe('hello')
     })
-  });
-
+  })
 })

--- a/src/structure/plain/getIn.js
+++ b/src/structure/plain/getIn.js
@@ -1,5 +1,6 @@
 // @flow
 import { toPath } from 'lodash'
+import Immutable from 'immutable';
 
 const getIn = (state: Object | Array<*>, field: string): any => {
   if (!state) {
@@ -12,9 +13,13 @@ const getIn = (state: Object | Array<*>, field: string): any => {
     return undefined
   }
 
+  if (Immutable.Iterable.isIterable(state)) {
+    state = state.toJSON();
+  }
+
   let result: any = state
   for (let i = 0; i < length && result; ++i) {
-    result = result[path[i]]
+    result = result[path[i]];
   }
 
   return result

--- a/src/structure/plain/getIn.js
+++ b/src/structure/plain/getIn.js
@@ -1,6 +1,6 @@
 // @flow
 import { toPath } from 'lodash'
-import Immutable from 'immutable';
+import Immutable from 'immutable'
 
 const getIn = (state: Object | Array<*>, field: string): any => {
   if (!state) {

--- a/src/structure/plain/getIn.js
+++ b/src/structure/plain/getIn.js
@@ -14,12 +14,12 @@ const getIn = (state: Object | Array<*>, field: string): any => {
   }
 
   if (Immutable.Iterable.isIterable(state)) {
-    state = state.toJSON();
+    state = state.toJSON()
   }
 
   let result: any = state
   for (let i = 0; i < length && result; ++i) {
-    result = result[path[i]];
+    result = result[path[i]]
   }
 
   return result

--- a/src/structure/plain/getIn.js
+++ b/src/structure/plain/getIn.js
@@ -1,6 +1,6 @@
 // @flow
 import { toPath } from 'lodash'
-import Immutable from 'immutable'
+import { Iterable } from 'immutable'
 
 const getIn = (state: Object | Array<*>, field: string): any => {
   if (!state) {
@@ -13,7 +13,7 @@ const getIn = (state: Object | Array<*>, field: string): any => {
     return undefined
   }
 
-  if (Immutable.Iterable.isIterable(state)) {
+  if (Iterable.isIterable(state)) {
     state = state.toJSON()
   }
 


### PR DESCRIPTION
- Fix for the issue I submitted yesterday: #3206 
- The `getIn` function now has support for states to be passed in that are Immutable.
- This is a large desire because redux stores created from the `redux-immutable` package will not work with `redux-form` when trying to pull values from individual form elements.
- This is because the immutable types don't support the syntax `immutableMap["some-key"]` and instead the developer must use: `immutableMap.get("some-key")`
- This fixes that issue.

