### PR TITLE
Include previous form values to onChange handler

### DIFF
--- a/docs/api/ReduxForm.md
+++ b/docs/api/ReduxForm.md
@@ -108,6 +108,10 @@ values change.
 
 > The props passed into your decorated component.
 
+> ##### `previousValues : Object`
+
+> The previous field values in the form of `{ field1: 'value1', field2: 'value2' }`.
+
 #### `onSubmit : Function` [optional]
 
 > The function to call with the form data when the `handleSubmit()` is fired from within the

--- a/src/__tests__/reduxForm.spec.js
+++ b/src/__tests__/reduxForm.spec.js
@@ -3640,6 +3640,7 @@ const describeReduxForm = (name, structure, combineReducers, setup) => {
       expect(onChange.mock.calls[0][0]).toEqualMap({ foo: 'dog' })
       expect(typeof onChange.mock.calls[0][1]).toBe('function')
       expect(onChange.mock.calls[0][2].values).toEqualMap({ foo: 'dog' })
+      expect(onChange.mock.calls[0][3]).toEqualMap({})
 
       changeBar('cat')
 
@@ -3652,6 +3653,9 @@ const describeReduxForm = (name, structure, combineReducers, setup) => {
       expect(onChange.mock.calls[1][2].values).toEqualMap({
         foo: 'dog',
         bar: 'cat'
+      })
+      expect(onChange.mock.calls[1][3]).toEqualMap({
+        foo: 'dog',
       })
 
       changeFoo('dog')
@@ -3668,6 +3672,10 @@ const describeReduxForm = (name, structure, combineReducers, setup) => {
       expect(typeof onChange.mock.calls[2][1]).toBe('function')
       expect(onChange.mock.calls[2][2].values).toEqualMap({
         foo: 'doggy',
+        bar: 'cat'
+      })
+      expect(onChange.mock.calls[2][3]).toEqualMap({
+        foo: 'dog',
         bar: 'cat'
       })
     })

--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -165,7 +165,7 @@ type OnChangeFunction = (
   values: Values,
   dispatch: Dispatch<*>,
   props: Object,
-  prevValus: Values,
+  previousValues: Values
 ) => void
 
 export type Config = {

--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -164,7 +164,8 @@ type ShouldWarnFunction = (params: ShouldWarnParams) => boolean
 type OnChangeFunction = (
   values: Values,
   dispatch: Dispatch<*>,
-  props: Object
+  props: Object,
+  prevValus: Values,
 ) => void
 
 export type Config = {
@@ -497,7 +498,7 @@ const createReduxForm = (structure: Structure<*, *>) => {
           this.submitIfNeeded(nextProps)
           const { onChange, values, dispatch } = nextProps
           if (onChange && !deepEqual(values, this.props.values)) {
-            onChange(values, dispatch, nextProps)
+            onChange(values, dispatch, nextProps, this.props.values)
           }
         }
 


### PR DESCRIPTION
It would be useful to know which field has changed in the `onChange` handler. Rather than bothering to compute this itself, redux-form can just send along the previous form values as an additional argument to the `onChange` handler.

One use case for this is an onChange handler that auto-submits the form values when one has changed.