### PR TITLE
Add missing "name" parameter to Validator function type.

### DIFF
--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -8,7 +8,12 @@ export type Action = {
   error?: any
 }
 
-export type Validator = (value: any, allValues: Object, props: Object) => ?any
+export type Validator = (
+  value: any,
+  allValues: Object,
+  props: Object,
+  name: string
+) => ?any
 
 export interface Structure<M, L> {
   allowsArrayErrors: boolean;


### PR DESCRIPTION
The name parameter is officially documented as part of the API but is missing from the Validator type definition.

BTW, I don't think it makes much sense to have `any` marked as a *maybe* type since `any` already implies it can be anything ;) But that's unrelated so I didn't change it.