### PR TITLE
Update SyncValidation.md

### DIFF
--- a/examples/syncValidation/src/SyncValidation.md
+++ b/examples/syncValidation/src/SyncValidation.md
@@ -34,6 +34,8 @@ has been touched, a flag that is set for you by `redux-form` when the onBlur
 event occurs on your field. When you submit the form, all the fields are marked
 as touched, allowing any of their validation errors to show.
 
+**IMPORTANT**: In your validate function, values can be `undefined`, so pay attention when you are validating nested fields. If not, you could encounter some `TypeError: undefined is not an object`.
+
 ## Running this example locally
 
 To run this example locally on your machine clone the `redux-form` repository,


### PR DESCRIPTION
Hello,

We ran into this issue and it's not clear whether it's a bug in redux-form. Sometimes, when the Form components are unmounted, redux-form validates the fields but the fields are already removed from the redux-store so they are undefined.