### PR TITLE
Fix flat structure for asyncErrors and submitErrors for FieldArray and Fields.

### DIFF
--- a/src/ConnectedFieldArray.js
+++ b/src/ConnectedFieldArray.js
@@ -149,11 +149,11 @@ const createConnectedFieldArray = (structure: Structure<*, *>) => {
       const syncWarning = getSyncWarning(getIn(formState, 'syncWarnings'), name)
       const pristine = deepEqual(value, initial)
       return {
-        asyncError: getIn(formState, `asyncErrors.${name}._error`),
+        asyncError: getIn(formState, `asyncErrors['${name}._error']`),
         dirty: !pristine,
         pristine,
         state: getIn(formState, `fields.${name}`),
-        submitError: getIn(formState, `submitErrors.${name}._error`),
+        submitError: getIn(formState, `submitErrors['${name}._error']`),
         submitFailed: getIn(formState, 'submitFailed'),
         submitting,
         syncError,

--- a/src/ConnectedFields.js
+++ b/src/ConnectedFields.js
@@ -125,24 +125,25 @@ const createConnectedFields = (structure: Structure<*, *>) => {
     render() {
       const { component, withRef, _fields, _reduxForm, ...rest } = this.props
       const { sectionPrefix, form } = _reduxForm
-      const { custom, ...props } = Object.keys(
-        _fields
-      ).reduce((accumulator, name) => {
-        const connectedProps = _fields[name]
-        const { custom, ...fieldProps } = createFieldProps(structure, name, {
-          ...connectedProps,
-          ...rest,
-          form,
-          onBlur: this.onBlurFns[name],
-          onChange: this.onChangeFns[name],
-          onFocus: this.onFocusFns[name]
-        })
-        accumulator.custom = custom
-        const fieldName = sectionPrefix
-          ? name.replace(`${sectionPrefix}.`, '')
-          : name
-        return plain.setIn(accumulator, fieldName, fieldProps)
-      }, {})
+      const { custom, ...props } = Object.keys(_fields).reduce(
+        (accumulator, name) => {
+          const connectedProps = _fields[name]
+          const { custom, ...fieldProps } = createFieldProps(structure, name, {
+            ...connectedProps,
+            ...rest,
+            form,
+            onBlur: this.onBlurFns[name],
+            onChange: this.onChangeFns[name],
+            onFocus: this.onFocusFns[name]
+          })
+          accumulator.custom = custom
+          const fieldName = sectionPrefix
+            ? name.replace(`${sectionPrefix}.`, '')
+            : name
+          return plain.setIn(accumulator, fieldName, fieldProps)
+        },
+        {}
+      )
       if (withRef) {
         props.ref = 'renderedComponent'
       }
@@ -178,13 +179,13 @@ const createConnectedFields = (structure: Structure<*, *>) => {
           const submitting = getIn(formState, 'submitting')
           const pristine = value === initial
           accumulator[name] = {
-            asyncError: getIn(formState, `asyncErrors.${name}`),
+            asyncError: getIn(formState, `asyncErrors['${name}']`),
             asyncValidating: getIn(formState, 'asyncValidating') === name,
             dirty: !pristine,
             initial,
             pristine,
             state: getIn(formState, `fields.${name}`),
-            submitError: getIn(formState, `submitErrors.${name}`),
+            submitError: getIn(formState, `submitErrors['${name}']`),
             submitFailed: getIn(formState, 'submitFailed'),
             submitting,
             syncError,

--- a/src/__tests__/FormSection.spec.js
+++ b/src/__tests__/FormSection.spec.js
@@ -71,6 +71,47 @@ const describeFormSection = (name, structure, combineReducers, setup) => {
       expect(divTags.length).toEqual(0)
     })
 
+    it('Should get submit errors from redux state', () => {
+      const store = makeStore({
+        testForm: {
+          values: {
+            foo: {
+              bar: '42'
+            }
+          },
+          submitErrors: {
+            'foo.bar': 'foo bar error message'
+          }
+        }
+      })
+
+      class TestInput extends Component {
+        render() {
+          return <div>TEST INPUT</div>
+        }
+      }
+
+      class Form extends Component {
+        render() {
+          return (
+            <FormSection name="foo">
+              <Field name="bar" component={TestInput} />
+            </FormSection>
+          )
+        }
+      }
+      const TestForm = reduxForm({ form: 'testForm' })(Form)
+      const dom = TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <TestForm />
+        </Provider>
+      )
+
+      var props = TestUtils.findRenderedComponentWithType(dom, TestInput).props
+
+      expect(props.meta.error).toBe('foo bar error message')
+    })
+
     it('should pass along unused props to div', () => {
       const store = makeStore({
         testForm: {


### PR DESCRIPTION
This PR fixes the rest of #3755 that was introduced in `7.2.1` where nested async errors and submit errors are flat. The other change should have been released as `8.0.0` since this is a breaking change in how `asyncErrors` and `submitErrors` are handled by redux-form.

This PR should also fix #3779 

Note that this change requires errors for parent FieldArrays to be structured as `foo._error` when returned from the server. The tests should be clear as to what will happen.