### PR TITLE
Support for dynamic form values in form values hoc

### DIFF
--- a/docs/api/FormValues.md
+++ b/docs/api/FormValues.md
@@ -1,4 +1,4 @@
-# `formValues(options:Object<String, String> | name1:String, name2:String, ...)`
+# `formValues(options:Object<String, String> | valuesMapper:Function | name1:String, name2:String, ...)`
 
 [`View source on GitHub`](https://github.com/erikras/redux-form/blob/master/src/formValues.js)
 
@@ -23,6 +23,10 @@ The path to the field, exactly like the `name` parameter of [`<Field/>`](https:/
 
 If you use the first form with the options object, the keys of the object will be the names of the props passed.
 
+### valuesMapper: (props) => name:String | (props) => options:Object<String, String>
+
+A function to map values. Like this you can create the path to the field(s) dynamically. Return a name or an options object.
+
 ## Usage
 
 ```javascript
@@ -30,6 +34,12 @@ const ItemList = formValues('withVat')(MyItemizedList)
 ```
 ```javascript
 const ItemList = formValues({showVat: 'withVat'})(MyItemizedList)
+```
+```javascript
+const ItemList = formValues((props) => props.formValueName)(MyItemizedList)
+```
+```javascript
+const ItemList = formValues((props) => ({showVat: props.formValueName}))(MyItemizedList)
 ```
 
 These decorated components will now get the props `withVat` and `showVat`, respectively.

--- a/src/__tests__/formValues.spec.js
+++ b/src/__tests__/formValues.spec.js
@@ -70,6 +70,8 @@ const describeValues = (
     it('should throw on missing names', () => {
       expect(() => testProps(false)).toThrow()
       expect(() => testProps(false, {})).toThrow()
+      expect(() => testProps(false, () => {})).toThrow()
+      expect(() => testProps(false, () => ({}))).toThrow()
     })
 
     it('should throw on missing context', () => {
@@ -93,6 +95,17 @@ const describeValues = (
 
     it('should use given prop names', () => {
       const props = testProps(false, { foo: 'cat', bar: 'sub.dog' })
+      expect(props.foo).toEqual('rat')
+      expect(props.bar).toEqual('cat')
+    })
+
+    it('should get values from Redux state when using a value mapper function', () => {
+      const props = testProps(false, (props) => 'cat')
+      expect(props.cat).toEqual('rat')
+    })
+
+    it('should use given prop names when using a value mapper function', () => {
+      const props = testProps(false, (props) => ({ foo: 'cat', bar: 'sub.dog' }))
       expect(props.foo).toEqual('rat')
       expect(props.bar).toEqual('cat')
     })

--- a/src/__tests__/formValues.spec.js
+++ b/src/__tests__/formValues.spec.js
@@ -58,7 +58,7 @@ const describeValues = (
             ? <FormSection name="sub">
                 <Decorated />
               </FormSection>
-            : <Decorated />}
+            : <Decorated fooFormFieldName="cat" barFormFieldName="sub.dog" />}
         </Form>
       </Provider>
     )
@@ -100,12 +100,12 @@ const describeValues = (
     })
 
     it('should get values from Redux state when using a value mapper function', () => {
-      const props = testProps(false, (props) => 'cat')
+      const props = testProps(false, (props) => props.fooFormFieldName)
       expect(props.cat).toEqual('rat')
     })
 
     it('should use given prop names when using a value mapper function', () => {
-      const props = testProps(false, (props) => ({ foo: 'cat', bar: 'sub.dog' }))
+      const props = testProps(false, (props) => ({ foo: props.fooFormFieldName, bar: props.barFormFieldName }))
       expect(props.foo).toEqual('rat')
       expect(props.bar).toEqual('cat')
     })


### PR DESCRIPTION
We run into a situation where we needed to retrieve a form field value of a form field with a dynamic name (form field name needs to be created by using variables available in props). To handle this in an appropriate way, we suggest to also accept functions as a first argument of the formValues hoc which will resolve the according form field values (where the name was created dynamically, using variables stored in props).

A short example: `formValues((props) => ({ myFormFieldValue: props.formFieldName }));`

Feature has been implemented, docs and unit tests have been updated.