### PR TITLE
Docs: add meta.submitFailed to fieldArray

### DIFF
--- a/docs/api/FieldArray.md
+++ b/docs/api/FieldArray.md
@@ -200,6 +200,10 @@ is tracking for you.
 > `true` if the all of the fields in the field array are the same as their initialized
 > value. Opposite of `dirty`.
 
+#### `meta.submitFailed : boolean`
+
+> `true` if form submission has failed for any reason
+
 #### `meta.submitting : boolean`
 
 > `true` if the field is currently being submitted


### PR DESCRIPTION
Adding docs for https://github.com/erikras/redux-form/blob/0183d43a19e52815e1b7870ac4f7ddd719ad97c7/src/createFieldArrayProps.js#L22

This property is already used in the fieldArray example, as pointed out in #3123