### PR TITLE
Skip adding preventDefault to onChange events in React Native

### DIFF
--- a/src/ConnectedField.js
+++ b/src/ConnectedField.js
@@ -6,6 +6,7 @@ import createFieldProps from './createFieldProps'
 import onChangeValue from './events/onChangeValue'
 import { dataKey } from './util/eventConsts'
 import plain from './structure/plain'
+import isReactNative from './isReactNative';
 import type { Structure } from './types.js.flow'
 import type { Props } from './ConnectedField.types'
 
@@ -98,17 +99,26 @@ const createConnectedField = (structure: Structure<*, *>) => {
 
       let defaultPrevented = false
       if (onChange) {
-        onChange(
-          {
-            ...event,
-            preventDefault: () => {
-              defaultPrevented = true
-              return eventPreventDefault(event)
-            }
-          },
-          newValue,
-          previousValue
-        )
+        // Can't seem to find a way to extend Event in React Native,
+        // thus I simply avoid adding preventDefault() in a RN environment
+        // to prevent the following error:
+        // `One of the sources for assign has an enumerable key on the prototype chain`
+        // Reference: https://github.com/facebook/react-native/issues/5507
+        if (!isReactNative) {
+          onChange(
+            {
+              ...event,
+              preventDefault: () => {
+                defaultPrevented = true
+                return eventPreventDefault(event)
+              }
+            },
+            newValue,
+            previousValue
+          )
+        } else {
+          onChange(event, newValue, previousValue)
+        }
       }
       if (!defaultPrevented) {
         // dispatch change action


### PR DESCRIPTION
# Bug
When using onChange in React Native, the users are faced with a couple possible error messages, as seen in #3153 and #3238.
This is due to the fact that it doesn't seem to be possible to properly extends React Native's event ( https://github.com/facebook/react-native/issues/5507). My proposal is to skip adding .preventDefault to TextInput's onChange's event.

## Tests
No test was broken

## Eslint
Linting was respected

Closes #3153, closes #3238