### PR TITLE
Delimit aside using parentheses instead of comma

### DIFF
--- a/examples/fieldLevelValidation/src/FieldLevelValidation.md
+++ b/examples/fieldLevelValidation/src/FieldLevelValidation.md
@@ -1,8 +1,8 @@
 # Field-Level Validation Example
 
 As well as allowing you to provide a validation function to validate all the
-values in your form at once, see
-[Synchronous Validation Example](http://redux-form.com/7.2.0/examples/syncValidation/),
+values in your form at once (see
+[Synchronous Validation Example](http://redux-form.com/7.2.0/examples/syncValidation/)),
 you may also provide individual value validation functions for each `Field` or
 `FieldArray`.
 


### PR DESCRIPTION
In this commit message, I'm using the word "aside" as a noun (as in, "She wrote it as an aside"), not as an adverb (as in, "She set her notes aside").