### PR TITLE
Update es6-error module

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "homepage": "https://redux-form.com/",
   "dependencies": {
     "deep-equal": "^1.0.1",
-    "es6-error": "^4.0.0",
+    "es6-error": "^4.1.1",
     "hoist-non-react-statics": "^2.3.1",
     "invariant": "^2.2.2",
     "is-promise": "^2.1.0",


### PR DESCRIPTION
es6-error in version 4.1.0 has an error and due of this redux-form doesn't show errors. 

An instance of SubmissionError class doesn't recognize as its class. 

```
const error= new SubmissionError({...});

error instanceof SubmissionError // gives false but should true
```

No issue with module es6-error@4.1.1. 

Unfortunately even there is never version of es6-error, yarn on my production server still installs broken version which is 4.1.0.  