### PR TITLE
Feat: add keepValues to initialize (closes #3649)

### DIFF
--- a/docs/api/ActionCreators.md
+++ b/docs/api/ActionCreators.md
@@ -88,7 +88,7 @@ actions such as `CHANGE` or `BLUR`, the specific field.
 
 > Marks the given field as `active` and `visited`.
 
-### `initialize(form:String, data:Object, [keepDirty:boolean], [options:{keepDirty:boolean, keepSubmitSucceeded:boolean, updateUnregisteredFields:boolean}])`
+### `initialize(form:String, data:Object, [keepDirty:boolean], [options:{keepDirty:boolean, keepSubmitSucceeded:boolean, updateUnregisteredFields:boolean, keepValues:boolean}])`
 
 > Sets the initial values in the form with which future data values will be
 > compared to calculate `dirty` and `pristine`. The `data` parameter may contain
@@ -106,6 +106,9 @@ actions such as `CHANGE` or `BLUR`, the specific field.
 > initialValue if still pristine instead of only registered fields. Highly
 > recommended, defaults to false because of non-breaking backwards
 > compatibility.
+
+> If the `keepValues` parameter is `true`, it will keep the old values and
+> initial values.
 
 ### `registerField(form:String, name:String, type:String)`
 

--- a/src/__tests__/helpers/reducer.initialize.js
+++ b/src/__tests__/helpers/reducer.initialize.js
@@ -599,6 +599,73 @@ const describeInitialize = (reducer, expect, { fromJS }) => () => {
       }
     })
   })
+
+  it('should keep initial values although new ones are added', () => {
+    const initial = {
+      existingField: 'existingValue'
+    }
+
+    const newInitial = {
+      newField: 'newValue'
+    }
+
+    const expectedInitial = {
+      ...initial,
+      ...newInitial
+    }
+
+    const state = reducer(undefined, initialize('foo', initial))
+    const newState = reducer(
+      state,
+      initialize('foo', newInitial, { keepValues: true })
+    )
+
+    expect(newState).toEqualMap({
+      foo: {
+        initial: expectedInitial,
+        values: expectedInitial
+      }
+    })
+  })
+
+  it('should keep old values add new pristine values at the root level', () => {
+    const newInitial = {
+      newField: 'newValue'
+    }
+
+    const registeredFields = {
+      oldField: { name: 'oldField', type: 'Field', count: 1 }
+    }
+
+    const state = reducer(
+      fromJS({
+        foo: {
+          registeredFields,
+          values: {
+            oldField: 'oldValue'
+          },
+          initial: {
+            oldField: 'oldValue'
+          }
+        }
+      }),
+      initialize('foo', newInitial, true, { keepValues: true })
+    )
+
+    expect(state).toEqualMap({
+      foo: {
+        registeredFields,
+        values: {
+          oldField: 'oldValue',
+          newField: 'newValue'
+        },
+        initial: {
+          oldField: 'oldValue',
+          newField: 'newValue'
+        }
+      }
+    })
+  })
 }
 
 export default describeInitialize

--- a/src/createReducer.js
+++ b/src/createReducer.js
@@ -277,7 +277,18 @@ function createReducer<M, L>(structure: Structure<M, L>) {
       result = setIn(result, 'active', field)
       return result
     },
-    [INITIALIZE](state, { payload, meta: { keepDirty, keepSubmitSucceeded, updateUnregisteredFields } }) {
+    [INITIALIZE](
+      state,
+      {
+        payload,
+        meta: {
+          keepDirty,
+          keepSubmitSucceeded,
+          updateUnregisteredFields,
+          keepValues
+        }
+      }
+    ) {
       const mapData = fromJS(payload)
       let result = empty // clean all field state
 
@@ -308,8 +319,8 @@ function createReducer<M, L>(structure: Structure<M, L>) {
 
       const previousValues = getIn(state, 'values')
       const previousInitialValues = getIn(state, 'initial')
-      const newInitialValues = mapData
 
+      let newInitialValues = mapData
       let newValues = previousValues
 
       if (keepDirty && registeredFields) {
@@ -345,7 +356,9 @@ function createReducer<M, L>(structure: Structure<M, L>) {
           }
 
           if (!updateUnregisteredFields) {
-            forEach(keys(registeredFields), name => overwritePristineValue(name))
+            forEach(keys(registeredFields), name =>
+              overwritePristineValue(name)
+            )
           }
 
           forEach(keys(newInitialValues), name => {
@@ -363,6 +376,20 @@ function createReducer<M, L>(structure: Structure<M, L>) {
         }
       } else {
         newValues = newInitialValues
+      }
+
+      if (keepValues) {
+        forEach(keys(previousValues), name => {
+          const previousValue = getIn(previousValues, name)
+
+          newValues = setIn(newValues, name, previousValue)
+        })
+
+        forEach(keys(previousInitialValues), name => {
+          const previousInitialValue = getIn(previousInitialValues, name)
+
+          newInitialValues = setIn(newInitialValues, name, previousInitialValue)
+        })
       }
 
       if (keepSubmitSucceeded && getIn(state, 'submitSucceeded')) {


### PR DESCRIPTION
I added the feature of #3649. Now I added just an option `keepValues`, but kept the initial values with the same flag. Should another flag `keepInitial` be set for this?