### PR TITLE
Extends PR #3460, also locks immutable version

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "flow-bin": "^0.56.0",
     "flux-standard-action": "^1.0.0",
     "get-typed": "^1.0.0-beta.2",
-    "immutable": "^4.0.0-rc.3",
+    "immutable": "4.0.0-rc.3",
     "jest": "^21.0.2",
     "lodash-webpack-plugin": "^0.11.2",
     "prettier": "^1.6.1",

--- a/src/ConnectedField.js
+++ b/src/ConnectedField.js
@@ -134,7 +134,6 @@ const createConnectedField = (structure: Structure<*, *>) => {
       const { name, dispatch, onFocus, _reduxForm } = this.props
 
       let defaultPrevented = false
-
       if (onFocus) {
         if (!isReactNative) {
           onFocus({
@@ -174,7 +173,6 @@ const createConnectedField = (structure: Structure<*, *>) => {
       }
 
       let defaultPrevented = false
-      
       if (onBlur) {
         if (!isReactNative) {
           onBlur(

--- a/src/ConnectedField.js
+++ b/src/ConnectedField.js
@@ -134,14 +134,19 @@ const createConnectedField = (structure: Structure<*, *>) => {
       const { name, dispatch, onFocus, _reduxForm } = this.props
 
       let defaultPrevented = false
+
       if (onFocus) {
-        onFocus({
-          ...event,
-          preventDefault: () => {
-            defaultPrevented = true
-            return eventPreventDefault(event)
-          }
-        })
+        if (!isReactNative) {
+          onFocus({
+            ...event,
+            preventDefault: () => {
+              defaultPrevented = true
+              return eventPreventDefault(event)
+            }
+          })
+        } else {
+          onFocus(event)
+        }
       }
 
       if (!defaultPrevented) {
@@ -169,18 +174,23 @@ const createConnectedField = (structure: Structure<*, *>) => {
       }
 
       let defaultPrevented = false
+      
       if (onBlur) {
-        onBlur(
-          {
-            ...event,
-            preventDefault: () => {
-              defaultPrevented = true
-              return eventPreventDefault(event)
-            }
-          },
-          newValue,
-          previousValue
-        )
+        if (!isReactNative) {
+          onBlur(
+            {
+              ...event,
+              preventDefault: () => {
+                defaultPrevented = true
+                return eventPreventDefault(event)
+              }
+            },
+            newValue,
+            previousValue
+          )
+        } else {
+          onBlur(event, newValue, previousValue)
+        }
       }
 
       if (!defaultPrevented) {


### PR DESCRIPTION
The main purpose of this PR is to add the same logic that PR #3460 (which was merged) added to `onChange` also to `onBlur` and `onFocus`.

I've also edited a dev-dependecy line of package.json:

```diff
-"immutable": "^4.0.0-rc.3",
+"immutable": "4.0.0-rc.3",
``` 

This was necessary to prevent the test suite to fail miserably with 21 errors (all of them are `immutable`-related). This isn't a solution to #3493, but it's needed to mark the fact that versions `4.0.0-rc.>3` of `immutable` aren't supported as of now. I hope this doesn't add to much noise to the PR @erikras.