### PR TITLE
Immutable setIn is broken with more than 32 elements in an array.

### DIFF
--- a/src/structure/immutable/__tests__/setIn.spec.js
+++ b/src/structure/immutable/__tests__/setIn.spec.js
@@ -312,4 +312,25 @@ describe('structure.immutable.setIn', () => {
     let b0c = b0.get('c')
     expect(b0c).toEqual('123')
   })
+  it('should handle arrays with length 64', () => {
+    let initial = fromJS({
+      a: {
+        b: []
+      }
+    })
+
+    let result = setIn(initial, 'a.b[64].d', '12')
+
+    let a = result.get('a')
+    expect(a).toBeTruthy()
+
+    let b = a.get('b')
+    expect(b).toBeTruthy()
+
+    let b64 = b.get(64)
+    expect(b64).toBeTruthy()
+
+    let b64d = b64.get('d')
+    expect(b64d).toEqual('12')
+  })
 })

--- a/src/structure/immutable/setIn.js
+++ b/src/structure/immutable/setIn.js
@@ -1,5 +1,6 @@
 // @flow
-import { List, Map } from 'immutable'
+// $FlowFixMe: Need to ignore the mergeDeepWith import until we are on Immutable@4.0.0
+import { List, Map, mergeDeepWith } from 'immutable'
 import { toPath } from 'lodash'
 import type { Map as ImmutableMap, List as ImmutableList } from 'immutable'
 
@@ -8,10 +9,19 @@ const arrayPattern = /\[(\d+)\]/
 const undefinedArrayMerge = (previous, next) =>
   next !== undefined ? next : previous
 
-const mergeLists = (original, value) =>
-  original && List.isList(original)
-    ? original.toMap().mergeDeepWith(undefinedArrayMerge, value.toMap()).toList()
-    : value
+const mergeLists = (original, value) => {
+  if (original && List.isList(original)) {
+    if (original.mergeDeepWith) {
+      // In this case we are using Immutable.js@3.x since we still have List.mergeDeepWith
+      return original.mergeDeepWith(undefinedArrayMerge, value)
+    }
+
+    // Immutable 4.x users will end here.
+    return mergeDeepWith(undefinedArrayMerge, original, value)
+  }
+
+  return value
+}
 
 /*
  * ImmutableJS' setIn function doesn't support array (List) creation


### PR DESCRIPTION
This PR fixes an issue introduced in #3692 where the `mergeLists` method in `setIn.js` for `immutable.js` was updated due to `mergeDeepWith` being removed as a `List` function in `immutable.js@4.0.0-rc.5`. Unfortunately this change introduced and error in which arrays with more than 32 elements were behaving unexpectedly since the new way of doing it didnt use ordered maps, instead just calls `toMap()`, which causes the merging to lose order with more than 32 elements due to optimizations in `immutable.js`. After `4.0.0-rc.5`, the `mergeDeepWith`-method is exported as a global export instead of being attatched to `Map`, and `List`. This PR uses the global export version `4.x` and uses the old way of merging for users with `3.x`. I also added a test with long arrays for immutable `setIn`.

This PR should fix #3791

@erikras @gustavohenke can this be merged fast? Its pretty important since all long FieldArrays are currently broken.