### PR TITLE
move initialization to componentDidMount

### DIFF
--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -526,6 +526,18 @@ const createReduxForm = (structure: Structure<*, *>) => {
           )
         }
 
+        componentDidMount() {
+          if (!isHotReloading()) {
+            this.initIfNeeded()
+            this.validateIfNeeded()
+            this.warnIfNeeded()
+          }
+          invariant(
+            this.props.shouldValidate,
+            'shouldValidate() is deprecated and will be removed in v8.0.0. Use shouldWarn() or shouldError() instead.'
+          )
+        }
+
         componentWillUnmount() {
           const { destroyOnUnmount, destroy } = this.props
           if (destroyOnUnmount && !isHotReloading()) {


### PR DESCRIPTION
React 16 ensures a certain order of lifcecycles when replacing a
component which causes redux-form to destroy the form, breaking
it. This change, when used with `enableReinitialize`, causes the
form to reinitialize correctly, preserving the form.

this pr address https://github.com/erikras/redux-form/issues/3435

this is probably going to fail a lot of tests, but want to start the 
conversation as to what is needed for redux-form to work with
React 16