### PR TITLE
Support async validation on change

### DIFF
--- a/src/ConnectedField.js
+++ b/src/ConnectedField.js
@@ -127,6 +127,11 @@ const createConnectedField = (structure: Structure<*, *>) => {
       if (!defaultPrevented) {
         // dispatch change action
         dispatch(_reduxForm.change(name, newValue))
+
+        // call post-change callback
+        if (_reduxForm.asyncValidate) {
+          _reduxForm.asyncValidate(name, newValue, 'change')
+        }
       }
     }
 
@@ -197,7 +202,7 @@ const createConnectedField = (structure: Structure<*, *>) => {
 
         // call post-blur callback
         if (_reduxForm.asyncValidate) {
-          _reduxForm.asyncValidate(name, newValue)
+          _reduxForm.asyncValidate(name, newValue, 'blur')
         }
       }
     }

--- a/src/ConnectedFields.js
+++ b/src/ConnectedFields.js
@@ -97,6 +97,11 @@ const createConnectedFields = (structure: Structure<*, *>) => {
       const value = onChangeValue(event, { name, parse })
 
       dispatch(_reduxForm.change(name, value))
+
+      // call post-change callback
+      if (_reduxForm.asyncValidate) {
+        _reduxForm.asyncValidate(name, value, 'change')
+      }
     }
 
     handleFocus = (name: string): void => {
@@ -113,7 +118,7 @@ const createConnectedFields = (structure: Structure<*, *>) => {
 
       // call post-blur callback
       if (_reduxForm.asyncValidate) {
-        _reduxForm.asyncValidate(name, value)
+        _reduxForm.asyncValidate(name, value, 'blur')
       }
     }
 

--- a/src/__tests__/reduxForm.spec.js
+++ b/src/__tests__/reduxForm.spec.js
@@ -3499,7 +3499,8 @@ const describeReduxForm = (name, structure, combineReducers, setup) => {
       const Decorated = reduxForm({
         form: 'testForm',
         asyncValidate,
-        asyncBlurFields: ['deep.foo']
+        asyncBlurFields: ['deep.foo'],
+        asyncChangeFields: [],
       })(Form)
 
       const dom = TestUtils.renderIntoDocument(
@@ -3594,6 +3595,90 @@ const describeReduxForm = (name, structure, combineReducers, setup) => {
 
         // input rerendered twice, at start and end of async validation
         expect(inputRender).toHaveBeenCalledTimes(4)
+        expect(propsAtNthRender(inputRender, 3).meta.pristine).toBe(false)
+        expect(propsAtNthRender(inputRender, 3).input.value).toBe('bar')
+        expect(propsAtNthRender(inputRender, 3).meta.valid).toBe(false)
+        expect(propsAtNthRender(inputRender, 3).meta.error).toBe('async error')
+      })
+    })
+
+    it('should call async on change of async change field', () => {
+      const store = makeStore({})
+      const inputRender = jest.fn(props => <input {...props.input} />)
+      const formRender = jest.fn()
+      const asyncErrors = {
+        deep: {
+          foo: 'async error'
+        }
+      }
+      const asyncValidate = jest
+        .fn()
+        .mockImplementation(() => Promise.reject(asyncErrors))
+
+      class Form extends Component {
+        render() {
+          formRender(this.props)
+          return (
+            <form>
+              <Field name="deep.foo" component={inputRender} type="text" />
+            </form>
+          )
+        }
+      }
+      const Decorated = reduxForm({
+        form: 'testForm',
+        asyncValidate,
+        asyncBlurFields: [],
+        asyncChangeFields: ['deep.foo'],
+      })(Form)
+
+      const dom = TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <Decorated />
+        </Provider>
+      )
+
+      const inputElement = TestUtils.findRenderedDOMComponentWithTag(
+        dom,
+        'input'
+      )
+
+      TestUtils.Simulate.change(inputElement, { target: { value: 'bar' } })
+
+      setTimeout(() => {
+        expect(store.getState()).toEqualMap({
+          form: {
+            testForm: {
+              anyTouched: true,
+              values: {
+                deep: {
+                  foo: 'bar'
+                }
+              },
+              fields: {
+                deep: {
+                  foo: {
+                    touched: true
+                  }
+                }
+              },
+              registeredFields: {
+                'deep.foo': { name: 'deep.foo', type: 'Field', count: 1 }
+              },
+              asyncErrors
+            }
+          }
+        })
+        // rerender form twice because of async validation start and again for valid -> invalid
+        expect(formRender.calls.length).toBe(4)
+
+        expect(asyncValidate).toHaveBeenCalled()
+        expect(propsAtNthRender(asyncValidate, 0)).toEqualMap({
+          deep: { foo: 'bar' }
+        })
+
+        // input rerendered twice, at start and end of async validation
+        expect(inputRender.calls.length).toBe(4)
         expect(propsAtNthRender(inputRender, 3).meta.pristine).toBe(false)
         expect(propsAtNthRender(inputRender, 3).input.value).toBe('bar')
         expect(propsAtNthRender(inputRender, 3).meta.valid).toBe(false)
@@ -4269,6 +4354,7 @@ const describeReduxForm = (name, structure, combineReducers, setup) => {
         form: 'testForm',
         asyncValidate,
         asyncBlurFields: ['foo'],
+        asyncChangeFields: [],
         shouldAsyncValidate
       })(Form)
 

--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -626,9 +626,10 @@ const createReduxForm = (structure: Structure<*, *>) => {
             : undefined
         }
 
-        asyncValidate = (name: string, value: any) => {
+        asyncValidate = (name: string, value: any, trigger: 'blur' | 'change') => {
           const {
             asyncBlurFields,
+            asyncChangeFields,
             asyncErrors,
             asyncValidate,
             dispatch,
@@ -646,16 +647,19 @@ const createReduxForm = (structure: Structure<*, *>) => {
               ? values
               : setIn(values, name, value)
             const syncValidationPasses = submitting || !getIn(syncErrors, name)
-            const isBlurredField =
+            const fieldNeedsValidation =
               !submitting &&
-              (!asyncBlurFields ||
-                ~asyncBlurFields.indexOf(name.replace(/\[[0-9]+\]/g, '[]')))
+              trigger === 'blur'
+                ? (!asyncBlurFields ||
+                  ~asyncBlurFields.indexOf(name.replace(/\[[0-9]+\]/g, '[]')))
+                : (!asyncChangeFields ||
+                  ~asyncChangeFields.indexOf(name.replace(/\[[0-9]+\]/g, '[]')))
             if (
-              (isBlurredField || submitting) &&
+              (fieldNeedsValidation || submitting) &&
               shouldAsyncValidate({
                 asyncErrors,
                 initialized,
-                trigger: submitting ? 'submit' : 'blur',
+                trigger: submitting ? 'submit' : trigger,
                 blurredField: name,
                 pristine,
                 syncValidationPasses

--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -202,6 +202,7 @@ export type Props = {
   arraySwap: ArraySwapAction,
   arrayUnshift: ArrayUnshiftAction,
   asyncBlurFields?: string[],
+  asyncChangeFields?: string[],
   asyncErrors?: any,
   asyncValidate: AsyncValidateFunction,
   asyncValidating: boolean,

--- a/src/defaultShouldAsyncValidate.js
+++ b/src/defaultShouldAsyncValidate.js
@@ -19,6 +19,7 @@ const defaultShouldAsyncValidate = ({
   }
   switch (trigger) {
     case 'blur':
+    case 'change':
       // blurring
       return true
     case 'submit':

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -65,7 +65,7 @@ export type Event = {
 export type Context = {
   form: string,
   getFormState: GetFormState,
-  asyncValidate: { (name: ?string, value: ?any): Promise<*> },
+  asyncValidate: { (name: ?string, value: ?any, trigger: 'blur' | 'change'): Promise<*> },
   getValues: { (): Object },
   sectionPrefix?: string,
   register: (


### PR DESCRIPTION
Currently, `asyncValidate` can only be run `onBlur`. This PR provides support for running it `onChange` as well.

This introduces an `asyncChangeFields` property to the `reduxForm()` API. Since the default functionality of `asyncBlurFields` is to run the validator on *all* fields if that property is not passed to the `reduxForm()` constructor, I kept that the same for `asyncChangeFields`. However, this introduces some potentially unwanted behavior: providing an `asyncValidate` function but neither `asyncChangeFields` nor `asyncBlurFields` props to `reduxForm()` will cause `asyncValidate` to run on both blur and change for all fields. I'm not sure this is desirable, and @danielrob [doesn't want](https://github.com/erikras/redux-form/issues/3521) to turn on async validation for on change events by default. Our options therefore seem to be:

1. Make the default functionality when omitting `asyncChangeFields` to be that no on change validation runs. This would cause it to operate differently from `asyncBlurFields`.

2. Make neither `asyncBlurFields` nor `asyncChangeFields` run on all fields when they aren't supplied to `reduxForm`. This would keep their functionality in sync, but result in a breaking change to the `asyncBlurFields` API. Might also be necessary to provide some new way to tell redux form to validate on blur or on change for all fields, since losing that ability introduces a maintenance burden as developers add new fields to a form in which all fields should be validated

3. Something else? e.g. `asyncBlurFields` runs on all fields not included in `asyncChangeFields`, thus eliminating duplicate validation calls for a given field... but you're still left with different functionality for omitting `asyncBlurFields` and `asyncChangeFields`.

Also, I'll be happy to add documentation if this PR is accepted.