### PR TITLE
Update age test within examples

### DIFF
--- a/examples/fieldLevelValidation/src/FieldLevelValidationForm.js
+++ b/examples/fieldLevelValidation/src/FieldLevelValidationForm.js
@@ -12,7 +12,7 @@ const number = value =>
   value && isNaN(Number(value)) ? 'Must be a number' : undefined
 const minValue = min => value =>
   value && value < min ? `Must be at least ${min}` : undefined
-const minValue1 = minValue(1)
+const minValue13 = minValue(13)
 const email = value =>
   value && !/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i.test(value)
     ? 'Invalid email address'
@@ -76,7 +76,7 @@ const FieldLevelValidationForm = props => {
         type="number"
         component={renderField}
         label="Age"
-        validate={[required, number, minValue18]}
+        validate={[required, number, minValue13]}
         warn={tooYoung}
       />
       <Field

--- a/examples/fieldLevelValidation/src/FieldLevelValidationForm.js
+++ b/examples/fieldLevelValidation/src/FieldLevelValidationForm.js
@@ -12,13 +12,15 @@ const number = value =>
   value && isNaN(Number(value)) ? 'Must be a number' : undefined
 const minValue = min => value =>
   value && value < min ? `Must be at least ${min}` : undefined
-const minValue18 = minValue(18)
+const minValue1 = minValue(1)
 const email = value =>
   value && !/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i.test(value)
     ? 'Invalid email address'
     : undefined
-const tooOld = value =>
-  value && value > 65 ? 'You might be too old for this' : undefined
+const tooYoung = value =>
+  value && value < 13
+    ? 'You do not meet the minimum age requirement!'
+    : undefined
 const aol = value =>
   value && /.+@aol\.com/.test(value)
     ? 'Really? You still use AOL for your email?'
@@ -75,7 +77,7 @@ const FieldLevelValidationForm = props => {
         component={renderField}
         label="Age"
         validate={[required, number, minValue18]}
-        warn={tooOld}
+        warn={tooYoung}
       />
       <Field
         name="phone"

--- a/examples/immutable/src/warn.js
+++ b/examples/immutable/src/warn.js
@@ -7,8 +7,8 @@ const warn = values => {
   if (values.get('email') && /.+@aol\.com/.test(values.get('email'))) {
     errors.email = 'Really? You still use AOL for your email?'
   }
-  if (values.get('age') && values.get('age') > 65) {
-    errors.age = 'You might be too old for this'
+  if (values.get('age') && values.get('age') < 13) {
+    errors.age = 'You do not meet the minimum age requirement!'
   }
   return errors
 }


### PR DESCRIPTION
The current form of these tests is ageist and not something that I feel ought to be joked about. It would be a shame if anyone using this library came across this example and felt excluded or discriminated against as a result! 😞

This change switches the test to be a more common example: ensuring that an individual filling out a form meets a particular legal age requirement.