### PR TITLE
Fix asyncValidate when asyncBlur/ChangeFields are provided

### DIFF
--- a/src/__tests__/Field.spec.js
+++ b/src/__tests__/Field.spec.js
@@ -1065,6 +1065,275 @@ const describeField = (name, structure, combineReducers, setup) => {
       expect(asyncValidate).toHaveBeenCalled()
     })
 
+    it('should call asyncValidate function on change', () => {
+      const store = makeStore({
+        testForm: {
+          values: {
+            title: 'Redux Form',
+            author: 'Erik Rasmussen',
+            username: 'oldusername'
+          }
+        }
+      })
+      const renderUsername = jest.fn(props => <input {...props.input} />)
+      class Form extends Component {
+        render() {
+          return (
+            <div>
+              <Field name="title" component="input" />
+              <Field name="author" component="input" />
+              <Field name="username" component={renderUsername} />
+            </div>
+          )
+        }
+      }
+      const asyncValidate = jest.fn(() => new Promise(resolve => resolve()))
+      const TestForm = reduxForm({ form: 'testForm', asyncValidate })(Form)
+      TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <TestForm />
+        </Provider>
+      )
+
+      renderUsername.mock.calls[0][0].input.onChange('ERIKRAS')
+
+      expect(asyncValidate).toHaveBeenCalled()
+    })
+
+    it('should call asyncValidate function on blur if field is specified', () => {
+      const store = makeStore({
+        testForm: {
+          values: {
+            title: 'Redux Form',
+            author: 'Erik Rasmussen',
+            username: 'oldusername'
+          }
+        }
+      })
+      const renderUsername = jest.fn(props => <input {...props.input} />)
+      class Form extends Component {
+        render() {
+          return (
+            <div>
+              <Field name="title" component="input" />
+              <Field name="author" component="input" />
+              <Field name="username" component={renderUsername} />
+            </div>
+          )
+        }
+      }
+      const asyncValidate = jest.fn(() => new Promise(resolve => resolve()))
+      const TestForm = reduxForm({
+        form: 'testForm',
+        asyncValidate,
+        asyncBlurFields: ['username']
+      })(Form)
+      TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <TestForm />
+        </Provider>
+      )
+
+      renderUsername.mock.calls[0][0].input.onBlur('ERIKRAS')
+
+      expect(asyncValidate).toHaveBeenCalled()
+    })
+
+    it('should call asyncValidate function on change if field is specified', () => {
+      const store = makeStore({
+        testForm: {
+          values: {
+            title: 'Redux Form',
+            author: 'Erik Rasmussen',
+            username: 'oldusername'
+          }
+        }
+      })
+      const renderUsername = jest.fn(props => <input {...props.input} />)
+      class Form extends Component {
+        render() {
+          return (
+            <div>
+              <Field name="title" component="input" />
+              <Field name="author" component="input" />
+              <Field name="username" component={renderUsername} />
+            </div>
+          )
+        }
+      }
+      const asyncValidate = jest.fn(() => new Promise(resolve => resolve()))
+      const TestForm = reduxForm({
+        form: 'testForm',
+        asyncValidate,
+        asyncChangeFields: ['username']
+      })(Form)
+      TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <TestForm />
+        </Provider>
+      )
+
+      renderUsername.mock.calls[0][0].input.onChange('ERIKRAS')
+
+      expect(asyncValidate).toHaveBeenCalled()
+    })
+
+    it('should not call asyncValidate function on blur if field is specified and different', () => {
+      const store = makeStore({
+        testForm: {
+          values: {
+            title: 'Redux Form',
+            author: 'Erik Rasmussen',
+            username: 'oldusername'
+          }
+        }
+      })
+      const renderUsername = jest.fn(props => <input {...props.input} />)
+      class Form extends Component {
+        render() {
+          return (
+            <div>
+              <Field name="title" component="input" />
+              <Field name="author" component="input" />
+              <Field name="username" component={renderUsername} />
+            </div>
+          )
+        }
+      }
+      const asyncValidate = jest.fn(() => new Promise(resolve => resolve()))
+      const TestForm = reduxForm({
+        form: 'testForm',
+        asyncValidate,
+        asyncBlurFields: ['author']
+      })(Form)
+      TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <TestForm />
+        </Provider>
+      )
+
+      renderUsername.mock.calls[0][0].input.onBlur('ERIKRAS')
+
+      expect(asyncValidate).not.toHaveBeenCalled()
+    })
+
+    it('should not call asyncValidate function on change if field is specified and different', () => {
+      const store = makeStore({
+        testForm: {
+          values: {
+            title: 'Redux Form',
+            author: 'Erik Rasmussen',
+            username: 'oldusername'
+          }
+        }
+      })
+      const renderUsername = jest.fn(props => <input {...props.input} />)
+      class Form extends Component {
+        render() {
+          return (
+            <div>
+              <Field name="title" component="input" />
+              <Field name="author" component="input" />
+              <Field name="username" component={renderUsername} />
+            </div>
+          )
+        }
+      }
+      const asyncValidate = jest.fn(() => new Promise(resolve => resolve()))
+      const TestForm = reduxForm({
+        form: 'testForm',
+        asyncValidate,
+        asyncChangeFields: ['author']
+      })(Form)
+      TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <TestForm />
+        </Provider>
+      )
+
+      renderUsername.mock.calls[0][0].input.onChange('ERIKRAS')
+
+      expect(asyncValidate).not.toHaveBeenCalled()
+    })
+
+    it('should not call asyncValidate function on change if field is specified as onBlur', () => {
+      const store = makeStore({
+        testForm: {
+          values: {
+            title: 'Redux Form',
+            author: 'Erik Rasmussen',
+            username: 'oldusername'
+          }
+        }
+      })
+      const renderUsername = jest.fn(props => <input {...props.input} />)
+      class Form extends Component {
+        render() {
+          return (
+            <div>
+              <Field name="title" component="input" />
+              <Field name="author" component="input" />
+              <Field name="username" component={renderUsername} />
+            </div>
+          )
+        }
+      }
+      const asyncValidate = jest.fn(() => new Promise(resolve => resolve()))
+      const TestForm = reduxForm({
+        form: 'testForm',
+        asyncValidate,
+        asyncBlurFields: ['username']
+      })(Form)
+      TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <TestForm />
+        </Provider>
+      )
+
+      renderUsername.mock.calls[0][0].input.onChange('ERIKRAS')
+
+      expect(asyncValidate).not.toHaveBeenCalled()
+    })
+
+    it('should not call asyncValidate function on blur if field is specified as onChange', () => {
+      const store = makeStore({
+        testForm: {
+          values: {
+            title: 'Redux Form',
+            author: 'Erik Rasmussen',
+            username: 'oldusername'
+          }
+        }
+      })
+      const renderUsername = jest.fn(props => <input {...props.input} />)
+      class Form extends Component {
+        render() {
+          return (
+            <div>
+              <Field name="title" component="input" />
+              <Field name="author" component="input" />
+              <Field name="username" component={renderUsername} />
+            </div>
+          )
+        }
+      }
+      const asyncValidate = jest.fn(() => new Promise(resolve => resolve()))
+      const TestForm = reduxForm({
+        form: 'testForm',
+        asyncValidate,
+        asyncChangeFields: ['username']
+      })(Form)
+      TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <TestForm />
+        </Provider>
+      )
+
+      renderUsername.mock.calls[0][0].input.onBlur('ERIKRAS')
+
+      expect(asyncValidate).not.toHaveBeenCalled()
+    })
+
     it('should call handle on focus', () => {
       const store = makeStore({
         testForm: {

--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -335,7 +335,7 @@ const createReduxForm = (structure: Structure<*, *>) => {
                 nextProps.initialized && this.props.keepDirtyOnReinitialize
               this.props.initialize(nextProps.initialValues, keepDirty, {
                 lastInitialValues: this.props.initialValues,
-                updateUnregisteredFields: nextProps.updateUnregisteredFields,
+                updateUnregisteredFields: nextProps.updateUnregisteredFields
               })
             }
           } else if (
@@ -346,7 +346,7 @@ const createReduxForm = (structure: Structure<*, *>) => {
               this.props.initialValues,
               this.props.keepDirtyOnReinitialize,
               {
-                updateUnregisteredFields: this.props.updateUnregisteredFields,
+                updateUnregisteredFields: this.props.updateUnregisteredFields
               }
             )
           }
@@ -649,7 +649,11 @@ const createReduxForm = (structure: Structure<*, *>) => {
             : undefined
         }
 
-        asyncValidate = (name: string, value: any, trigger: 'blur' | 'change') => {
+        asyncValidate = (
+          name: string,
+          value: any,
+          trigger: 'blur' | 'change'
+        ) => {
           const {
             asyncBlurFields,
             asyncChangeFields,
@@ -670,13 +674,19 @@ const createReduxForm = (structure: Structure<*, *>) => {
               ? values
               : setIn(values, name, value)
             const syncValidationPasses = submitting || !getIn(syncErrors, name)
+            const fieldNeedsValidationForBlur =
+              asyncBlurFields &&
+              ~asyncBlurFields.indexOf(name.replace(/\[[0-9]+\]/g, '[]'))
+            const fieldNeedsValidationForChange =
+              asyncChangeFields &&
+              ~asyncChangeFields.indexOf(name.replace(/\[[0-9]+\]/g, '[]'))
+            const formHasAsyncFields = !asyncBlurFields && !asyncChangeFields
             const fieldNeedsValidation =
               !submitting &&
-              trigger === 'blur'
-                ? (!asyncBlurFields ||
-                  ~asyncBlurFields.indexOf(name.replace(/\[[0-9]+\]/g, '[]')))
-                : (!asyncChangeFields ||
-                  ~asyncChangeFields.indexOf(name.replace(/\[[0-9]+\]/g, '[]')))
+              (formHasAsyncFields ||
+                (trigger === 'blur'
+                  ? fieldNeedsValidationForBlur
+                  : fieldNeedsValidationForChange))
             if (
               (fieldNeedsValidation || submitting) &&
               shouldAsyncValidate({


### PR DESCRIPTION
Check if either asyncBlurFields or asyncChangeFields are provided. If neither is, trigger validation. If any is, need to check if the blurred/changed field is on the corresponding list.
Fixes #3645 