### PR TITLE
Add clearFields and clearSubmitErrors to propTypes

### DIFF
--- a/src/__tests__/reduxForm.spec.js
+++ b/src/__tests__/reduxForm.spec.js
@@ -10,6 +10,7 @@ import createField from '../createField'
 import createFieldArray from '../createFieldArray'
 import createReducer from '../createReducer'
 import createReduxForm from '../createReduxForm'
+import formPropTypes from '../propTypes'
 import FormSection from '../FormSection'
 import immutable from '../structure/immutable'
 import immutableExpectations from '../structure/immutable/__tests__/expectations'
@@ -216,6 +217,13 @@ const describeReduxForm = (name, structure, combineReducers, setup) => {
       expect(typeof props.touch).toBe('function')
       expect(typeof props.untouch).toBe('function')
       expect(typeof props.valid).toBe('boolean')
+    })
+
+    it('should have declared all propTypes passed to decorated component', () => {
+      const passedProps = Object.keys(propChecker({})).sort()
+      const declaredPropTypes = Object.keys(formPropTypes).sort()
+
+      expect(passedProps).toEqual(declaredPropTypes)
     })
 
     describe('dirty prop', () => {

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -38,6 +38,8 @@ export const formPropTypes = {
   blur: func.isRequired, // action to mark a field as blurred
   change: func.isRequired, // action to change the value of a field
   clearAsyncError: func.isRequired, // action to clear the async error of a field
+  clearFields: func.isRequired, // action to clean fields values for all fields
+  clearSubmitErrors: func.isRequired, // action to remove submitErrors and error
   destroy: func.isRequired, // action to destroy the form's data in Redux
   dispatch: func.isRequired, // the Redux dispatch action
   handleSubmit: func.isRequired, // function to submit the form


### PR DESCRIPTION
Added propTypes for `clearFields` & `clearSubmitErrors` and test case comparing declared prop types in `src/propTypes.js` and passed to decorated component