### PR TITLE
Add the Webpack 4 'sideEffects' flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "./lib/index.js",
   "module": "./es/index.js",
   "jsnext:main": "./es/index.js",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "https://github.com/erikras/redux-form"


### PR DESCRIPTION
This adds the Webpack v4 sideEffects optimization. See a similar PR for Lodash: https://github.com/lodash/lodash/pull/3533

What does it do? If I import just one export from the library:
```
import { reducer } from 'redux-form'
```
then `sideEffects: false` ensures that only the reducer code and the code it depends on will be imported, and not all the reexports in `es/index.js`.

If the `sideEffects` flag were not set to `false`, Webpack must assume that the reexported modules can have side-effects (e.g., setting a property on `window`) and imports them all.

Very useful for code splitting where the main chunk typically imports only the reducer and the other chunks import UI components, selectors etc.
