### PR TITLE
Add cleanFields action

### DIFF
--- a/docs/api/ActionCreators.md
+++ b/docs/api/ActionCreators.md
@@ -13,7 +13,7 @@ form, and, in the case of field-specific actions such as `CHANGE` or `BLUR`, the
 
 ### `arrayMove(form:String, field:String, from:Number, to:Number)`
 
-> Moves an item from one index in the array to another. In effect, it performs a remove and an 
+> Moves an item from one index in the array to another. In effect, it performs a remove and an
 insert, so the item already at the `to` position will be bumped to a higher index, not overwritten.
 
 ### `arrayPop(form:String, field:String)`
@@ -63,7 +63,15 @@ insert, so the item already at the `to` position will be bumped to a higher inde
 
 ### `clearSubmitErrors(form:String)`
 
-> Removes `submitErrors` and `error`. 
+> Removes `submitErrors` and `error`.
+
+### `clearFields(form:String, keepTouched: boolean, persistentSubmitErrors: boolean, ...fields:String)`
+
+> Cleans fields values for all the fields passed in.
+
+> If the `keepTouched` parameter is `true`, the values of currently touched fields will be retained
+> If the `persistentSubmitErrors` parameter is `true`, the values of currently submit errors fields will be retained
+
 
 ### `destroy(...forms:String)`
 
@@ -83,7 +91,7 @@ your form fields.
 to avoid overwriting user edits.  (`keepDirty` can appear as either the third argument, or a property of `options` as
 the 3rd or 4th argument, for the sake of backwards compatibility).
 
-> If the `keepSubmitSucceeded` parameter is `true`, 
+> If the `keepSubmitSucceeded` parameter is `true`,
 it will not clear the `submitSucceeded` flag if it is set.
 
 ### `registerField(form:String, name:String, type:String)`
@@ -96,7 +104,7 @@ it will not clear the `submitSucceeded` flag if it is set.
 
 ### `setSubmitFailed(form:String, ...fields:String)`
 
-> Flips `submitFailed` flag `true`, removes `submitSucceeded` and `submitting`, marks all the fields passed in as `touched`, and if at least one field was passed flips `anyTouched` to `true`. 
+> Flips `submitFailed` flag `true`, removes `submitSucceeded` and `submitting`, marks all the fields passed in as `touched`, and if at least one field was passed flips `anyTouched` to `true`.
 
 ### `setSubmitSucceeded(form:String)`
 

--- a/src/ConnectedFieldArray.js
+++ b/src/ConnectedFieldArray.js
@@ -37,9 +37,7 @@ const createConnectedFieldArray = (structure: Structure<*, *>) => {
       const nextValue = nextProps.value
 
       if (thisValue && nextValue) {
-        let nextValueItemsSame = nextValue.every(
-          val => ~thisValue.indexOf(val)
-        )
+        let nextValueItemsSame = nextValue.every(val => ~thisValue.indexOf(val))
         let nextValueItemsOrderChanged = nextValue.some(
           (val, index) => val !== thisValue[index]
         )

--- a/src/__tests__/actions.spec.js
+++ b/src/__tests__/actions.spec.js
@@ -13,6 +13,7 @@ import {
   CHANGE,
   CLEAR_SUBMIT,
   CLEAR_SUBMIT_ERRORS,
+  CLEAR_FIELDS,
   DESTROY,
   FOCUS,
   INITIALIZE,
@@ -50,6 +51,7 @@ const {
   change,
   clearSubmit,
   clearSubmitErrors,
+  clearFields,
   destroy,
   focus,
   initialize,
@@ -380,6 +382,21 @@ describe('actions', () => {
 
       meta: {
         form: 'myForm'
+      }
+    })
+
+    expect(isFSA(clearSubmitErrors('myForm'))).toBe(true)
+  })
+
+  it('should create clear fields action', () => {
+    expect(clearFields('myForm', true, true, 'a', 'b')).toEqual({
+      type: CLEAR_FIELDS,
+
+      meta: {
+        form: 'myForm',
+        keepTouched: true,
+        persistentSubmitErrors: true,
+        fields: ['a', 'b']
       }
     })
 

--- a/src/__tests__/createFieldProps.spec.js
+++ b/src/__tests__/createFieldProps.spec.js
@@ -16,7 +16,8 @@ const describeCreateFieldProps = (name, structure, setup) => {
 
     it('should pass value through', () => {
       expect(
-        createFieldProps({ getIn, toJS, deepEqual }, 'foo', { value: 'hello' }).input.value
+        createFieldProps({ getIn, toJS, deepEqual }, 'foo', { value: 'hello' })
+          .input.value
       ).toBe('hello')
     })
 
@@ -49,8 +50,9 @@ const describeCreateFieldProps = (name, structure, setup) => {
 
     it('should pass initial value through', () => {
       expect(
-        createFieldProps({ getIn, toJS, deepEqual }, 'foo', { initial: 'hello' }).meta
-          .initial
+        createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
+          initial: 'hello'
+        }).meta.initial
       ).toBe('hello')
     })
 
@@ -112,10 +114,14 @@ const describeCreateFieldProps = (name, structure, setup) => {
     })
 
     it('should read active from state', () => {
-      const inactiveResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
-        value: 'bar',
-        state: empty
-      })
+      const inactiveResult = createFieldProps(
+        { getIn, toJS, deepEqual },
+        'foo',
+        {
+          value: 'bar',
+          state: empty
+        }
+      )
       expect(inactiveResult.meta.active).toBe(false)
       const activeResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         value: 'bar',
@@ -127,21 +133,33 @@ const describeCreateFieldProps = (name, structure, setup) => {
     })
 
     it('should pass along submitting flag', () => {
-      const notSubmittingResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
-        value: 'bar'
-      })
+      const notSubmittingResult = createFieldProps(
+        { getIn, toJS, deepEqual },
+        'foo',
+        {
+          value: 'bar'
+        }
+      )
       expect(notSubmittingResult.meta.submitting).toBe(false)
-      const submittingResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
-        value: 'bar',
-        submitting: true
-      })
+      const submittingResult = createFieldProps(
+        { getIn, toJS, deepEqual },
+        'foo',
+        {
+          value: 'bar',
+          submitting: true
+        }
+      )
       expect(submittingResult.meta.submitting).toBe(true)
     })
 
     it('should pass along submitFailed flag', () => {
-      const notFailedResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
-        value: 'bar'
-      })
+      const notFailedResult = createFieldProps(
+        { getIn, toJS, deepEqual },
+        'foo',
+        {
+          value: 'bar'
+        }
+      )
       expect(notFailedResult.meta.submitFailed).toBe(false)
       const failedResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         value: 'bar',
@@ -151,9 +169,13 @@ const describeCreateFieldProps = (name, structure, setup) => {
     })
 
     it('should pass along all custom state props', () => {
-      const pristineResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
-        value: 'bar'
-      })
+      const pristineResult = createFieldProps(
+        { getIn, toJS, deepEqual },
+        'foo',
+        {
+          value: 'bar'
+        }
+      )
       expect(pristineResult.meta.customProp).toBe(undefined)
       const customResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         value: 'bar',
@@ -165,9 +187,13 @@ const describeCreateFieldProps = (name, structure, setup) => {
     })
 
     it('should not override canonical props with custom props', () => {
-      const pristineResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
-        value: 'bar'
-      })
+      const pristineResult = createFieldProps(
+        { getIn, toJS, deepEqual },
+        'foo',
+        {
+          value: 'bar'
+        }
+      )
       expect(pristineResult.meta.customProp).toBe(undefined)
       const customResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
         value: 'bar',
@@ -180,40 +206,60 @@ const describeCreateFieldProps = (name, structure, setup) => {
     })
 
     it('should read touched from state', () => {
-      const untouchedResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
-        value: 'bar',
-        state: empty
-      })
+      const untouchedResult = createFieldProps(
+        { getIn, toJS, deepEqual },
+        'foo',
+        {
+          value: 'bar',
+          state: empty
+        }
+      )
       expect(untouchedResult.meta.touched).toBe(false)
-      const touchedResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
-        value: 'bar',
-        state: fromJS({
-          touched: true
-        })
-      })
+      const touchedResult = createFieldProps(
+        { getIn, toJS, deepEqual },
+        'foo',
+        {
+          value: 'bar',
+          state: fromJS({
+            touched: true
+          })
+        }
+      )
       expect(touchedResult.meta.touched).toBe(true)
     })
 
     it('should read visited from state', () => {
-      const notVisitedResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
-        value: 'bar',
-        state: empty
-      })
+      const notVisitedResult = createFieldProps(
+        { getIn, toJS, deepEqual },
+        'foo',
+        {
+          value: 'bar',
+          state: empty
+        }
+      )
       expect(notVisitedResult.meta.visited).toBe(false)
-      const visitedResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
-        value: 'bar',
-        state: fromJS({
-          visited: true
-        })
-      })
+      const visitedResult = createFieldProps(
+        { getIn, toJS, deepEqual },
+        'foo',
+        {
+          value: 'bar',
+          state: fromJS({
+            visited: true
+          })
+        }
+      )
       expect(visitedResult.meta.visited).toBe(true)
     })
 
     it('should read sync errors from prop', () => {
-      const noErrorResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
-        value: 'bar',
-        state: empty
-      })
+      const noErrorResult = createFieldProps(
+        { getIn, toJS, deepEqual },
+        'foo',
+        {
+          value: 'bar',
+          state: empty
+        }
+      )
       expect(noErrorResult.meta.error).toBeFalsy()
       expect(noErrorResult.meta.valid).toBe(true)
       expect(noErrorResult.meta.invalid).toBe(false)
@@ -228,24 +274,36 @@ const describeCreateFieldProps = (name, structure, setup) => {
     })
 
     it('should read sync warnings from prop', () => {
-      const noWarningResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
-        value: 'bar',
-        state: empty
-      })
+      const noWarningResult = createFieldProps(
+        { getIn, toJS, deepEqual },
+        'foo',
+        {
+          value: 'bar',
+          state: empty
+        }
+      )
       expect(noWarningResult.meta.warning).toBeFalsy()
-      const warningResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
-        value: 'bar',
-        state: empty,
-        syncWarning: 'This is an warning'
-      })
+      const warningResult = createFieldProps(
+        { getIn, toJS, deepEqual },
+        'foo',
+        {
+          value: 'bar',
+          state: empty,
+          syncWarning: 'This is an warning'
+        }
+      )
       expect(warningResult.meta.warning).toBe('This is an warning')
     })
 
     it('should read async errors from state', () => {
-      const noErrorResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
-        value: 'bar',
-        state: empty
-      })
+      const noErrorResult = createFieldProps(
+        { getIn, toJS, deepEqual },
+        'foo',
+        {
+          value: 'bar',
+          state: empty
+        }
+      )
       expect(noErrorResult.meta.error).toBeFalsy()
       expect(noErrorResult.meta.valid).toBe(true)
       expect(noErrorResult.meta.invalid).toBe(false)
@@ -260,10 +318,14 @@ const describeCreateFieldProps = (name, structure, setup) => {
     })
 
     it('should read submit errors from state', () => {
-      const noErrorResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
-        value: 'bar',
-        state: empty
-      })
+      const noErrorResult = createFieldProps(
+        { getIn, toJS, deepEqual },
+        'foo',
+        {
+          value: 'bar',
+          state: empty
+        }
+      )
       expect(noErrorResult.meta.error).toBeFalsy()
       expect(noErrorResult.meta.valid).toBe(true)
       expect(noErrorResult.meta.invalid).toBe(false)
@@ -278,10 +340,14 @@ const describeCreateFieldProps = (name, structure, setup) => {
     })
 
     it('should prioritize sync errors over async or submit errors', () => {
-      const noErrorResult = createFieldProps({ getIn, toJS, deepEqual }, 'foo', {
-        value: 'bar',
-        state: empty
-      })
+      const noErrorResult = createFieldProps(
+        { getIn, toJS, deepEqual },
+        'foo',
+        {
+          value: 'bar',
+          state: empty
+        }
+      )
       expect(noErrorResult.meta.error).toBeFalsy()
       expect(noErrorResult.meta.valid).toBe(true)
       expect(noErrorResult.meta.invalid).toBe(false)

--- a/src/__tests__/helpers/reducer.clearFields.js
+++ b/src/__tests__/helpers/reducer.clearFields.js
@@ -1,0 +1,386 @@
+import actions from '../../actions'
+const { clearFields } = actions
+
+const describeClearFields = (reducer, expect, { fromJS }) => () => {
+  it('should clear fields value, touched, submitErrors', () => {
+    const state = reducer(
+      fromJS({
+        foo: {
+          registeredFields: {
+            myField: { type: 'Field', name: 'myField' },
+            myOtherField: { type: 'Field', name: 'myOtherField' }
+          },
+          values: {
+            myField: 'value',
+            myOtherField: 'otherValue'
+          },
+          asyncErrors: {
+            myField: 'async error',
+            myOtherField: 'async error'
+          },
+          submitErrors: {
+            myField: 'submit error',
+            myOtherField: 'submit error'
+          },
+          fields: {
+            myField: {
+              touched: true
+            },
+            myOtherField: {
+              touched: true
+            }
+          },
+          error: 'some global error',
+          anyTouched: true
+        }
+      }),
+      clearFields('foo', false, false, 'myField', 'myOtherField')
+    )
+    expect(state).toEqualMap({
+      foo: {
+        registeredFields: {
+          myField: { type: 'Field', name: 'myField' },
+          myOtherField: { type: 'Field', name: 'myOtherField' }
+        },
+        fields: {
+          myField: {},
+          myOtherField: {}
+        },
+        error: 'some global error'
+      }
+    })
+  })
+  it('should clear fields value, touched, but NOT submitErrors', () => {
+    const state = reducer(
+      fromJS({
+        foo: {
+          registeredFields: {
+            myField: { type: 'Field', name: 'myField' },
+            myOtherField: { type: 'Field', name: 'myOtherField' }
+          },
+          values: {
+            myField: 'value',
+            myOtherField: 'otherValue'
+          },
+          asyncErrors: {
+            myField: 'async error',
+            myOtherField: 'async error'
+          },
+          submitErrors: {
+            myField: 'submit error',
+            myOtherField: 'submit error'
+          },
+          fields: {
+            myField: {
+              touched: true
+            },
+            myOtherField: {
+              touched: true
+            }
+          },
+          anyTouched: true,
+          error: 'some global error'
+        }
+      }),
+      clearFields('foo', false, true, 'myField', 'myOtherField')
+    )
+    expect(state).toEqualMap({
+      foo: {
+        registeredFields: {
+          myField: { type: 'Field', name: 'myField' },
+          myOtherField: { type: 'Field', name: 'myOtherField' }
+        },
+        fields: {
+          myField: {},
+          myOtherField: {}
+        },
+        submitErrors: {
+          myField: 'submit error',
+          myOtherField: 'submit error'
+        },
+        error: 'some global error'
+      }
+    })
+  })
+  it('should clear fields values and keep touched', () => {
+    const state = reducer(
+      fromJS({
+        foo: {
+          registeredFields: {
+            myField: { type: 'Field', name: 'myField' },
+            myOtherField: { type: 'Field', name: 'myOtherField' }
+          },
+          values: {
+            myField: 'value',
+            myOtherField: 'otherValue'
+          },
+          fields: {
+            myField: {
+              touched: true
+            },
+            myOtherField: {
+              touched: true
+            }
+          },
+          anyTouched: true
+        }
+      }),
+      clearFields('foo', true, false, 'myField', 'myOtherField')
+    )
+    expect(state).toEqualMap({
+      foo: {
+        registeredFields: {
+          myField: { type: 'Field', name: 'myField' },
+          myOtherField: { type: 'Field', name: 'myOtherField' }
+        },
+        fields: {
+          myField: {
+            touched: true
+          },
+          myOtherField: {
+            touched: true
+          }
+        },
+        anyTouched: true
+      }
+    })
+  })
+
+  it('should only clear fields values and touched', () => {
+    const state = reducer(
+      fromJS({
+        foo: {
+          registeredFields: {
+            myField: { type: 'Field', name: 'myField' },
+            myOtherField: { type: 'Field', name: 'myOtherField' }
+          },
+          values: {
+            myField: 'value',
+            myOtherField: 'otherValue'
+          },
+          fields: {
+            myField: {
+              touched: true
+            },
+            myOtherField: {
+              touched: true
+            }
+          },
+          anyTouched: true
+        }
+      }),
+      clearFields('foo', false, false, 'myField')
+    )
+    expect(state).toEqualMap({
+      foo: {
+        registeredFields: {
+          myField: { type: 'Field', name: 'myField' },
+          myOtherField: { type: 'Field', name: 'myOtherField' }
+        },
+        values: {
+          myOtherField: 'otherValue'
+        },
+        fields: {
+          myField: {},
+          myOtherField: {
+            touched: true
+          }
+        },
+        anyTouched: true
+      }
+    })
+  })
+
+  it('should only clear fields values and keep touched', () => {
+    const state = reducer(
+      fromJS({
+        foo: {
+          registeredFields: {
+            myField: { type: 'Field', name: 'myField' },
+            myOtherField: { type: 'Field', name: 'myOtherField' }
+          },
+          values: {
+            myField: 'value',
+            myOtherField: 'otherValue'
+          },
+          fields: {
+            myField: {
+              touched: true
+            },
+            myOtherField: {
+              touched: true
+            }
+          },
+          anyTouched: true
+        }
+      }),
+      clearFields('foo', true, false, 'myField')
+    )
+    expect(state).toEqualMap({
+      foo: {
+        registeredFields: {
+          myField: { type: 'Field', name: 'myField' },
+          myOtherField: { type: 'Field', name: 'myOtherField' }
+        },
+        values: {
+          myOtherField: 'otherValue'
+        },
+        fields: {
+          myField: {
+            touched: true
+          },
+          myOtherField: {
+            touched: true
+          }
+        },
+        anyTouched: true
+      }
+    })
+  })
+
+  it('should NOT remove field-level submit errors and global errors if persistentSubmitErrors is enabled', () => {
+    const state = reducer(
+      fromJS({
+        foo: {
+          registeredFields: {
+            myField: { type: 'Field', name: 'myField' },
+            myOtherField: { type: 'Field', name: 'myOtherField' }
+          },
+          values: {
+            myField: 'value',
+            myOtherField: 'otherValue'
+          },
+          asyncErrors: {
+            myField: 'async error',
+            myOtherField: 'async error'
+          },
+          submitErrors: {
+            myField: 'submit error',
+            myOtherField: 'submit error'
+          },
+          fields: {
+            myField: {
+              touched: true
+            },
+            myOtherField: {
+              touched: true
+            }
+          },
+          error: 'some global error',
+          anyTouched: true
+        }
+      }),
+      clearFields('foo', true, true, 'myField')
+    )
+    expect(state).toEqualMap({
+      foo: {
+        registeredFields: {
+          myField: { type: 'Field', name: 'myField' },
+          myOtherField: { type: 'Field', name: 'myOtherField' }
+        },
+        values: {
+          myOtherField: 'otherValue'
+        },
+        fields: {
+          myField: {
+            touched: true
+          },
+          myOtherField: {
+            touched: true
+          }
+        },
+        asyncErrors: {
+          myOtherField: 'async error'
+        },
+        submitErrors: {
+          myField: 'submit error',
+          myOtherField: 'submit error'
+        },
+        error: 'some global error',
+        anyTouched: true
+      }
+    })
+  })
+
+  it('should reset deep fields as touched and remove values on clearFields', () => {
+    const state = reducer(
+      fromJS({
+        foo: {
+          registeredFields: {
+            'deep.myField': { type: 'Field', name: 'deep.myField' },
+            'deep.myOtherField': { type: 'Field', name: 'deep.myOtherField' }
+          },
+          values: {
+            deep: {
+              myField: 'value',
+              myOtherField: 'otherValue'
+            }
+          },
+          fields: {
+            deep: {
+              myField: {
+                touched: true
+              },
+              myOtherField: {
+                touched: true
+              }
+            }
+          },
+          anyTouched: true
+        }
+      }),
+      clearFields('foo', false, false, 'deep.myField', 'deep.myOtherField')
+    )
+    expect(state).toEqualMap({
+      foo: {
+        registeredFields: {
+          'deep.myField': { type: 'Field', name: 'deep.myField' },
+          'deep.myOtherField': { type: 'Field', name: 'deep.myOtherField' }
+        },
+        fields: {
+          deep: {
+            myField: {},
+            myOtherField: {}
+          }
+        }
+      }
+    })
+  })
+
+  it('should reset array fields as touched and clear values on clearFields', () => {
+    const state = reducer(
+      fromJS({
+        foo: {
+          registeredFields: {
+            'myFields[0]': { type: 'Field', name: 'myFields[0]' },
+            'myFields[1]': { type: 'Field', name: 'myFields[1]' }
+          },
+          values: {
+            myFields: ['value', 'otherValue']
+          },
+          fields: {
+            myFields: [{ touched: true }, { touched: true }]
+          },
+          anyTouched: true
+        }
+      }),
+      clearFields('foo', false, false, 'myFields[0]', 'myFields[1]')
+    )
+    expect(state).toEqualMap({
+      foo: {
+        registeredFields: {
+          'myFields[0]': { type: 'Field', name: 'myFields[0]' },
+          'myFields[1]': { type: 'Field', name: 'myFields[1]' }
+        },
+        values: {
+          myFields: [undefined, undefined]
+        },
+        fields: {
+          myFields: [{}, {}]
+        }
+      }
+    })
+  })
+}
+
+export default describeClearFields

--- a/src/__tests__/reducer.spec.js
+++ b/src/__tests__/reducer.spec.js
@@ -23,6 +23,7 @@ import describeChange from './helpers/reducer.change'
 import describeClearSubmit from './helpers/reducer.clearSubmit'
 import describeClearSubmitErrors from './helpers/reducer.clearSubmitErrors'
 import describeClearAsyncError from './helpers/reducer.clearAsyncError'
+import describeClearFields from './helpers/reducer.clearFields'
 import describeDestroy from './helpers/reducer.destroy'
 import describeFocus from './helpers/reducer.focus'
 import describeTouch from './helpers/reducer.touch'
@@ -59,6 +60,7 @@ const tests = {
   clearSubmit: describeClearSubmit,
   clearSubmitErrors: describeClearSubmitErrors,
   clearAsyncError: describeClearAsyncError,
+  clearFields: describeClearFields,
   destroy: describeDestroy,
   focus: describeFocus,
   reset: describeReset,

--- a/src/__tests__/reduxForm.spec.js
+++ b/src/__tests__/reduxForm.spec.js
@@ -147,6 +147,7 @@ const describeReduxForm = (name, structure, combineReducers, setup) => {
         'blur',
         'change',
         'clearAsyncError',
+        'clearFields',
         'clearSubmit',
         'clearSubmitErrors',
         'destroy',
@@ -201,6 +202,7 @@ const describeReduxForm = (name, structure, combineReducers, setup) => {
       expect(typeof props.autofill).toBe('function')
       expect(typeof props.blur).toBe('function')
       expect(typeof props.change).toBe('function')
+      expect(typeof props.clearFields).toBe('function')
       expect(typeof props.destroy).toBe('function')
       expect(typeof props.dirty).toBe('boolean')
       expect(typeof props.form).toBe('string')
@@ -3655,7 +3657,7 @@ const describeReduxForm = (name, structure, combineReducers, setup) => {
         bar: 'cat'
       })
       expect(onChange.mock.calls[1][3]).toEqualMap({
-        foo: 'dog',
+        foo: 'dog'
       })
 
       changeFoo('dog')

--- a/src/actionTypes.js
+++ b/src/actionTypes.js
@@ -14,6 +14,7 @@ export const ARRAY_SWAP = `${prefix}ARRAY_SWAP`
 export const AUTOFILL = `${prefix}AUTOFILL`
 export const BLUR = `${prefix}BLUR`
 export const CHANGE = `${prefix}CHANGE`
+export const CLEAR_FIELDS = `${prefix}CLEAR_FIELDS`
 export const CLEAR_SUBMIT = `${prefix}CLEAR_SUBMIT`
 export const CLEAR_SUBMIT_ERRORS = `${prefix}CLEAR_SUBMIT_ERRORS`
 export const CLEAR_ASYNC_ERROR = `${prefix}CLEAR_ASYNC_ERROR`

--- a/src/actionTypes.types.js.flow
+++ b/src/actionTypes.types.js.flow
@@ -16,6 +16,7 @@ export type ActionTypes = {
   CLEAR_SUBMIT: string,
   CLEAR_SUBMIT_ERRORS: string,
   CLEAR_ASYNC_ERROR: string,
+  CLEAR_FIELDS: string,
   DESTROY: string,
   FOCUS: string,
   INITIALIZE: string,

--- a/src/actions.js
+++ b/src/actions.js
@@ -21,6 +21,7 @@ import {
   INITIALIZE,
   REGISTER_FIELD,
   RESET,
+  CLEAR_FIELDS,
   SET_SUBMIT_FAILED,
   SET_SUBMIT_SUCCEEDED,
   START_ASYNC_VALIDATION,
@@ -68,6 +69,8 @@ import type {
   ClearSubmitErrors,
   ClearAsyncErrorAction,
   ClearAsyncError,
+  ClearFieldsAction,
+  ClearFields,
   DestroyAction,
   Destroy,
   FocusAction,
@@ -260,6 +263,16 @@ const clearAsyncError: ClearAsyncError = (
   meta: { form, field }
 })
 
+const clearFields: ClearFields = (
+  form: string,
+  keepTouched: boolean,
+  persistentSubmitErrors: boolean,
+  ...fields: string[]
+): ClearFieldsAction => ({
+  type: CLEAR_FIELDS,
+  meta: { form, keepTouched, persistentSubmitErrors, fields }
+})
+
 const destroy: Destroy = (...form: string[]): DestroyAction => ({
   type: DESTROY,
   meta: { form }
@@ -423,6 +436,7 @@ const actions = {
   initialize,
   registerField,
   reset,
+  clearFields,
   startAsyncValidation,
   startSubmit,
   stopAsyncValidation,

--- a/src/actions.types.js.flow
+++ b/src/actions.types.js.flow
@@ -134,6 +134,23 @@ export type ClearAsyncErrorAction = {
 export type ClearAsyncError = {
   (form: string, field: string): ClearAsyncErrorAction
 }
+export type ClearFieldsAction = {
+  type: string,
+  meta: {
+    form: string,
+    keepTouched: boolean,
+    persistentSubmitErrors: boolean,
+    fields: string[]
+  }
+} & Action
+export type ClearFields = {
+  (
+    form: string,
+    keepTouched: boolean,
+    persistentSubmitErrors: boolean,
+    ...fields: string[]
+  ): ClearFieldsAction
+}
 export type DestroyAction = { type: string, meta: { form: string[] } } & Action
 export type Destroy = { (...forms: string[]): DestroyAction }
 export type FocusAction = {
@@ -267,6 +284,7 @@ export type Actions = {
   clearSubmit: ClearSubmit,
   clearSubmitErrors: ClearSubmitErrors,
   clearAsyncError: ClearAsyncError,
+  clearFields: ClearFields,
   destroy: Destroy,
   focus: Focus,
   initialize: Initialize,

--- a/src/immutable.js
+++ b/src/immutable.js
@@ -62,6 +62,7 @@ export const autofill = actions.autofill
 export const blur = actions.blur
 export const change = actions.change
 export const clearSubmitErrors = actions.clearSubmitErrors
+export const clearFields = actions.clearFields
 export const destroy = actions.destroy
 export const focus = actions.focus
 export const initialize = actions.initialize


### PR DESCRIPTION
`clearFields(form:String, keepTouched: boolean, persistentSubmitErrors: boolean, ...fields:String)`

Cleans fields values for all the fields passed in.

> If the `keepTouched` parameter is `true`, the values of currently touched fields will be retained
> If the `persistentSubmitErrors` parameter is `true`, the values of currently submit errors fields will be retained

Closes: #3055, Closes: #2224