### PR TITLE
Simplify travis and prepublish build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,4 @@ node_js:
   - "stable"
 
 script:
-  - npm run lint
-  - npm test
-
-after_success:
-  - npm run test:cov
-  - npm run test:codecov
+  - # prepublish does it all

--- a/package.json
+++ b/package.json
@@ -34,12 +34,11 @@
     "example:syncValidation": "form=syncValidation npm run example",
     "example:wizard": "form=wizard npm run example",
     "format": "prettier-eslint \"+(src|examples)/**/*.+(js|js.flow)\" --ignore \"**/bundle.js\" --write --no-semi --single-quote --trailing-comma=none",
-    "prepublish": "npm run test && npm run test:flow && npm run clean && npm run build",
+    "prepublish": "npm run lint && npm run test:cov && npm run test:flow && npm run clean && npm run build",
     "test": "cross-env NODE_ENV=test jest --runInBand",
     "test:flow": "flow check",
     "test:watch": "npm test -- --watch",
-    "test:cov": "npm run test -- --coverage",
-    "test:codecov": "cat ./coverage/lcov.info | ./node_modules/codecov.io/bin/codecov.io.js"
+    "test:cov": "npm run test -- --coverage"
   },
   "keywords": [
     "react",


### PR DESCRIPTION
The thing is that `prepublish` currently runs:
- npm run test 
- npm run test:flow 

On top of `prepublish` Travis also runs
- npm run lint
 - npm test
 - npm run test:cov
 - npm run test:codecov

(so test is running 3 times currently on CI...).

### Proposal

Would make more sense (and speed up travis a lot up) if `prepublish` ran:
- npm run lint
- npm run test:flow 
- npm run test:cov

And Travis additional step ran
 - npm run test:codecov
