### PR TITLE
Don't use "import * as React" to avoid deprecation warnings

### DIFF
--- a/src/createFormValues.js
+++ b/src/createFormValues.js
@@ -1,8 +1,9 @@
 // @flow
-import * as React from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import prefixName from './util/prefixName'
+import type { ComponentType } from 'react';
 import type { Structure, ReactContext } from './types'
 import type { FormValuesInterface, PropPath } from './formValues.types'
 
@@ -32,10 +33,10 @@ const createValues = ({ getIn }: Structure<*, *>): FormValuesInterface => (
 
   // create a class that reads current form name and creates a selector
   // return
-  return (Component: React.ComponentType<*>): React.ComponentType<*> => {
+  return (Component: ComponentType<*>): ComponentType<*> => {
     class FormValues extends React.Component<Object> {
       context: ReactContext
-      Component: React.ComponentType<*>
+      Component: ComponentType<*>
 
       constructor(props: Object, context: ReactContext) {
         super(props, context)

--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -1,5 +1,4 @@
 // @flow
-import * as React from 'react'
 import hoistStatics from 'hoist-non-react-statics'
 import isPromise from 'is-promise'
 import { mapValues, merge } from 'lodash'
@@ -18,6 +17,7 @@ import handleSubmit from './handleSubmit'
 import createIsValid from './selectors/isValid'
 import plain from './structure/plain'
 import getDisplayName from './util/getDisplayName'
+import type { ComponentType } from 'react'
 import type { Dispatch } from 'redux'
 import type {
   ConnectedComponent,
@@ -276,9 +276,9 @@ const createReduxForm = (structure: Structure<*, *>) => {
       ...initialConfig
     }
 
-    return (WrappedComponent: React.ComponentType<*>) => {
+    return (WrappedComponent: ComponentType<*>) => {
       class Form extends Component<Props> {
-        static WrappedComponent: React.ComponentType<*>
+        static WrappedComponent: ComponentType<*>
 
         context: ReactContext
 
@@ -1003,7 +1003,7 @@ const createReduxForm = (structure: Structure<*, *>) => {
           return this.ref ? this.ref.getWrappedInstance().getFieldList() : []
         }
 
-        get wrappedInstance(): ?React.Component<*, *> {
+        get wrappedInstance(): ?Component<*, *> {
           // for testing
           return this.ref && this.ref.getWrappedInstance().refs.wrapped
         }

--- a/src/util/getDisplayName.js
+++ b/src/util/getDisplayName.js
@@ -1,7 +1,7 @@
 // @flow
-import * as React from 'react'
+import type { ComponentType } from 'react'
 
-const getDisplayName = (Comp: React.ComponentType<any>): string =>
+const getDisplayName = (Comp: ComponentType<any>): string =>
   Comp.displayName || Comp.name || 'Component'
 
 export default getDisplayName


### PR DESCRIPTION
I never used Flow before, so I have no idea whether this is correct or not 😃 

I just started a trial and error game until the warnings disappeared and no errors were spilled by `npm run test:flow`

Fixes #3385 
