### PR TITLE
Deep equal the value of radio input form fields to detect changes

### DIFF
--- a/src/__tests__/createFieldProps.spec.js
+++ b/src/__tests__/createFieldProps.spec.js
@@ -8,36 +8,36 @@ import addExpectations from './addExpectations'
 import tmp from 'tmp'
 
 const describeCreateFieldProps = (name, structure, expect) => {
-  const { empty, getIn, fromJS, toJS } = structure
+  const { empty, getIn, fromJS, toJS, deepEqual } = structure
 
   describe(name, () => {
     it('should pass value through', () => {
       expect(
-        createFieldProps({ getIn, toJS }, 'foo', { value: 'hello' }).input.value
+        createFieldProps({ getIn, toJS, deepEqual }, 'foo', { value: 'hello' }).input.value
       ).toBe('hello')
     })
 
     it('should pass dirty/pristine through', () => {
       expect(
-        createFieldProps({ getIn, toJS }, 'foo', {
+        createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
           dirty: false,
           pristine: true
         }).meta.dirty
       ).toBe(false)
       expect(
-        createFieldProps({ getIn, toJS }, 'foo', {
+        createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
           dirty: false,
           pristine: true
         }).meta.pristine
       ).toBe(true)
       expect(
-        createFieldProps({ getIn, toJS }, 'foo', {
+        createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
           dirty: true,
           pristine: false
         }).meta.dirty
       ).toBe(true)
       expect(
-        createFieldProps({ getIn, toJS }, 'foo', {
+        createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
           dirty: true,
           pristine: false
         }).meta.pristine
@@ -46,7 +46,7 @@ const describeCreateFieldProps = (name, structure, expect) => {
 
     it('should pass initial value through', () => {
       expect(
-        createFieldProps({ getIn, toJS }, 'foo', { initial: 'hello' }).meta
+        createFieldProps({ getIn, toJS, deepEqual }, 'foo', { initial: 'hello' }).meta
           .initial
       ).toBe('hello')
     })
@@ -54,33 +54,37 @@ const describeCreateFieldProps = (name, structure, expect) => {
     it('should provide onBlur', () => {
       const onBlur = createSpy()
       expect(onBlur).toNotHaveBeenCalled()
-      const result = createFieldProps({ getIn, toJS }, 'foo', {
+      const result = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         value: 'bar',
         onBlur
       })
       expect(result.input.onBlur).toBeA('function')
       expect(onBlur).toNotHaveBeenCalled()
       result.input.onBlur('rabbit')
-      expect(onBlur).toHaveBeenCalled().toHaveBeenCalledWith('rabbit')
+      expect(onBlur)
+        .toHaveBeenCalled()
+        .toHaveBeenCalledWith('rabbit')
     })
 
     it('should provide onChange', () => {
       const onChange = createSpy()
       expect(onChange).toNotHaveBeenCalled()
-      const result = createFieldProps({ getIn, toJS }, 'foo', {
+      const result = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         value: 'bar',
         onChange
       })
       expect(result.input.onChange).toBeA('function')
       expect(onChange).toNotHaveBeenCalled()
       result.input.onChange('rabbit')
-      expect(onChange).toHaveBeenCalled().toHaveBeenCalledWith('rabbit')
+      expect(onChange)
+        .toHaveBeenCalled()
+        .toHaveBeenCalledWith('rabbit')
     })
 
     it('should provide onFocus', () => {
       const onFocus = createSpy()
       expect(onFocus).toNotHaveBeenCalled()
-      const result = createFieldProps({ getIn, toJS }, 'foo', {
+      const result = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         value: 'bar',
         onFocus
       })
@@ -92,7 +96,7 @@ const describeCreateFieldProps = (name, structure, expect) => {
 
     it('should provide onDragStart', () => {
       const onDragStart = createSpy()
-      const result = createFieldProps({ getIn, toJS }, 'foo', {
+      const result = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         value: 'bar',
         onDragStart
       })
@@ -101,7 +105,7 @@ const describeCreateFieldProps = (name, structure, expect) => {
 
     it('should provide onDrop', () => {
       const onDrop = createSpy()
-      const result = createFieldProps({ getIn, toJS }, 'foo', {
+      const result = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         value: 'bar',
         onDrop
       })
@@ -109,12 +113,12 @@ const describeCreateFieldProps = (name, structure, expect) => {
     })
 
     it('should read active from state', () => {
-      const inactiveResult = createFieldProps({ getIn, toJS }, 'foo', {
+      const inactiveResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         value: 'bar',
         state: empty
       })
       expect(inactiveResult.meta.active).toBe(false)
-      const activeResult = createFieldProps({ getIn, toJS }, 'foo', {
+      const activeResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         value: 'bar',
         state: fromJS({
           active: true
@@ -124,11 +128,11 @@ const describeCreateFieldProps = (name, structure, expect) => {
     })
 
     it('should pass along submitting flag', () => {
-      const notSubmittingResult = createFieldProps({ getIn, toJS }, 'foo', {
+      const notSubmittingResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         value: 'bar'
       })
       expect(notSubmittingResult.meta.submitting).toBe(false)
-      const submittingResult = createFieldProps({ getIn, toJS }, 'foo', {
+      const submittingResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         value: 'bar',
         submitting: true
       })
@@ -136,11 +140,11 @@ const describeCreateFieldProps = (name, structure, expect) => {
     })
 
     it('should pass along submitFailed flag', () => {
-      const notFailedResult = createFieldProps({ getIn, toJS }, 'foo', {
+      const notFailedResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         value: 'bar'
       })
       expect(notFailedResult.meta.submitFailed).toBe(false)
-      const failedResult = createFieldProps({ getIn, toJS }, 'foo', {
+      const failedResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         value: 'bar',
         submitFailed: true
       })
@@ -148,11 +152,11 @@ const describeCreateFieldProps = (name, structure, expect) => {
     })
 
     it('should pass along all custom state props', () => {
-      const pristineResult = createFieldProps({ getIn, toJS }, 'foo', {
+      const pristineResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         value: 'bar'
       })
       expect(pristineResult.meta.customProp).toBe(undefined)
-      const customResult = createFieldProps({ getIn, toJS }, 'foo', {
+      const customResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         value: 'bar',
         state: fromJS({
           customProp: 'my-custom-prop'
@@ -162,11 +166,11 @@ const describeCreateFieldProps = (name, structure, expect) => {
     })
 
     it('should not override canonical props with custom props', () => {
-      const pristineResult = createFieldProps({ getIn, toJS }, 'foo', {
+      const pristineResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         value: 'bar'
       })
       expect(pristineResult.meta.customProp).toBe(undefined)
-      const customResult = createFieldProps({ getIn, toJS }, 'foo', {
+      const customResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         value: 'bar',
         submitting: true,
         state: fromJS({
@@ -177,12 +181,12 @@ const describeCreateFieldProps = (name, structure, expect) => {
     })
 
     it('should read touched from state', () => {
-      const untouchedResult = createFieldProps({ getIn, toJS }, 'foo', {
+      const untouchedResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         value: 'bar',
         state: empty
       })
       expect(untouchedResult.meta.touched).toBe(false)
-      const touchedResult = createFieldProps({ getIn, toJS }, 'foo', {
+      const touchedResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         value: 'bar',
         state: fromJS({
           touched: true
@@ -192,12 +196,12 @@ const describeCreateFieldProps = (name, structure, expect) => {
     })
 
     it('should read visited from state', () => {
-      const notVisitedResult = createFieldProps({ getIn, toJS }, 'foo', {
+      const notVisitedResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         value: 'bar',
         state: empty
       })
       expect(notVisitedResult.meta.visited).toBe(false)
-      const visitedResult = createFieldProps({ getIn, toJS }, 'foo', {
+      const visitedResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         value: 'bar',
         state: fromJS({
           visited: true
@@ -207,14 +211,14 @@ const describeCreateFieldProps = (name, structure, expect) => {
     })
 
     it('should read sync errors from prop', () => {
-      const noErrorResult = createFieldProps({ getIn, toJS }, 'foo', {
+      const noErrorResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         value: 'bar',
         state: empty
       })
       expect(noErrorResult.meta.error).toNotExist()
       expect(noErrorResult.meta.valid).toBe(true)
       expect(noErrorResult.meta.invalid).toBe(false)
-      const errorResult = createFieldProps({ getIn, toJS }, 'foo', {
+      const errorResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         value: 'bar',
         state: empty,
         syncError: 'This is an error'
@@ -225,12 +229,12 @@ const describeCreateFieldProps = (name, structure, expect) => {
     })
 
     it('should read sync warnings from prop', () => {
-      const noWarningResult = createFieldProps({ getIn, toJS }, 'foo', {
+      const noWarningResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         value: 'bar',
         state: empty
       })
       expect(noWarningResult.meta.warning).toNotExist()
-      const warningResult = createFieldProps({ getIn, toJS }, 'foo', {
+      const warningResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         value: 'bar',
         state: empty,
         syncWarning: 'This is an warning'
@@ -239,14 +243,14 @@ const describeCreateFieldProps = (name, structure, expect) => {
     })
 
     it('should read async errors from state', () => {
-      const noErrorResult = createFieldProps({ getIn, toJS }, 'foo', {
+      const noErrorResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         value: 'bar',
         state: empty
       })
       expect(noErrorResult.meta.error).toNotExist()
       expect(noErrorResult.meta.valid).toBe(true)
       expect(noErrorResult.meta.invalid).toBe(false)
-      const errorResult = createFieldProps({ getIn, toJS }, 'foo', {
+      const errorResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         value: 'bar',
         state: empty,
         syncError: 'This is an error'
@@ -257,14 +261,14 @@ const describeCreateFieldProps = (name, structure, expect) => {
     })
 
     it('should read submit errors from state', () => {
-      const noErrorResult = createFieldProps({ getIn, toJS }, 'foo', {
+      const noErrorResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         value: 'bar',
         state: empty
       })
       expect(noErrorResult.meta.error).toNotExist()
       expect(noErrorResult.meta.valid).toBe(true)
       expect(noErrorResult.meta.invalid).toBe(false)
-      const errorResult = createFieldProps({ getIn, toJS }, 'foo', {
+      const errorResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         value: 'bar',
         state: empty,
         submitError: 'This is an error'
@@ -275,14 +279,14 @@ const describeCreateFieldProps = (name, structure, expect) => {
     })
 
     it('should prioritize sync errors over async or submit errors', () => {
-      const noErrorResult = createFieldProps({ getIn, toJS }, 'foo', {
+      const noErrorResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         value: 'bar',
         state: empty
       })
       expect(noErrorResult.meta.error).toNotExist()
       expect(noErrorResult.meta.valid).toBe(true)
       expect(noErrorResult.meta.invalid).toBe(false)
-      const errorResult = createFieldProps({ getIn, toJS }, 'foo', {
+      const errorResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         value: 'bar',
         asyncError: 'async error',
         submitError: 'submit error',
@@ -294,7 +298,7 @@ const describeCreateFieldProps = (name, structure, expect) => {
     })
 
     it('should pass through other props', () => {
-      const result = createFieldProps({ getIn, toJS }, 'foo', {
+      const result = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         value: 'bar',
         state: empty,
         someOtherProp: 'dog',
@@ -307,7 +311,7 @@ const describeCreateFieldProps = (name, structure, expect) => {
     })
 
     it('should pass through other props using props prop', () => {
-      const result = createFieldProps({ getIn, toJS }, 'foo', {
+      const result = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         value: 'bar',
         state: empty,
         props: {
@@ -323,20 +327,20 @@ const describeCreateFieldProps = (name, structure, expect) => {
 
     it('should set checked for checkboxes', () => {
       expect(
-        createFieldProps({ getIn, toJS }, 'foo', {
+        createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
           state: empty,
           type: 'checkbox'
         }).input.checked
       ).toBe(false)
       expect(
-        createFieldProps({ getIn, toJS }, 'foo', {
+        createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
           value: true,
           state: empty,
           type: 'checkbox'
         }).input.checked
       ).toBe(true)
       expect(
-        createFieldProps({ getIn, toJS }, 'foo', {
+        createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
           value: false,
           state: empty,
           type: 'checkbox'
@@ -346,14 +350,14 @@ const describeCreateFieldProps = (name, structure, expect) => {
 
     it('should set checked for radio buttons', () => {
       expect(
-        createFieldProps({ getIn, toJS }, 'foo', {
+        createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
           state: empty,
           type: 'radio',
           _value: 'bar'
         }).input.checked
       ).toBe(false)
       expect(
-        createFieldProps({ getIn, toJS }, 'foo', {
+        createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
           value: 'bar',
           state: empty,
           type: 'radio',
@@ -361,18 +365,41 @@ const describeCreateFieldProps = (name, structure, expect) => {
         }).input.checked
       ).toBe(true)
       expect(
-        createFieldProps({ getIn, toJS }, 'foo', {
+        createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
           value: 'baz',
           state: empty,
           type: 'radio',
           _value: 'bar'
         }).input.checked
       ).toBe(false)
+      expect(
+        createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
+          state: empty,
+          type: 'radio',
+          _value: { randomName: 'bar' }
+        }).input.checked
+      ).toBe(false)
+      expect(
+        createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
+          value: { randomName: 'bar' },
+          state: empty,
+          type: 'radio',
+          _value: { randomName: 'bar' }
+        }).input.checked
+      ).toBe(true)
+      expect(
+        createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
+          value: { randomName: 'baz' },
+          state: empty,
+          type: 'radio',
+          _value: { randomName: 'bar' }
+        }).input.checked
+      ).toBe(false)
     })
 
     it('should default value to [] for multi-selects', () => {
       expect(
-        createFieldProps({ getIn, toJS }, 'foo', {
+        createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
           state: empty,
           type: 'select-multiple'
         }).input.value
@@ -383,7 +410,7 @@ const describeCreateFieldProps = (name, structure, expect) => {
 
     it('should default value to undefined for file inputs', () => {
       expect(
-        createFieldProps({ getIn, toJS }, 'foo', {
+        createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
           state: empty,
           type: 'file'
         }).input.value
@@ -393,7 +420,7 @@ const describeCreateFieldProps = (name, structure, expect) => {
     it('should update value to selected file for file inputs', () => {
       let tmpFile = tmp.fileSync()
       expect(
-        createFieldProps({ getIn, toJS }, 'foo', {
+        createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
           value: [tmpFile],
           state: empty,
           type: 'file'
@@ -402,14 +429,14 @@ const describeCreateFieldProps = (name, structure, expect) => {
     })
 
     it('should replace undefined value with empty string', () => {
-      const result = createFieldProps({ getIn, toJS }, 'foo', {
+      const result = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         state: empty
       })
       expect(result.input.value).toBe('')
     })
 
     it('should not format value when format prop is null', () => {
-      const result = createFieldProps({ getIn, toJS }, 'foo', {
+      const result = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         state: empty,
         value: null,
         format: null

--- a/src/createFieldProps.js
+++ b/src/createFieldProps.js
@@ -42,7 +42,8 @@ export type Props = {
 const processProps = (
   type: ?string,
   props: InputProps,
-  _value: any
+  _value: any,
+  deepEqual: Function
 ): Object => {
   const { value } = props
   if (type === 'checkbox') {
@@ -54,7 +55,7 @@ const processProps = (
   if (type === 'radio') {
     return {
       ...props,
-      checked: value === _value,
+      checked: deepEqual(value, _value),
       value: _value
     }
   }
@@ -74,7 +75,7 @@ const processProps = (
 }
 
 const createFieldProps = (
-  { getIn, toJS }: Structure<*, *>,
+  { getIn, toJS, deepEqual }: Structure<*, *>,
   name: string,
   {
     asyncError,
@@ -130,7 +131,8 @@ const createFieldProps = (
         onFocus,
         value: formattedFieldValue
       },
-      _value
+      _value,
+      deepEqual
     ),
     meta: {
       ...toJS(state),


### PR DESCRIPTION
Intro:
To detect changes on form field values, redux form is using deepEqual. This means, for example, that we can use (complex) object values for text inputs (which is great) - or simple values.

Problem:
Unfortunately the usage of (complex) object values does not work for radio inputs currently.

Solution:
This PR enables radio inputs to handle (complex) object values as well.