### PR TITLE
Remove unnecessary import alias in BundleSize.md

### DIFF
--- a/docs/faq/BundleSize.md
+++ b/docs/faq/BundleSize.md
@@ -18,6 +18,7 @@ use:
 import reduxForm from 'redux-form/es/reduxForm'
 import Field from 'redux-form/es/Field'
 import FieldArray from 'redux-form/es/FieldArray'
+import actions from 'redux-form/es/actions';
 ```
 
 
@@ -55,7 +56,7 @@ One would import the actions binding and then extract the needed action creators
 Example:
 
 ```js
-import * as actions from 'redux-form/es/actions';
+import actions from 'redux-form/es/actions';
 
 const { change, destroy } = actions;
 ```


### PR DESCRIPTION
There is only one single default export in the actions source code, so there is no need to use a multi-import alias.
https://github.com/erikras/redux-form/blob/0b49d4349f008a0458b0fa0a6b5cee10bc3e2b0a/src/actions.js#L440