### PR TITLE
Dont delete initial initialValues structure on withCleanUp

### DIFF
--- a/src/__tests__/deleteInWithCleanUp.spec.js
+++ b/src/__tests__/deleteInWithCleanUp.spec.js
@@ -1,4 +1,4 @@
-import createDeleteInWithCleanUp from '../deleteInWithCleanUp'
+import createCreateDeleteInWithCleanUp from '../deleteInWithCleanUp'
 import plain from '../structure/plain'
 import plainExpectations from '../structure/plain/__tests__/expectations'
 import immutable from '../structure/immutable'
@@ -6,7 +6,7 @@ import immutableExpectations from '../structure/immutable/__tests__/expectations
 
 const describeDeleteInWithCleanUp = (name, structure, setup) => {
   const { fromJS } = structure
-  const deleteInWithCleanUp = createDeleteInWithCleanUp(structure)
+  const deleteInWithCleanUp = createCreateDeleteInWithCleanUp(structure)()
 
   describe(name, () => {
     beforeAll(() => {

--- a/src/__tests__/deleteInWithCleanUp.spec.js
+++ b/src/__tests__/deleteInWithCleanUp.spec.js
@@ -145,6 +145,35 @@ const describeDeleteInWithCleanUp = (name, structure, setup) => {
         )
       ).toEqualMap({})
     })
+
+    it('should only delete cats because I am a dog person', () => {
+      const validation = (structure) => (state, path) => path.startsWith('cat')
+      const deleteInSpecial = createCreateDeleteInWithCleanUp(structure)(validation)
+
+      expect(
+        deleteInSpecial(
+          fromJS({
+            dog: 'Scooby',
+            cat: 'Garfield'
+          }),
+          'dog'
+        )
+      ).toEqualMap({
+        dog: 'Scooby',
+        cat: 'Garfield'
+      })
+      expect(
+        deleteInSpecial(
+          fromJS({
+            dog: 'Scooby',
+            cat: 'Garfield'
+          }),
+          'cat'
+        )
+      ).toEqualMap({
+        dog: 'Scooby',
+      })
+    })
   })
 }
 

--- a/src/__tests__/helpers/reducer.blur.js
+++ b/src/__tests__/helpers/reducer.blur.js
@@ -242,6 +242,42 @@ const describeBlur = (reducer, expect, { fromJS, setIn }) => () => {
     })
   })
 
+  it('should NOT remove nested value container if it is included inside the initial values', () => {
+    const state = reducer(
+      fromJS({
+        foo: {
+          initial: {
+            nested: {}
+          },
+          values: {
+            nested: {
+              myField: 'initialValue'
+            }
+          }
+        }
+      }),
+      blur('foo', 'nested.myField', '', true)
+    )
+    expect(state).toEqualMap({
+      foo: {
+        anyTouched: true,
+        fields: {
+          nested: {
+            myField: {
+              touched: true
+            }
+          }
+        },
+        initial: {
+          nested: {}
+        },
+        values: {
+          nested: {}
+        }
+      }
+    })
+  })
+
   it('should set nested value on blur', () => {
     const state = reducer(
       fromJS({

--- a/src/createReducer.js
+++ b/src/createReducer.js
@@ -36,9 +36,21 @@ import {
   CLEAR_FIELDS,
   UPDATE_SYNC_WARNINGS
 } from './actionTypes'
-import createDeleteInWithCleanUp from './deleteInWithCleanUp'
+import createCreateDeleteInWithCleanUp from './deleteInWithCleanUp'
 import plain from './structure/plain'
 import type { Action, Structure } from './types.js.flow'
+
+const shouldDelete = ({ getIn }) => (state, path) => {
+  let initialValuesPath = null
+
+  if (path.startsWith('values')) {
+    initialValuesPath = path.replace('values', 'initial')
+  }
+
+  const initialValueComparison = initialValuesPath ? (getIn(state, initialValuesPath) === undefined) : true
+
+  return (getIn(state, path) !== undefined) && initialValueComparison
+}
 
 const isReduxFormAction = action =>
   action &&
@@ -60,8 +72,8 @@ function createReducer<M, L>(structure: Structure<M, L>) {
     some,
     splice
   } = structure
-  const deleteInWithCleanUp = createDeleteInWithCleanUp(structure)
-  const plainDeleteInWithCleanUp = createDeleteInWithCleanUp(plain)
+  const deleteInWithCleanUp = createCreateDeleteInWithCleanUp(structure)(shouldDelete)
+  const plainDeleteInWithCleanUp = createCreateDeleteInWithCleanUp(plain)(shouldDelete)
   const doSplice = (state, key, field, index, removeNum, value, force) => {
     const existing = getIn(state, `${key}.${field}`)
     return existing || force

--- a/src/deleteInWithCleanUp.js
+++ b/src/deleteInWithCleanUp.js
@@ -10,6 +10,12 @@ function createDeleteInWithCleanUp<DIM, DIL>({
   setIn
 }: Structure<DIM, DIL>) {
   const deleteInWithCleanUp = (state: DIM | DIL, path: string): DIM | DIL => {
+    let initialValuesPath = null
+
+    if (path.startsWith('values')) {
+      initialValuesPath = path.replace('values', 'initial')
+    }
+
     if (path[path.length - 1] === ']') {
       // array path
       const pathTokens = toPath(path)
@@ -19,7 +25,10 @@ function createDeleteInWithCleanUp<DIM, DIL>({
     }
 
     let result: DIM | DIL = state
-    if (getIn(state, path) !== undefined) {
+
+    const initialValueComparison = initialValuesPath ? (getIn(state, initialValuesPath) === undefined) : true
+
+    if (getIn(state, path) !== undefined && initialValueComparison) {
       result = deleteIn(state, path)
     }
 

--- a/src/deleteInWithCleanUp.js
+++ b/src/deleteInWithCleanUp.js
@@ -2,12 +2,23 @@
 import { toPath } from 'lodash'
 import type { Structure } from './types'
 
-function createCreateDeleteInWithCleanUp<DIM, DIL>(structure: Structure<DIM, DIL>) {
-  const shouldDeleteDefault = (structure) => (state, path) => structure.getIn(state, path) !== undefined
+type ShouldDelete<SDM, SDL> = (
+  structure: Structure<SDM, SDL>
+) => (state: SDM | SDL, path: string) => boolean
+
+function createCreateDeleteInWithCleanUp<DIM, DIL>(
+  structure: Structure<DIM, DIL>
+) {
+  const shouldDeleteDefault: ShouldDelete<DIM, DIL> = structure => (
+    state,
+    path
+  ) => structure.getIn(state, path) !== undefined
 
   const { deepEqual, empty, getIn, deleteIn, setIn } = structure
 
-  return (shouldDelete = shouldDeleteDefault) => {
+  return (
+    shouldDelete: ShouldDelete<DIM, DIL> = shouldDeleteDefault
+  ): DIM | DIL => {
     const deleteInWithCleanUp = (state: DIM | DIL, path: string): DIM | DIL => {
       if (path[path.length - 1] === ']') {
         // array path


### PR DESCRIPTION
possibly fixes #2597  #3366 

@erikras What's your opinion here?

I will create an additional test to catch this case for the future.

Edit: Let me try to restructure it. I don't like to have this logic inside a util function. 

Edit2: The second commit did restructure the implementation. `deleteInWithCleanUp` now takes an optional `shouldDelete` function, where you can specify when to delete and when not.

Edit3: Added a test to the `BLUR` reducer, if you like it, I can add it also to the `CHANGE` and `CLEAR_FIELDS` reducer.