### PR TITLE
Fix: Update FlowType Definitions to include clearFields

### DIFF
--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -55,6 +55,7 @@ import type {
   Blur,
   Change,
   ClearSubmitErrors,
+  ClearFields,
   Destroy,
   Focus,
   Initialize,
@@ -239,6 +240,7 @@ declare export var autofill: Autofill
 declare export var blur: Blur
 declare export var change: Change
 declare export var clearSubmitErrors: ClearSubmitErrors
+declare export var clearFields: ClearFields
 declare export var destroy: Destroy
 declare export var focus: Focus
 declare export var initialize: Initialize


### PR DESCRIPTION
Steps to reproduce:
1. Install `redux-form` 7.2.3
2. Install `flow-bin` 0.53

3. Try to import `clearFields` with Flow enabled:
```
// @flow
import {clearFields} from 'redux-form';
```

Expected: Flow does not error.
Actual: Flow displays the following error:

```
 2: import {clearFields} from 'redux-form';
             ^^^^^^^^^^^ Named import from module `redux-form`. This module has no named export called `clearFields`.
```

This is because `index.js.flow` is missing declarations for `clearFields`.

This is my first time contributing to this repository - please let me know if there is anything else I need to do in order to get this PR accepted. 