### PR TITLE
Fix for double INITIALIZE happening on first mount

### DIFF
--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -539,7 +539,7 @@ const createReduxForm = (structure: Structure<*, *>) => {
 
         componentDidMount() {
           if (!isHotReloading()) {
-            this.initIfNeeded()
+            this.initIfNeeded(this.props)
             this.validateIfNeeded()
             this.warnIfNeeded()
           }


### PR DESCRIPTION
This is a fix for an issue where the INITIALIZE action is fired twice, clearing change actions that happen when a form mounts.

See #3690 for details of the bug.

This fixes #3706 and fixes #3690.

I attempted to remove those formatting changes, but they got reversed by the precommit hook I believe.