### PR TITLE
Fields re-render every time due to regression introduced with flow typings.

### DIFF
--- a/src/__tests__/Field.spec.js
+++ b/src/__tests__/Field.spec.js
@@ -914,6 +914,52 @@ const describeField = (name, structure, combineReducers, setup) => {
       expect(input).toHaveBeenCalledTimes(1)
     })
 
+    it('The render() function should not be called if neither state nor props of the field has changed', () => {
+      const store = makeStore()
+      const input = jest.fn(props => <input {...props.input} />)
+      const renderSpy = jest.fn()
+
+      class TestField extends Field {
+        render() {
+          renderSpy()
+          return super.render()
+        }
+      }
+
+      class Form extends Component {
+        constructor() {
+          super()
+          this.state = { foo: 'bar' }
+        }
+
+        render() {
+          return (
+            <div>
+              <TestField name="myField" component={input} />
+              <button onClick={() => this.setState({ foo: 'qux' })}>
+                Change
+              </button>
+            </div>
+          )
+        }
+      }
+      const TestForm = reduxForm({ form: 'testForm' })(Form)
+      const dom = TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <TestForm />
+        </Provider>
+      )
+
+      expect(renderSpy).toHaveBeenCalledTimes(1)
+      expect(input).toHaveBeenCalledTimes(1)
+
+      const button = TestUtils.findRenderedDOMComponentWithTag(dom, 'button')
+      TestUtils.Simulate.click(button)
+
+      expect(renderSpy).toHaveBeenCalledTimes(1)
+      expect(input).toHaveBeenCalledTimes(1)
+    })
+
     it('should call normalize function on change', () => {
       const store = makeStore({
         testForm: {

--- a/src/createField.js
+++ b/src/createField.js
@@ -33,7 +33,7 @@ const createField = (structure: Structure<*, *>) => {
       }
     }
 
-    shouldComponentUpdate(nextProps: Props, nextState: Object) {
+    shouldComponentUpdate(nextProps: Props, nextState?: Object) {
       return shallowCompare(this, nextProps, nextState)
     }
 

--- a/src/createField.js
+++ b/src/createField.js
@@ -33,8 +33,8 @@ const createField = (structure: Structure<*, *>) => {
       }
     }
 
-    shouldComponentUpdate(nextProps: Props) {
-      return shallowCompare(this, nextProps)
+    shouldComponentUpdate(nextProps: Props, nextState: Object) {
+      return shallowCompare(this, nextProps, nextState)
     }
 
     componentWillMount() {

--- a/src/util/shallowCompare.js
+++ b/src/util/shallowCompare.js
@@ -24,8 +24,11 @@ const shallowCompare = (
   instance: { props: any, state?: any },
   nextProps: Object,
   nextState?: Object
-): boolean =>
-  !isEqualWith(instance.props, nextProps, customizer) ||
-  !isEqualWith(instance.state, nextState, customizer)
+): boolean => {
+  const propsEqual = isEqualWith(instance.props, nextProps, customizer)
+  const stateEqual = isEqualWith(instance.state, nextState, customizer)
+
+  return !propsEqual || !stateEqual
+}
 
 export default shallowCompare


### PR DESCRIPTION
This PR fixes a regression introduced in #3138 where the `shouldComponentUpdate` method of `createField.js` no longer sent `nextState` as an argument to `shallowCompare` when checking if a component should update. This regression effectively made every field re-render every time since the default state of a react component is `null` and an unspecified argument is `undefined`, making `shallowCompare` do a `null === undefined` check to determine if the component should update.