### PR TITLE
Don't set submitSucceeded on promise rejection

### DIFF
--- a/src/handleSubmit.js
+++ b/src/handleSubmit.js
@@ -68,7 +68,7 @@ const handleSubmit = (
             const error =
               submitError instanceof SubmissionError
                 ? submitError.errors
-                : undefined
+                : {}
             stopSubmit(error)
             setSubmitFailed(...fields)
             if (onSubmitFail) {


### PR DESCRIPTION
From #2260, we see that there's an issue when the `onSubmit` method returns a rejected Promise.

When `onSubmit` is called and return a rejected promise, the event **STOP_SUBMIT** sets `submitSucceeded` to `true` before that **SET_SUBMIT_FAILED** sets it to `false` and `submitFailed` to `true`

`submitSucceded` should not pass to `true`, so here I pass an empty object as error to tell the reducer that there were an error.