### PR TITLE
Add FieldArray propTypes close #2447

### DIFF
--- a/src/__tests__/immutable.spec.js
+++ b/src/__tests__/immutable.spec.js
@@ -1,7 +1,8 @@
 import expect from 'expect'
 import * as expectedActionTypes from '../actionTypes'
 import expectedPropTypes, {
-  fieldPropTypes as expectedFieldPropTypes
+  fieldPropTypes as expectedFieldPropTypes,
+  fieldArrayPropTypes as expectedFieldArrayPropTypes
 } from '../propTypes'
 import {
   actionTypes,
@@ -45,6 +46,7 @@ import {
   hasSubmitSucceeded,
   hasSubmitFailed,
   fieldPropTypes,
+  fieldArrayPropTypes,
   propTypes,
   formPropTypes,
   reducer,
@@ -188,6 +190,9 @@ describe('immutable', () => {
   })
   it('should export fieldPropTypes', () => {
     expect(fieldPropTypes).toEqual(expectedFieldPropTypes)
+  })
+  it('should export fieldArrayPropTypes', () => {
+    expect(fieldArrayPropTypes).toEqual(expectedFieldArrayPropTypes)
   })
   it('should export propTypes', () => {
     expect(propTypes).toEqual(expectedPropTypes)

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -1,7 +1,8 @@
 import expect from 'expect'
 import * as expectedActionTypes from '../actionTypes'
 import expectedPropTypes, {
-  fieldPropTypes as expectedFieldPropTypes
+  fieldPropTypes as expectedFieldPropTypes,
+  fieldArrayPropTypes as expectedFieldArrayPropTypes
 } from '../propTypes'
 import {
   actionTypes,
@@ -46,6 +47,7 @@ import {
   hasSubmitSucceeded,
   hasSubmitFailed,
   fieldPropTypes,
+  fieldArrayPropTypes,
   propTypes,
   formPropTypes,
   reducer,
@@ -192,6 +194,9 @@ describe('index', () => {
   })
   it('should export fieldPropTypes', () => {
     expect(fieldPropTypes).toEqual(expectedFieldPropTypes)
+  })
+  it('should export fieldArrayPropTypes', () => {
+    expect(fieldArrayPropTypes).toEqual(expectedFieldArrayPropTypes)
   })
   it('should export propTypes', () => {
     expect(propTypes).toEqual(expectedPropTypes)

--- a/src/immutable.js
+++ b/src/immutable.js
@@ -14,6 +14,9 @@ export {
   fieldInputPropTypes,
   fieldMetaPropTypes,
   fieldPropTypes,
+  fieldArrayFieldsPropTypes,
+  fieldArrayMetaPropTypes,
+  fieldArrayPropTypes,
   formPropTypes
 } from './propTypes'
 export { default as Field } from './immutable/Field'

--- a/src/immutable.js.flow
+++ b/src/immutable.js.flow
@@ -95,6 +95,12 @@ declare export var fieldMetaPropTypes: Object
 
 declare export var fieldPropTypes: Object
 
+declare export var fieldArrayFieldsPropTypes: Object
+
+declare export var fieldArrayMetaPropTypes: Object
+
+declare export var fieldArrayPropTypes: Object
+
 declare export var formPropTypes: Object
 
 declare export var Field: React.ComponentType<FieldInputProps>

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,9 @@ export {
   fieldInputPropTypes,
   fieldMetaPropTypes,
   fieldPropTypes,
+  fieldArrayFieldsPropTypes,
+  fieldArrayMetaPropTypes,
+  fieldArrayPropTypes,
   formPropTypes
 } from './propTypes'
 export { default as Field } from './Field'

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -93,6 +93,12 @@ declare export var fieldMetaPropTypes: Object
 
 declare export var fieldPropTypes: Object
 
+declare export var fieldArrayFieldsPropTypes: Object
+
+declare export var fieldArrayMetaPropTypes: Object
+
+declare export var fieldArrayPropTypes: Object
+
 declare export var formPropTypes: Object
 
 declare export var Field: React.ComponentType<FieldInputProps>

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -1,7 +1,7 @@
 // @flow
 import PropTypes from 'prop-types'
 
-const { any, bool, func, shape, string, oneOfType, object } = PropTypes
+const { any, bool, func, shape, string, oneOfType, object, number } = PropTypes
 
 export const formPropTypes = {
   // State:
@@ -81,9 +81,45 @@ export const fieldMetaPropTypes = {
   warning: string
 }
 
+export const fieldArrayMetaPropTypes = {
+  dirty: bool.isRequired,
+  error: string,
+  form: string.isRequired,
+  invalid: bool.isRequired,
+  pristine: bool.isRequired,
+  submitFailed: bool,
+  submitting: bool,
+  valid: bool.isRequired,
+  warning: string
+}
+
+export const fieldArrayFieldsPropTypes = {
+  name: string.isRequired,
+  forEach: func.isRequired,
+  get: func.isRequired,
+  getAll: func.isRequired,
+  insert: func.isRequired,
+  length: number.isRequired,
+  map: func.isRequired,
+  move: func.isRequired,
+  pop: func.isRequired,
+  push: func.isRequired,
+  reduce: func.isRequired,
+  remove: func.isRequired,
+  removeAll: func.isRequired,
+  shift: func.isRequired,
+  swap: func.isRequired,
+  unshift: func.isRequired
+}
+
 export const fieldPropTypes = {
   input: shape(fieldInputPropTypes).isRequired,
   meta: shape(fieldMetaPropTypes).isRequired
+}
+
+export const fieldArrayPropTypes = {
+  fields: shape(fieldArrayFieldsPropTypes).isRequired,
+  meta: shape(fieldArrayMetaPropTypes).isRequired
 }
 
 export default formPropTypes


### PR DESCRIPTION
Add FieldArray PropTypes for the user's convenience.

Closes #2447 

Basic Usage
``` js
import { fieldArrayMetaPropTypes, fieldArrayFieldsPropTypes } from 'redux-form';

class MultiClientSelectForm extends React.Component {
  // do FieldArray react conmponent stuff
}

MultiClientSelectForm.propTypes ={
  fields: fieldArrayFieldsPropTypes,
  meta: fieldArrayMetaPropTypes
}
```
