### PR TITLE
Update downloads badge to point to graph of downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ---
 
 [![NPM Version](https://img.shields.io/npm/v/redux-form.svg?style=flat)](https://www.npmjs.com/package/redux-form)
-[![NPM Downloads](https://img.shields.io/npm/dm/redux-form.svg?style=flat)](https://www.npmjs.com/package/redux-form)
+[![NPM Downloads](https://img.shields.io/npm/dm/redux-form.svg?style=flat)](https://npmcharts.com/compare/redux-form?minimal=true)
 [![Build Status](https://img.shields.io/travis/erikras/redux-form/v6.svg?style=flat)](https://travis-ci.org/erikras/redux-form)
 [![codecov.io](https://codecov.io/gh/erikras/redux-form/branch/master/graph/badge.svg)](https://codecov.io/gh/erikras/redux-form)
 [![Code Climate](https://codeclimate.com/github/erikras/redux-form/badges/gpa.svg)](https://codeclimate.com/github/erikras/redux-form)


### PR DESCRIPTION
Hi! I noticed that your "npm" badge and "downloads" badge currently both point to the same page for the project on npmjs.org  

I was wondering if you might prefer having the download badge point to a [download chart](https://npmcharts.com/compare/redux-form?minimal=true) instead?

If not, feel free to close and apologies for the drive-by PR 😄