### PR TITLE
Fix hot reloading destroying form

### DIFF
--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -20,6 +20,7 @@ import handleSubmit from './handleSubmit'
 import createIsValid from './selectors/isValid'
 import plain from './structure/plain'
 import getDisplayName from './util/getDisplayName'
+import isHotReloading from './util/isHotReloading'
 import type { ComponentType } from 'react'
 import type { Dispatch } from 'redux'
 import type {
@@ -477,9 +478,11 @@ const createReduxForm = (structure: Structure<*, *>) => {
         }
 
         componentWillMount() {
-          this.initIfNeeded()
-          this.validateIfNeeded()
-          this.warnIfNeeded()
+          if (!isHotReloading()) {
+            this.initIfNeeded()
+            this.validateIfNeeded()
+            this.warnIfNeeded()
+          }
           invariant(
             this.props.shouldValidate,
             'shouldValidate() is deprecated and will be removed in v8.0.0. Use shouldWarn() or shouldError() instead.'
@@ -524,7 +527,7 @@ const createReduxForm = (structure: Structure<*, *>) => {
 
         componentWillUnmount() {
           const { destroyOnUnmount, destroy } = this.props
-          if (destroyOnUnmount) {
+          if (destroyOnUnmount && !isHotReloading()) {
             this.destroyed = true
             destroy()
           }

--- a/src/util/isHotReloading.js
+++ b/src/util/isHotReloading.js
@@ -1,0 +1,9 @@
+// @flow
+const isHotReloading = (): boolean =>
+  (typeof module !== 'undefined' &&
+    module.hot &&
+    typeof module.hot.status === 'function' &&
+    module.hot.status() === 'apply') ||
+  false
+
+export default isHotReloading

--- a/src/util/isHotReloading.js
+++ b/src/util/isHotReloading.js
@@ -1,9 +1,10 @@
 // @flow
 const isHotReloading = (): boolean =>
-  (typeof module !== 'undefined' &&
+  !!(
+    typeof module !== 'undefined' &&
     module.hot &&
     typeof module.hot.status === 'function' &&
-    module.hot.status() === 'apply') ||
-  false
+    module.hot.status() === 'apply'
+  )
 
 export default isHotReloading


### PR DESCRIPTION
This PR only destroys the form on unmount when there is not a hot reload in progress. This is currently webpack HMR specific.

A similar fix was suggested in #947 but this PR fixes the behavior only during a hot update, not in the presence of hot reloading capabilities. @gaearon suggested not to do this but since react-hot-loader@3.x seems dead and this issue has been around for a while with redux-form and is very frustrating to deal with I think it is worth fixing it with this workaround.

There are some flow errors that I'm really not sure how to fix. I also don't know how to create tests that are useful since it requires overriding the global `module`.

Fixes #623 
Fixes #2826 
Fixes #3005.