### PR TITLE
Clarify sync and async keys in Documentation for selectors #2899 

### DIFF
--- a/docs/api/Selectors.md
+++ b/docs/api/Selectors.md
@@ -39,9 +39,9 @@ MyComponent = connect(
   state => ({
     values: getFormValues('myForm')(state),
     initialValues: getFormInitialValues('myForm')(state),
-    syncErrors: getFormSyncErrors('myForm')(state),
+    formSyncErrors: getFormSyncErrors('myForm')(state),
     fields: getFormMeta('myForm')(state),
-    asyncErrors: getFormAsyncErrors('myForm')(state),
+    formAsyncErrors: getFormAsyncErrors('myForm')(state),
     syncWarnings: getFormSyncWarnings('myForm')(state),
     submitErrors: getFormSubmitErrors('myForm')(state),
     formError: getFormError()(state),


### PR DESCRIPTION
Change names of keys to avoid colliding if one follows the naming of the documentation. 
Referring to issue #2899 