### PR TITLE
Split 'error' on three different fields; do not unset form-wide submit error if persistentSubmitErrors is true

### DIFF
--- a/src/__tests__/helpers/reducer.change.js
+++ b/src/__tests__/helpers/reducer.change.js
@@ -280,7 +280,7 @@ const describeChange = (reducer, expect, { fromJS }) => () => {
           submitErrors: {
             myField: 'submit error'
           },
-          error: 'some global error'
+          submitFormWideError: 'some global error'
         }
       }),
       change('foo', 'myField', 'different', false, true)
@@ -293,7 +293,8 @@ const describeChange = (reducer, expect, { fromJS }) => () => {
         submitErrors: {
           myField: 'submit error'
         },
-        error: 'some global error'
+        submitFormWideError: 'some global error',
+        submitErrorsUpToDate: false
       }
     })
   })

--- a/src/__tests__/helpers/reducer.clearFields.js
+++ b/src/__tests__/helpers/reducer.clearFields.js
@@ -79,7 +79,7 @@ const describeClearFields = (reducer, expect, { fromJS }) => () => {
             }
           },
           anyTouched: true,
-          error: 'some global error'
+          submitFormWideError: 'some global error'
         }
       }),
       clearFields('foo', false, true, 'myField', 'myOtherField')
@@ -98,7 +98,8 @@ const describeClearFields = (reducer, expect, { fromJS }) => () => {
           myField: 'submit error',
           myOtherField: 'submit error'
         },
-        error: 'some global error'
+        submitErrorsUpToDate: false,
+        submitFormWideError: 'some global error'
       }
     })
   })
@@ -266,7 +267,8 @@ const describeClearFields = (reducer, expect, { fromJS }) => () => {
               touched: true
             }
           },
-          error: 'some global error',
+          submitErrorsUpToDate: true,
+          submitFormWideError: 'some global error',
           anyTouched: true
         }
       }),
@@ -296,7 +298,8 @@ const describeClearFields = (reducer, expect, { fromJS }) => () => {
           myField: 'submit error',
           myOtherField: 'submit error'
         },
-        error: 'some global error',
+        submitErrorsUpToDate: false,
+        submitFormWideError: 'some global error',
         anyTouched: true
       }
     })

--- a/src/__tests__/helpers/reducer.clearSubmitErrors.js
+++ b/src/__tests__/helpers/reducer.clearSubmitErrors.js
@@ -29,7 +29,7 @@ const describeClearSubmitErrors = (reducer, expect, { fromJS }) => () => {
           submitErrors: {
             some: 'error'
           },
-          error: 'form-wide error',
+          submitFormWideError: 'form-wide error',
           active: 'otherField',
           triggerSubmit: true
         }

--- a/src/__tests__/helpers/reducer.initialize.js
+++ b/src/__tests__/helpers/reducer.initialize.js
@@ -398,7 +398,7 @@ const describeInitialize = (reducer, expect, { fromJS }) => () => {
           initial: {
             myField: 'initialValue'
           },
-          error: 'form wide error',
+          syncFormWideError: 'form wide error',
           syncErrors: {
             myField: 'field error'
           }
@@ -415,7 +415,7 @@ const describeInitialize = (reducer, expect, { fromJS }) => () => {
         initial: {
           myField: 'newValue'
         },
-        error: 'form wide error',
+        syncFormWideError: 'form wide error',
         syncErrors: {
           myField: 'field error'
         }

--- a/src/__tests__/helpers/reducer.stopAsyncValidation.js
+++ b/src/__tests__/helpers/reducer.stopAsyncValidation.js
@@ -171,7 +171,7 @@ const describeStopAsyncValidation = (reducer, expect, { fromJS }) => () => {
             }
           },
           asyncValidating: true,
-          error: 'Previous global error'
+          asyncFormWideError: 'Previous global error'
         }
       }),
       stopAsyncValidation('foo')
@@ -219,7 +219,7 @@ const describeStopAsyncValidation = (reducer, expect, { fromJS }) => () => {
             touched: true
           }
         },
-        error: 'This is a global error'
+        asyncFormWideError: 'This is a global error'
       }
     })
   })

--- a/src/__tests__/helpers/reducer.stopSubmit.js
+++ b/src/__tests__/helpers/reducer.stopSubmit.js
@@ -78,6 +78,7 @@ const describeStopSubmit = (reducer, expect, { fromJS }) => () => {
             myOtherField: 'Error about myOtherField'
           }
         },
+        submitErrorsUpToDate: true,
         fields: {
           bar: {
             myField: {
@@ -131,6 +132,7 @@ const describeStopSubmit = (reducer, expect, { fromJS }) => () => {
         submitErrors: {
           bar: ['Error about myField', 'Error about myOtherField']
         },
+        submitErrorsUpToDate: true,
         fields: {
           bar: [
             {
@@ -180,6 +182,7 @@ const describeStopSubmit = (reducer, expect, { fromJS }) => () => {
           cat: ['Not funny', 'Sleeps too much'],
           dog: ['Unhelpful', 'Not house trained']
         },
+        submitErrorsUpToDate: true,
         fields: {
           cat: {
             touched: true
@@ -274,7 +277,8 @@ const describeStopSubmit = (reducer, expect, { fromJS }) => () => {
             touched: true
           }
         },
-        error: 'some global error',
+        submitFormWideError: 'some global error',
+        submitErrorsUpToDate: true,
         submitFailed: true
       }
     })
@@ -293,7 +297,8 @@ const describeStopSubmit = (reducer, expect, { fromJS }) => () => {
             }
           },
           submitting: true,
-          error: 'Previous global error'
+          submitFormWideError: 'Previous global error',
+          submitErrorsUpToDate: true
         }
       }),
       stopSubmit('foo')
@@ -326,7 +331,8 @@ const describeStopSubmit = (reducer, expect, { fromJS }) => () => {
             }
           },
           submitting: true,
-          error: 'some global error'
+          submitFormWideError: 'Previous global error',
+          submitErrorsUpToDate: true
         }
       }),
       stopSubmit('foo', { myField: 'some submit error' })
@@ -339,6 +345,7 @@ const describeStopSubmit = (reducer, expect, { fromJS }) => () => {
         submitErrors: {
           myField: 'some submit error'
         },
+        submitErrorsUpToDate: true,
         fields: {
           myField: {
             touched: true
@@ -412,6 +419,7 @@ const describeStopSubmit = (reducer, expect, { fromJS }) => () => {
           myField: 'Error about myField',
           myOtherField: 'Error about myOtherField'
         },
+        submitErrorsUpToDate: true,
         fields: {
           myField: {
             touched: true
@@ -454,7 +462,8 @@ const describeStopSubmit = (reducer, expect, { fromJS }) => () => {
             touched: true
           }
         },
-        error: 'This is a global error',
+        submitFormWideError: 'This is a global error',
+        submitErrorsUpToDate: true,
         submitFailed: true
       }
     })

--- a/src/__tests__/helpers/reducer.updateSyncErrors.js
+++ b/src/__tests__/helpers/reducer.updateSyncErrors.js
@@ -62,8 +62,7 @@ const describeUpdateSyncErrors = (reducer, expect, { fromJS, setIn }) => () => {
               myField: 'value',
               myOtherField: 'otherValue'
             },
-            syncError: true,
-            error: 'form wide error'
+            syncFormWideError: 'form wide error'
           }
         }),
         'foo.syncErrors',

--- a/src/createReducer.js
+++ b/src/createReducer.js
@@ -568,9 +568,9 @@ function createReducer<M, L>(structure: Structure<M, L>) {
     [UPDATE_SYNC_WARNINGS](state, { payload: { syncWarnings, warning } }) {
       let result = state
       if (warning) {
-        result = setIn(result, 'warningSync', warning)
+        result = setIn(result, 'warning', warning)
       } else {
-        result = deleteIn(result, 'warningSync')
+        result = deleteIn(result, 'warning')
       }
       if (Object.keys(syncWarnings).length) {
         result = setIn(result, 'syncWarnings', syncWarnings)

--- a/src/createReducer.js
+++ b/src/createReducer.js
@@ -309,6 +309,18 @@ function createReducer<M, L>(structure: Structure<M, L>) {
       if (syncFormWideError) {
         result = setIn(result, 'syncFormWideError', syncFormWideError)
       }
+
+      // Might not be needed, but test coverage relies on it
+      const asyncFormWideError = getIn(state, 'asyncFormWideError')
+      if (asyncFormWideError) {
+        result = setIn(result, 'asyncFormWideError', asyncFormWideError)
+      }
+
+      const submitFormWideError = getIn(state, 'submitFormWideError')
+      if (submitFormWideError) {
+        result = setIn(result, 'submitFormWideError', submitFormWideError)
+      }
+
       const syncErrors = getIn(state, 'syncErrors')
       if (syncErrors) {
         result = setIn(result, 'syncErrors', syncErrors)

--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -218,6 +218,10 @@ export type Props = {
   dispatch: Dispatch<*>,
   enableReinitialize: boolean,
   error?: any,
+  syncFormWideError?: any,
+  asyncFormWideError?: any,
+  submitFormWideError?: any,
+  submitErrorsUpToDate: boolean,
   focus: FocusAction,
   form: string,
   getFormState: GetFormState,
@@ -354,21 +358,22 @@ const createReduxForm = (structure: Structure<*, *>) => {
 
         updateSyncErrorsIfNeeded(
           nextSyncErrors: ?Object,
-          nextError: ?any,
+          nextSyncError: ?any,
           lastSyncErrors: ?Object
         ) {
-          const { error, updateSyncErrors } = this.props
+          const { syncFormWideError, updateSyncErrors } = this.props
           const noErrors =
-            (!lastSyncErrors || !Object.keys(lastSyncErrors).length) && !error
+            (!lastSyncErrors || !Object.keys(lastSyncErrors).length) &&
+            !syncFormWideError
           const nextNoErrors =
             (!nextSyncErrors || !Object.keys(nextSyncErrors).length) &&
-            !nextError
+            !nextSyncError
           if (
             !(noErrors && nextNoErrors) &&
             (!plain.deepEqual(lastSyncErrors, nextSyncErrors) ||
-              !plain.deepEqual(error, nextError))
+              !plain.deepEqual(syncFormWideError, nextSyncError))
           ) {
-            updateSyncErrors(nextSyncErrors, nextError)
+            updateSyncErrors(nextSyncErrors, nextSyncError)
           }
         }
 
@@ -387,6 +392,7 @@ const createReduxForm = (structure: Structure<*, *>) => {
           }
         }
 
+        // Runs synchronous validators
         validateIfNeeded(nextProps: ?Props) {
           const { shouldValidate, shouldError, validate, values } = this.props
           const fieldLevelValidate = this.generateValidator()
@@ -946,6 +952,7 @@ const createReduxForm = (structure: Structure<*, *>) => {
           const pristine = shouldResetValues || deepEqual(initial, values)
           const asyncErrors = getIn(formState, 'asyncErrors')
           const syncErrors = getIn(formState, 'syncErrors') || {}
+          const submitErrors = getIn(formState, 'submitErrors')
           const syncWarnings = getIn(formState, 'syncWarnings') || {}
           const registeredFields = getIn(formState, 'registeredFields')
           const valid = isValid(form, getFormState, false)(state)
@@ -954,22 +961,31 @@ const createReduxForm = (structure: Structure<*, *>) => {
           const submitting = !!getIn(formState, 'submitting')
           const submitFailed = !!getIn(formState, 'submitFailed')
           const submitSucceeded = !!getIn(formState, 'submitSucceeded')
-          const error = getIn(formState, 'error')
+          const syncFormWideError = getIn(formState, 'syncFormWideError')
+          const submitFormWideError = getIn(formState, 'submitFormWideError')
+          const error =
+            syncFormWideError ||
+            getIn(formState, 'asyncFormWideError') ||
+            getIn(formState, 'submitFormWideError')
           const warning = getIn(formState, 'warning')
           const triggerSubmit = getIn(formState, 'triggerSubmit')
+
           return {
             anyTouched,
             asyncErrors,
             asyncValidating: getIn(formState, 'asyncValidating') || false,
             dirty: !pristine,
             error,
+            syncFormWideError,
             initialized,
             invalid: !valid,
             pristine,
             registeredFields,
             submitting,
+            submitErrors,
             submitFailed,
             submitSucceeded,
+            submitFormWideError,
             syncErrors,
             syncWarnings,
             triggerSubmit,

--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -219,9 +219,6 @@ export type Props = {
   enableReinitialize: boolean,
   error?: any,
   syncFormWideError?: any,
-  asyncFormWideError?: any,
-  submitFormWideError?: any,
-  submitErrorsUpToDate: boolean,
   focus: FocusAction,
   form: string,
   getFormState: GetFormState,
@@ -392,7 +389,6 @@ const createReduxForm = (structure: Structure<*, *>) => {
           }
         }
 
-        // Runs synchronous validators
         validateIfNeeded(nextProps: ?Props) {
           const { shouldValidate, shouldError, validate, values } = this.props
           const fieldLevelValidate = this.generateValidator()
@@ -811,6 +807,7 @@ const createReduxForm = (structure: Structure<*, *>) => {
             dispatch,
             enableReinitialize,
             error,
+            syncFormWideError,
             focus,
             form,
             getFormState,
@@ -952,7 +949,6 @@ const createReduxForm = (structure: Structure<*, *>) => {
           const pristine = shouldResetValues || deepEqual(initial, values)
           const asyncErrors = getIn(formState, 'asyncErrors')
           const syncErrors = getIn(formState, 'syncErrors') || {}
-          const submitErrors = getIn(formState, 'submitErrors')
           const syncWarnings = getIn(formState, 'syncWarnings') || {}
           const registeredFields = getIn(formState, 'registeredFields')
           const valid = isValid(form, getFormState, false)(state)
@@ -962,7 +958,6 @@ const createReduxForm = (structure: Structure<*, *>) => {
           const submitFailed = !!getIn(formState, 'submitFailed')
           const submitSucceeded = !!getIn(formState, 'submitSucceeded')
           const syncFormWideError = getIn(formState, 'syncFormWideError')
-          const submitFormWideError = getIn(formState, 'submitFormWideError')
           const error =
             syncFormWideError ||
             getIn(formState, 'asyncFormWideError') ||
@@ -982,10 +977,8 @@ const createReduxForm = (structure: Structure<*, *>) => {
             pristine,
             registeredFields,
             submitting,
-            submitErrors,
             submitFailed,
             submitSucceeded,
-            submitFormWideError,
             syncErrors,
             syncWarnings,
             triggerSubmit,

--- a/src/handleSubmit.js
+++ b/src/handleSubmit.js
@@ -26,13 +26,12 @@ const handleSubmit = (
     syncErrors,
     asyncErrors,
     touch,
-    values,
-    persistentSubmitErrors
+    values
   } = props
 
   touch(...fields) // mark all fields as touched
 
-  if (valid || persistentSubmitErrors) {
+  if (valid) {
     const doSubmit = () => {
       let result
       try {

--- a/src/selectors/__tests__/getFormError.spec.js
+++ b/src/selectors/__tests__/getFormError.spec.js
@@ -24,7 +24,7 @@ const describeGetFormError = (name, structure, setup) => {
           fromJS({
             form: {
               foo: {
-                error: 'Wow'
+                syncFormWideError: 'Wow'
               }
             }
           })
@@ -32,7 +32,66 @@ const describeGetFormError = (name, structure, setup) => {
       ).toBe('Wow')
     })
 
-    it('should return undefined when it is not presented', () => {
+    it('should return async error when it is presented', () => {
+      expect(
+        getFormError('foo')(
+          fromJS({
+            form: {
+              foo: {
+                asyncFormWideError: 'Wow'
+              }
+            }
+          })
+        )
+      ).toBe('Wow')
+    })
+
+    it('should return submit error when it is presented', () => {
+      expect(
+        getFormError('foo')(
+          fromJS({
+            form: {
+              foo: {
+                submitFormWideError: 'Wow'
+              }
+            }
+          })
+        )
+      ).toBe('Wow')
+    })
+
+    it('should prioritize async error to submit error when it is presented', () => {
+      expect(
+        getFormError('foo')(
+          fromJS({
+            form: {
+              foo: {
+                asyncFormWideError: 'Wow (async)',
+                submitFormWideError: 'Wow (submit)'
+              }
+            }
+          })
+        )
+      ).toBe('Wow (async)')
+    })
+
+    it('should prioritize sync error when it is presented', () => {
+      expect(
+        getFormError('foo')(
+          fromJS({
+            form: {
+              foo: {
+                syncFormWideError: 'Wow (sync)',
+                asyncFormWideError: 'Wow (async)',
+                submitFormWideError: 'Wow (submit)'
+              }
+            }
+          })
+        )
+      ).toBe('Wow (sync)')
+    })
+
+    it('should return undefined when error is not presented', () => {
       expect(
         getFormError('foo')(
           fromJS({
@@ -48,12 +107,14 @@ const describeGetFormError = (name, structure, setup) => {
           fromJS({
             someOtherSlice: {
               foo: {
-                error: 'Wow'
+                syncFormWideError: 'Wow (sync)',
+                asyncFormWideError: 'Wow (async)',
+                submitFormWideError: 'Wow (submit)'
               }
             }
           })
         )
-      ).toBe('Wow')
+      ).toBe('Wow (sync)')
     })
   })
 }

--- a/src/selectors/__tests__/isInvalid.spec.js
+++ b/src/selectors/__tests__/isInvalid.spec.js
@@ -135,7 +135,7 @@ const describeIsInvalid = (name, structure, setup) => {
       ).toBe(true)
     })
 
-    it('should return true when there is a syncError', () => {
+    it('should return true when there is a sync form-wide error', () => {
       expect(
         isInvalid('foo', getFormState)(
           fromJS({
@@ -145,8 +145,7 @@ const describeIsInvalid = (name, structure, setup) => {
                   dog: 'Odie',
                   cat: 'Garfield'
                 },
-                error: 'Bad Data',
-                syncError: true,
+                syncFormWideError: 'Bad Data',
                 registeredFields: {
                   dog: { name: 'dog', type: 'Field', count: 1 },
                   cat: { name: 'cat', type: 'Field', count: 1 }
@@ -232,6 +231,28 @@ const describeIsInvalid = (name, structure, setup) => {
       ).toBe(true)
     })
 
+    it('should return true when there is an async form wide error', () => {
+      expect(
+        isInvalid('foo', getFormState)(
+          fromJS({
+            form: {
+              foo: {
+                values: {
+                  dog: 'Odie',
+                  cat: 'Garfield'
+                },
+                asyncFormWideError: 'Bad data',
+                registeredFields: {
+                  dog: { name: 'dog', type: 'Field', count: 1 },
+                  cat: { name: 'cat', type: 'Field', count: 1 }
+                }
+              }
+            }
+          })
+        )
+      ).toBe(true)
+    })
+
     it('should return false when there are submit errors for a NON-registered field', () => {
       expect(
         isInvalid('foo', getFormState)(
@@ -298,6 +319,28 @@ const describeIsInvalid = (name, structure, setup) => {
                   cats: {
                     _error: 'Too many cats'
                   }
+                }
+              }
+            }
+          })
+        )
+      ).toBe(true)
+    })
+
+    it('should return true when there is a form-wide submit error', () => {
+      expect(
+        isInvalid('foo', getFormState)(
+          fromJS({
+            form: {
+              foo: {
+                values: {
+                  dog: 'Odie',
+                  cat: 'Garfield'
+                },
+                submitFormWideError: 'Bad data',
+                registeredFields: {
+                  dog: { name: 'dog', type: 'Field', count: 1 },
+                  cat: { name: 'cat', type: 'Field', count: 1 }
                 }
               }
             }

--- a/src/selectors/__tests__/isValid.spec.js
+++ b/src/selectors/__tests__/isValid.spec.js
@@ -135,7 +135,7 @@ const describeIsValid = (name, structure, setup) => {
       ).toBe(false)
     })
 
-    it('should return false when there is a syncError', () => {
+    it('should return false when there is a sync form wide error', () => {
       expect(
         isValid('foo', getFormState)(
           fromJS({
@@ -145,8 +145,7 @@ const describeIsValid = (name, structure, setup) => {
                   dog: 'Odie',
                   cat: 'Garfield'
                 },
-                error: 'Bad data',
-                syncError: true,
+                syncFormWideError: 'Bad data',
                 registeredFields: {
                   dog: { name: 'dog', type: 'Field', count: 1 },
                   cat: { name: 'cat', type: 'Field', count: 1 }
@@ -224,6 +223,28 @@ const describeIsValid = (name, structure, setup) => {
                   cats: {
                     _error: 'Too many cats'
                   }
+                }
+              }
+            }
+          })
+        )
+      ).toBe(false)
+    })
+
+    it('should return false when there is an async form wide error', () => {
+      expect(
+        isValid('foo', getFormState)(
+          fromJS({
+            form: {
+              foo: {
+                values: {
+                  dog: 'Odie',
+                  cat: 'Garfield'
+                },
+                asyncFormWideError: 'Bad data',
+                registeredFields: {
+                  dog: { name: 'dog', type: 'Field', count: 1 },
+                  cat: { name: 'cat', type: 'Field', count: 1 }
                 }
               }
             }
@@ -316,11 +337,11 @@ const describeIsValid = (name, structure, setup) => {
                   dog: 'Odie',
                   cat: 'Garfield'
                 },
+                submitFormWideError: 'Bad data',
                 registeredFields: {
                   dog: { name: 'dog', type: 'Field', count: 1 },
                   cat: { name: 'cat', type: 'Field', count: 1 }
-                },
-                error: 'Form wide'
+                }
               }
             }
           })
@@ -328,7 +349,32 @@ const describeIsValid = (name, structure, setup) => {
       ).toBe(false)
     })
 
-    it('should return true when there are submit errors for registered fields but told to ignore submit errors', () => {
+    it('should return false when there are submit errors for registered fields and told to ignore outdated submit errors, but errors are still relevant', () => {
+      expect(
+        isValid('foo', getFormState, true)(
+          fromJS({
+            form: {
+              foo: {
+                values: {
+                  dog: 'Odie',
+                  cat: 'Garfield'
+                },
+                registeredFields: {
+                  dog: { name: 'dog', type: 'Field', count: 1 },
+                  cat: { name: 'cat', type: 'Field', count: 1 }
+                },
+                submitErrors: {
+                  dog: 'Too old'
+                },
+                submitErrorsUpToDate: true
+              }
+            }
+          })
+        )
+      ).toBe(false)
+    })
+
+    it('should return true when there are outdated submit errors for registered fields but told to ignore outdated submit errors', () => {
       expect(
         isValid('foo', getFormState, true)(
           fromJS({
@@ -352,7 +398,7 @@ const describeIsValid = (name, structure, setup) => {
       ).toBe(true)
     })
 
-    it('should return true when there is a form-wide submit error, but ignoring submit errors', () => {
+    it('should return false when there is form-wide submit error that is still relevant, but ignoring outdated submit errors', () => {
       expect(
         isValid('foo', getFormState, true)(
           fromJS({
@@ -366,7 +412,31 @@ const describeIsValid = (name, structure, setup) => {
                   dog: { name: 'dog', type: 'Field', count: 1 },
                   cat: { name: 'cat', type: 'Field', count: 1 }
                 },
-                error: 'Form wide'
+                submitFormWideError: 'Form wide',
+                submitErrorsUpToDate: true
+              }
+            }
+          })
+        )
+      ).toBe(false)
+    })
+
+    it('should return true when there is an outdated form-wide submit error, but ignoring outdated submit errors', () => {
+      expect(
+        isValid('foo', getFormState, true)(
+          fromJS({
+            form: {
+              foo: {
+                values: {
+                  dog: 'Odie',
+                  cat: 'Garfield'
+                },
+                registeredFields: {
+                  dog: { name: 'dog', type: 'Field', count: 1 },
+                  cat: { name: 'cat', type: 'Field', count: 1 }
+                },
+                submitFormWideError: 'Form wide',
+                submitErrorsUpToDate: false
               }
             }
           })

--- a/src/selectors/getFormError.js
+++ b/src/selectors/getFormError.js
@@ -8,7 +8,13 @@ const createGetFormError = ({ getIn }: Structure<*, *>) => (
 ): GetFormErrorInterface => (state: any) => {
   const nonNullGetFormState: GetFormState =
     getFormState || (state => getIn(state, 'form'))
-  return getIn(nonNullGetFormState(state), `${form}.error`)
+  const formState = nonNullGetFormState(state)
+
+  return (
+    getIn(formState, `${form}.syncFormWideError`) ||
+    getIn(formState, `${form}.asyncFormWideError`) ||
+    getIn(formState, `${form}.submitFormWideError`)
+  )
 }
 
 export default createGetFormError

--- a/src/selectors/isValid.js
+++ b/src/selectors/isValid.js
@@ -14,19 +14,25 @@ const createIsValid = (structure: Structure<*, *>) => {
     const nonNullGetFormState: GetFormState =
       getFormState || (state => getIn(state, 'form'))
     const formState = nonNullGetFormState(state)
-    const syncError = getIn(formState, `${form}.syncError`)
-    if (syncError) {
+    const submitErrorsToBeRespected = !ignoreSubmitErrors
+      ? true
+      : !!getIn(formState, `${form}.submitErrorsUpToDate`)
+
+    const syncFormWideError = getIn(formState, `${form}.syncFormWideError`)
+    const asyncFormWideError = getIn(formState, `${form}.asyncFormWideError`)
+    const submitFormWideError = getIn(formState, `${form}.submitFormWideError`)
+
+    if (
+      syncFormWideError ||
+      asyncFormWideError ||
+      (submitFormWideError && submitErrorsToBeRespected)
+    ) {
       return false
     }
-    if (!ignoreSubmitErrors) {
-      const error = getIn(formState, `${form}.error`)
-      if (error) {
-        return false
-      }
-    }
+
     const syncErrors = getIn(formState, `${form}.syncErrors`)
     const asyncErrors = getIn(formState, `${form}.asyncErrors`)
-    const submitErrors = ignoreSubmitErrors
+    const submitErrors = !submitErrorsToBeRespected
       ? undefined
       : getIn(formState, `${form}.submitErrors`)
     if (!syncErrors && !asyncErrors && !submitErrors) {

--- a/src/selectors/isValid.js
+++ b/src/selectors/isValid.js
@@ -9,12 +9,12 @@ const createIsValid = (structure: Structure<*, *>) => {
   return (
     form: string,
     getFormState: ?GetFormState,
-    ignoreSubmitErrors: ?boolean = false
+    ignoreOutdatedSubmitErrors: ?boolean = false
   ): IsValidInterface => (state: any) => {
     const nonNullGetFormState: GetFormState =
       getFormState || (state => getIn(state, 'form'))
     const formState = nonNullGetFormState(state)
-    const submitErrorsToBeRespected = !ignoreSubmitErrors
+    const submitErrorsToBeRespected = !ignoreOutdatedSubmitErrors
       ? true
       : !!getIn(formState, `${form}.submitErrorsUpToDate`)
 


### PR DESCRIPTION
Fixes #3384 but breaks behavior introduced all the way back in d84aa7f as a workaround for #2244. 
See [this comment][that-comment] for additional info

Need feedback on how to be with that change and test case for it from d84aa7f

[that-comment]: https://github.com/erikras/redux-form/issues/3384#issuecomment-369457928