### PR TITLE
update hoist-non-react-statics version for v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "homepage": "https://github.com/erikras/redux-form",
   "dependencies": {
     "deep-equal": "^1.0.1",
-    "hoist-non-react-statics": "^1.0.5",
+    "hoist-non-react-statics": "^2.3.1",
     "invariant": "^2.0.0",
     "is-promise": "^2.1.0",
     "prop-types": "^15.5.8",


### PR DESCRIPTION
Upgraded single package to the latest version
should not have any breaking changes