### PR TITLE
Use shouldError/shouldWarn by default unless only shouldValidate is passed in.

### DIFF
--- a/src/__tests__/reduxForm.spec.js
+++ b/src/__tests__/reduxForm.spec.js
@@ -4173,27 +4173,19 @@ const describeReduxForm = (name, structure, combineReducers, setup) => {
     })
 
     describe('validateIfNeeded', () => {
-      it('should not call validate if shouldValidate and shouldError returns false', () => {
+      it('should not call validate if shouldValidate returns false', () => {
         const validate = jest.fn().mockImplementation(() => ({}))
         const shouldValidate = jest.fn().mockImplementation(() => false)
-        const shouldError = jest.fn().mockImplementation(() => false)
 
         const Form = makeForm()
-        const dom = renderForm(
-          Form,
-          {},
-          { validate, shouldValidate, shouldError }
-        )
+        const dom = renderForm(Form, {}, { validate, shouldValidate })
 
         // initial render
         expect(shouldValidate).toHaveBeenCalled()
         expect(shouldValidate.mock.calls[0][0].initialRender).toBe(true)
-        expect(shouldError).toHaveBeenCalled()
-        expect(shouldError.mock.calls[0][0].initialRender).toBe(true)
         expect(validate).not.toHaveBeenCalled()
 
         shouldValidate.mockClear()
-        shouldError.mockClear()
 
         // on change
         const inputElement = TestUtils.findRenderedDOMComponentWithTag(
@@ -4204,6 +4196,30 @@ const describeReduxForm = (name, structure, combineReducers, setup) => {
 
         expect(shouldValidate).toHaveBeenCalled()
         expect(shouldValidate.mock.calls[0][0].initialRender).toBe(false)
+        expect(validate).not.toHaveBeenCalled()
+      })
+
+      it('should not call validate if shouldError returns false', () => {
+        const validate = jest.fn().mockImplementation(() => ({}))
+        const shouldError = jest.fn().mockImplementation(() => false)
+
+        const Form = makeForm()
+        const dom = renderForm(Form, {}, { validate, shouldError })
+
+        // initial render
+        expect(shouldError).toHaveBeenCalled()
+        expect(shouldError.mock.calls[0][0].initialRender).toBe(true)
+        expect(validate).not.toHaveBeenCalled()
+
+        shouldError.mockClear()
+
+        // on change
+        const inputElement = TestUtils.findRenderedDOMComponentWithTag(
+          dom,
+          'input'
+        )
+        TestUtils.Simulate.change(inputElement, { target: { value: 'bar' } })
+
         expect(shouldError).toHaveBeenCalled()
         expect(shouldError.mock.calls[0][0].initialRender).toBe(false)
         expect(validate).not.toHaveBeenCalled()
@@ -4317,23 +4333,19 @@ const describeReduxForm = (name, structure, combineReducers, setup) => {
     })
 
     describe('warnIfNeeded', () => {
-      it('should not call warn if shouldValidate and shouldWarn returns false', () => {
+      it('should not call warn if shouldValidate returns false', () => {
         const warn = jest.fn().mockImplementation(() => ({}))
         const shouldValidate = jest.fn().mockImplementation(() => false)
-        const shouldWarn = jest.fn().mockImplementation(() => false)
 
         const Form = makeForm()
-        const dom = renderForm(Form, {}, { warn, shouldValidate, shouldWarn })
+        const dom = renderForm(Form, {}, { warn, shouldValidate })
 
         // initial render
         expect(shouldValidate).toHaveBeenCalled()
         expect(shouldValidate.mock.calls[0][0].initialRender).toBe(true)
-        expect(shouldWarn).toHaveBeenCalled()
-        expect(shouldWarn.mock.calls[0][0].initialRender).toBe(true)
         expect(warn).not.toHaveBeenCalled()
 
         shouldValidate.mockClear()
-        shouldWarn.mockClear()
 
         // on change
         const inputElement = TestUtils.findRenderedDOMComponentWithTag(
@@ -4344,6 +4356,30 @@ const describeReduxForm = (name, structure, combineReducers, setup) => {
 
         expect(shouldValidate).toHaveBeenCalled()
         expect(shouldValidate.mock.calls[0][0].initialRender).toBe(false)
+        expect(warn).not.toHaveBeenCalled()
+      })
+
+      it('should not call warn if shouldWarn returns false', () => {
+        const warn = jest.fn().mockImplementation(() => ({}))
+        const shouldWarn = jest.fn().mockImplementation(() => false)
+
+        const Form = makeForm()
+        const dom = renderForm(Form, {}, { warn, shouldWarn })
+
+        // initial render
+        expect(shouldWarn).toHaveBeenCalled()
+        expect(shouldWarn.mock.calls[0][0].initialRender).toBe(true)
+        expect(warn).not.toHaveBeenCalled()
+
+        shouldWarn.mockClear()
+
+        // on change
+        const inputElement = TestUtils.findRenderedDOMComponentWithTag(
+          dom,
+          'input'
+        )
+        TestUtils.Simulate.change(inputElement, { target: { value: 'bar' } })
+
         expect(shouldWarn).toHaveBeenCalled()
         expect(shouldWarn.mock.calls[0][0].initialRender).toBe(false)
         expect(warn).not.toHaveBeenCalled()

--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -388,8 +388,20 @@ const createReduxForm = (structure: Structure<*, *>) => {
           }
         }
 
+        shouldErrorFunction(): ShouldValidateFunction | ShouldErrorFunction {
+          const { shouldValidate, shouldError } = this.props
+          const shouldValidateOverridden =
+            shouldValidate !== defaultShouldValidate
+          const shouldErrorOverridden = shouldError !== defaultShouldError
+
+          return shouldValidateOverridden && !shouldErrorOverridden
+            ? shouldValidate
+            : shouldError
+        }
+
         validateIfNeeded(nextProps: ?Props) {
-          const { shouldValidate, shouldError, validate, values } = this.props
+          const { validate, values } = this.props
+          const shouldError = this.shouldErrorFunction()
           const fieldLevelValidate = this.generateValidator()
           if (validate || fieldLevelValidate) {
             const initialRender = nextProps === undefined
@@ -403,10 +415,8 @@ const createReduxForm = (structure: Structure<*, *>) => {
               fieldValidatorKeys,
               structure
             }
-            const shouldValidateResult = shouldValidate(validateParams)
-            const shouldErrorResult = shouldError(validateParams)
 
-            if (shouldValidateResult || shouldErrorResult) {
+            if (shouldError(validateParams)) {
               const propsToValidate =
                 initialRender || !nextProps ? this.props : nextProps
               const { _error, ...nextSyncErrors } = merge(
@@ -452,8 +462,20 @@ const createReduxForm = (structure: Structure<*, *>) => {
           }
         }
 
+        shouldWarnFunction(): ShouldValidateFunction | ShouldWarnFunction {
+          const { shouldValidate, shouldWarn } = this.props
+          const shouldValidateOverridden =
+            shouldValidate !== defaultShouldValidate
+          const shouldWarnOverridden = shouldWarn !== defaultShouldWarn
+
+          return shouldValidateOverridden && !shouldWarnOverridden
+            ? shouldValidate
+            : shouldWarn
+        }
+
         warnIfNeeded(nextProps: ?Props) {
-          const { shouldValidate, shouldWarn, warn, values } = this.props
+          const { warn, values } = this.props
+          const shouldWarn = this.shouldWarnFunction()
           const fieldLevelWarn = this.generateWarner()
           if (warn || fieldLevelWarn) {
             const initialRender = nextProps === undefined
@@ -467,10 +489,8 @@ const createReduxForm = (structure: Structure<*, *>) => {
               fieldValidatorKeys: fieldWarnerKeys,
               structure
             }
-            const shouldWarnResult = shouldWarn(validateParams)
-            const shouldValidateResult = shouldValidate(validateParams)
 
-            if (shouldValidateResult || shouldWarnResult) {
+            if (shouldWarn(validateParams)) {
               const propsToWarn =
                 initialRender || !nextProps ? this.props : nextProps
               const { _warning, ...nextSyncWarnings } = merge(


### PR DESCRIPTION
When providing a custom `shouldError` prop, it needs to be passed into both `shouldError` and the deprecated `shouldValidate`.

```javascript
const customShouldError = () => { ... };
const myForm = reduxForm({
  shouldError: customShouldError,
  shouldValidate: customShouldError,
});
``` 

If only `shouldError` is passed in the `shouldValidate` may override the expected behavior.  For example the `shouldError` prop returns `false` but the default `shouldValidate` returns `true`, the code will still run the validation.

This PR will allow for either `shouldError` or `shouldValidate` to be used.