### PR TITLE
Switched from isNan to typeof

### DIFF
--- a/src/structure/plain/setIn.js
+++ b/src/structure/plain/setIn.js
@@ -17,7 +17,7 @@ const setInWithPath = (
   const next = setInWithPath(firstState, value, path, pathIndex + 1)
 
   if (!state) {
-    if (isNaN(first)) {
+    if (typeof first !== 'number') {
       return { [first]: next }
     }
     const initialized = []


### PR DESCRIPTION
I noticed an issue when using `redux-form`. I was creating a form with field names that were IDs that were long numbers. This stores `fields` as an array rather than an object. The trouble with this is that the IDs were large enough to overflow the max array size.Cause crashing within `deleteIn` because there is a loop dependent on the array lengths and the array lengths for the arrays created from these IDs were incredibly high. I am not sure of the motivation of using `isNaN` here but switching to `typeof` resolves this issue. 