### PR TITLE
Update non dirty values also for non registered field values

### DIFF
--- a/docs/api/ActionCreators.md
+++ b/docs/api/ActionCreators.md
@@ -81,7 +81,7 @@ insert, so the item already at the `to` position will be bumped to a higher inde
 
 > Marks the given field as `active` and `visited`.
 
-### `initialize(form:String, data:Object, [keepDirty:boolean], [options:{keepDirty:boolean, keepSubmitSucceeded:boolean}])`
+### `initialize(form:String, data:Object, [keepDirty:boolean], [options:{keepDirty:boolean, keepSubmitSucceeded:boolean, updateUnregisteredFields:boolean}])`
 
 > Sets the initial values in the form with which future data values will be compared to calculate
 `dirty` and `pristine`. The `data` parameter may contain deep nested array and object values that match the shape of
@@ -93,6 +93,10 @@ the 3rd or 4th argument, for the sake of backwards compatibility).
 
 > If the `keepSubmitSucceeded` parameter is `true`,
 it will not clear the `submitSucceeded` flag if it is set.
+
+> If the `updateUnregisteredFields` parameter is `true`,
+it will update every initialValue if still pristine instead of only registered fields.
+Highly recommended, defaults to false because of non-breaking backwards compatibility. 
 
 ### `registerField(form:String, name:String, type:String)`
 

--- a/docs/api/ReduxForm.md
+++ b/docs/api/ReduxForm.md
@@ -84,10 +84,15 @@ The values should be in the form `{ field1: 'value1', field2: 'value2' }`.
 #### `keepDirtyOnReinitialize : boolean` [optional]
 
 > When set to `true` and `enableReinitialize` is also set, the form will retain the value
-of dirty fields when reinitializing. When this option is not set (the default), reinitializing
+of dirty fields and update every registered field which is still pristine when reinitializing. When this option is not set (the default), reinitializing
 the form replaces all field values. This option is useful in situations where the form has
 live updates or continues to be editable after form submission; it prevents
 reinitialization from overwriting user changes. Defaults to `false`.
+
+#### `updateUnregisteredFields : boolean` [optional]
+
+> Used in combination with `keepDirty(OnReinitialize)`. Will update every initialValue which is still pristine. Normally only registered Fields will be updated.
+In most cases, this option should be set to `true` to work as expected and avoid edge cases. It defaults to `false` because of non-breaking backwards compatibility.
 
 #### `onChange : Function` [optional]
 

--- a/src/__tests__/helpers/reducer.initialize.js
+++ b/src/__tests__/helpers/reducer.initialize.js
@@ -447,6 +447,30 @@ const describeInitialize = (reducer, expect, { fromJS }) => () => {
     })
   })
 
+  it('should update pristine values if keepDirty, even if the field is not registered (yet)', () => {
+    const values = {
+      myField: [{ name: 'One' }, { name: 'Two' }]
+    }
+    const initial = {
+      myField: [{ name: 'One' }, { name: 'Two' }]
+    }
+
+    const newInitial = {
+      myField: [{ name: 'One' }, { name: 'Two' }, { name: 'Three' }]
+    }
+
+    const registeredFields = {}
+
+    const state = reducer(
+      fromJS({ foo: { registeredFields, values, initial } }),
+      initialize('foo', newInitial, true)
+    )
+
+    expect(state).toEqualMap({
+      foo: { registeredFields, values: newInitial, initial: newInitial }
+    })
+  })
+
   it('should not create empty object if new initial value is an empty array and keepDirty is set', () => {
     const before = {
       myForm: {

--- a/src/__tests__/helpers/reducer.initialize.js
+++ b/src/__tests__/helpers/reducer.initialize.js
@@ -447,7 +447,7 @@ const describeInitialize = (reducer, expect, { fromJS }) => () => {
     })
   })
 
-  it('should update pristine values if keepDirty, even if the field is not registered (yet)', () => {
+  it('should update pristine values if keepDirty and updateUnregisteredFields, even if the field is not registered (yet)', () => {
     const values = {
       myField: [{ name: 'One' }, { name: 'Two' }]
     }
@@ -463,7 +463,7 @@ const describeInitialize = (reducer, expect, { fromJS }) => () => {
 
     const state = reducer(
       fromJS({ foo: { registeredFields, values, initial } }),
-      initialize('foo', newInitial, true)
+      initialize('foo', newInitial, true, { updateUnregisteredFields: true })
     )
 
     expect(state).toEqualMap({

--- a/src/createReducer.js
+++ b/src/createReducer.js
@@ -313,24 +313,28 @@ function createReducer<M, L>(structure: Structure<M, L>) {
       let newValues = previousValues
 
       if (keepDirty && registeredFields) {
-        if (!deepEqual(newInitialValues, previousInitialValues)) {
-          //
-          // Keep the value of dirty fields while updating the value of
-          // pristine fields. This way, apps can reinitialize forms while
-          // avoiding stomping on user edits.
-          //
-          // Note 1: The initialize action replaces all initial values
-          // regardless of keepDirty.
-          //
-          // Note 2: When a field is dirty, keepDirty is enabled, and the field
-          // value is the same as the new initial value for the field, the
-          // initialize action causes the field to become pristine. That effect
-          // is what we want.
-          //
-          forEach(keys(registeredFields), name => {
+        if (!deepEqual(newInitialValues, previousInitialValues)) {          
+          forEach(keys(newInitialValues), name => {
             const previousInitialValue = getIn(previousInitialValues, name)
+            if (typeof previousInitialValue === 'undefined') {
+              // Add new values at the root level.
+              const newInitialValue = getIn(newInitialValues, name)
+              newValues = setIn(newValues, name, newInitialValue)
+            }
+
             const previousValue = getIn(previousValues, name)
 
+            // Keep the value of dirty fields while updating the value of
+            // pristine fields. This way, apps can reinitialize forms while
+            // avoiding stomping on user edits.
+            //
+            // Note 1: The initialize action replaces all initial values
+            // regardless of keepDirty.
+            //
+            // Note 2: When a field is dirty, keepDirty is enabled, and the field
+            // value is the same as the new initial value for the field, the
+            // initialize action causes the field to become pristine. That effect
+            // is what we want.
             if (deepEqual(previousValue, previousInitialValue)) {
               // Overwrite the old pristine value with the new pristine value
               const newInitialValue = getIn(newInitialValues, name)
@@ -341,15 +345,6 @@ function createReducer<M, L>(structure: Structure<M, L>) {
               if (getIn(newValues, name) !== newInitialValue) {
                 newValues = setIn(newValues, name, newInitialValue)
               }
-            }
-          })
-
-          forEach(keys(newInitialValues), name => {
-            const previousInitialValue = getIn(previousInitialValues, name)
-            if (typeof previousInitialValue === 'undefined') {
-              // Add new values at the root level.
-              const newInitialValue = getIn(newInitialValues, name)
-              newValues = setIn(newValues, name, newInitialValue)
             }
           })
         }

--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -224,6 +224,7 @@ export type Props = {
   initialValues?: any,
   invalid: boolean,
   keepDirtyOnReinitialize: any,
+  updateUnregisteredFields: boolean,
   onChange?: OnChangeFunction,
   onSubmit?: OnSubmitFunction,
   onSubmitFail?: OnSubmitFail,
@@ -283,6 +284,7 @@ const createReduxForm = (structure: Structure<*, *>) => {
       shouldWarn: defaultShouldWarn,
       enableReinitialize: false,
       keepDirtyOnReinitialize: false,
+      updateUnregisteredFields: false,
       getFormState: state => getIn(state, 'form'),
       pure: true,
       forceUnregisterOnUnmount: false,
@@ -330,7 +332,8 @@ const createReduxForm = (structure: Structure<*, *>) => {
               const keepDirty =
                 nextProps.initialized && this.props.keepDirtyOnReinitialize
               this.props.initialize(nextProps.initialValues, keepDirty, {
-                lastInitialValues: this.props.initialValues
+                lastInitialValues: this.props.initialValues,
+                updateUnregisteredFields: nextProps.updateUnregisteredFields,
               })
             }
           } else if (
@@ -339,7 +342,10 @@ const createReduxForm = (structure: Structure<*, *>) => {
           ) {
             this.props.initialize(
               this.props.initialValues,
-              this.props.keepDirtyOnReinitialize
+              this.props.keepDirtyOnReinitialize,
+              {
+                updateUnregisteredFields: this.props.updateUnregisteredFields,
+              }
             )
           }
         }
@@ -778,6 +784,7 @@ const createReduxForm = (structure: Structure<*, *>) => {
             initialValues,
             invalid,
             keepDirtyOnReinitialize,
+            updateUnregisteredFields,
             pristine,
             propNamespace,
             registeredFields,


### PR DESCRIPTION
I struggled a lot after working with dynamic fields. I figured out, that the fields have to be registered in order to get the (initial) values updated if keepDirty.

The problem is, that I got fields which will register after the initialising happens. Just initialising again doesn't solve the problem, because the first initialise did mutate the initialValues, which will be  dirty in the second case and will not update because of this.

After this change, the logic for updating pristine fields will now always apply, no matter if the fields a registered or not. This may be breaking to some apps? But I think this is more expected then the other case?

Does this make any sense to you @erikras ?

Thanks
