### PR TITLE
Fix Immutable 4 merging. Again.

### DIFF
--- a/src/structure/immutable/__tests__/setIn.spec.js
+++ b/src/structure/immutable/__tests__/setIn.spec.js
@@ -312,7 +312,7 @@ describe('structure.immutable.setIn', () => {
     let b0c = b0.get('c')
     expect(b0c).toEqual('123')
   })
-  it('should handle arrays with length 64', () => {
+  it('should handle arrays with length 65', () => {
     let initial = fromJS({
       a: {
         b: []
@@ -320,6 +320,29 @@ describe('structure.immutable.setIn', () => {
     })
 
     let result = setIn(initial, 'a.b[64].d', '12')
+
+    let a = result.get('a')
+    expect(a).toBeTruthy()
+
+    let b = a.get('b')
+    expect(b).toBeTruthy()
+
+    let b64 = b.get(64)
+    expect(b64).toBeTruthy()
+
+    let b64d = b64.get('d')
+    expect(b64d).toEqual('12')
+  })
+  it('should handle arrays with length 65 with existing content', () => {
+    let initial = fromJS({
+      a: {
+        b: [undefined, undefined, 'val']
+      }
+    })
+
+    let result = setIn(initial, 'a.b[64].d', '12')
+
+    expect(result.getIn(['a', 'b', 2])).toEqual('val')
 
     let a = result.get('a')
     expect(a).toBeTruthy()

--- a/src/structure/immutable/setIn.js
+++ b/src/structure/immutable/setIn.js
@@ -1,6 +1,5 @@
 // @flow
-// $FlowFixMe: Need to ignore the mergeDeepWith import until we are on Immutable@4.0.0
-import { List, Map, mergeDeepWith } from 'immutable'
+import { List, Map } from 'immutable'
 import { toPath } from 'lodash'
 import type { Map as ImmutableMap, List as ImmutableList } from 'immutable'
 
@@ -9,15 +8,22 @@ const arrayPattern = /\[(\d+)\]/
 const undefinedArrayMerge = (previous, next) =>
   next !== undefined ? next : previous
 
-const mergeLists = (original, value) => {
-  if (original && List.isList(original)) {
-    if (original.mergeDeepWith) {
+const mergeLists = (originalList, value) => {
+  if (originalList && List.isList(originalList)) {
+    if (originalList.mergeDeepWith) {
       // In this case we are using Immutable.js@3.x since we still have List.mergeDeepWith
-      return original.mergeDeepWith(undefinedArrayMerge, value)
+      return originalList.mergeDeepWith(undefinedArrayMerge, value)
     }
 
     // Immutable 4.x users will end here.
-    return mergeDeepWith(undefinedArrayMerge, original, value)
+
+    let mapped = originalList
+      .map((originalListValue, index) =>
+        undefinedArrayMerge(value.get(index), originalListValue)
+      )
+      .concat(value.slice(originalList.size))
+
+    return mapped
   }
 
   return value

--- a/src/structure/immutable/setIn.js
+++ b/src/structure/immutable/setIn.js
@@ -10,20 +10,11 @@ const undefinedArrayMerge = (previous, next) =>
 
 const mergeLists = (originalList, value) => {
   if (originalList && List.isList(originalList)) {
-    if (originalList.mergeDeepWith) {
-      // In this case we are using Immutable.js@3.x since we still have List.mergeDeepWith
-      return originalList.mergeDeepWith(undefinedArrayMerge, value)
-    }
-
-    // Immutable 4.x users will end here.
-
-    let mapped = originalList
+    return originalList
       .map((originalListValue, index) =>
         undefinedArrayMerge(value.get(index), originalListValue)
       )
       .concat(value.slice(originalList.size))
-
-    return mapped
   }
 
   return value


### PR DESCRIPTION
Turns out the list-merging was still broken in `7.2.2` since I hadnt bothered to test arrays with content in them already, `immutable.js@4.0.0-rc.5+` concats lists when merging them. This PR does the merging by hand instead of using a built in method to do it, and I added a test for it, so it shouldnt break in the future. I have tested this solution both with `immutable@3.8.2` and `immutable@4.0.0-rc.9`. Sorry for the broken PR that got merged in `7.2.2`.