### PR TITLE
Ensure errors thrown from submit handler are not silenced

### DIFF
--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -718,7 +718,7 @@ const createReduxForm = (structure: Structure<*, *>) => {
 
         submitFailed = (error: any): void => {
           delete this.submitPromise
-          return error
+          throw error
         }
 
         listenToSubmit = (promise: any) => {


### PR DESCRIPTION
Fixes https://github.com/erikras/redux-form/issues/3303

In the very likely case that an error is encountered during a submit callback we need to be able to reliably detect any failures.

This restores the correct behavior stated in the [documentation](https://redux-form.com/7.2.0/docs/api/reduxform.md/#-code-submit-promise-code-):

> Submits the form. [You'd never have guessed that, right?] Returns a promise that will be resolved when the form is submitted successfully, or rejected if the submission fails.

This will revert the change made in https://github.com/erikras/redux-form/pull/3227, but throwing the error is a _far better_ compromise that benefits a _much larger set_ of redux-form users. It's possible to silence errors in your own code, but not possible to recover discarded errors from inside an isolated context in a lib.