### PR TITLE
Accept function as first argument in form value selector

### DIFF
--- a/src/createFormValues.js
+++ b/src/createFormValues.js
@@ -7,29 +7,9 @@ import type { Structure, ReactContext } from './types'
 import type { FormValuesInterface, PropPath } from './formValues.types.js.flow'
 
 const createValues = ({ getIn }: Structure<*, *>): FormValuesInterface => (
-  firstArg: string | Object,
+  firstArg: string | Object | Function,
   ...rest: string[]
 ) => {
-  let valuesMap: PropPath[]
-
-  if (typeof firstArg === 'string') {
-    valuesMap = [firstArg, ...rest].map((k: string): PropPath => ({
-      prop: k,
-      path: k
-    }))
-  } else {
-    const config: Object = firstArg
-    valuesMap = Object.keys(config).map(k => ({
-      prop: k,
-      path: config[k]
-    }))
-  }
-  if (!valuesMap.length) {
-    throw new Error(
-      'formValues(): You must specify values to get as formValues(name1, name2, ...) or formValues({propName1: propPath1, ...})'
-    )
-  }
-
   // create a class that reads current form name and creates a selector
   // return
   return (Component: ReactClass<*>): ReactClass<*> => {
@@ -43,6 +23,25 @@ const createValues = ({ getIn }: Structure<*, *>): FormValuesInterface => (
         if (!context._reduxForm) {
           throw new Error(
             'formValues() must be used inside a React tree decorated with reduxForm()'
+          )
+        }
+        let valuesMap: PropPath[]
+        const resolvedFirstArg: string | Object = typeof firstArg === 'function' ? firstArg(props) : firstArg
+        if (typeof resolvedFirstArg === 'string') {
+          valuesMap = [resolvedFirstArg, ...rest].map((k: string): PropPath => ({
+            prop: k,
+            path: k
+          }))
+        } else {
+          const config: Object = resolvedFirstArg
+          valuesMap = Object.keys(config).map(k => ({
+            prop: k,
+            path: config[k]
+          }))
+        }
+        if (!valuesMap.length) {
+          throw new Error(
+            'formValues(): You must specify values to get as formValues(name1, name2, ...) or formValues({propName1: propPath1, ...})'
           )
         }
         const formValuesSelector = (_, { sectionPrefix }) => {


### PR DESCRIPTION
We run into a situation where we needed to retrieve a form field value of a form field value we didn't know, but was passed in by prop. To handle this in an appropriate way, we suggest to also accept functions as a first argument of the formValues selector which will resolve the according form field values.

(This code has not been tested, it should act as a proposal. I can try to run it and adjust tests if we see that there is a chance to have this in the master.)