### PR TITLE
Use 'prebublishOnly' instead of 'prepublish'

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "example:syncValidation": "form=syncValidation npm run example",
     "example:wizard": "form=wizard npm run example",
     "precommit": "lint-staged",
-    "prepublish":
+    "prepublishOnly":
       "npm run lint && npm run test:cov && npm run test:flow && npm run clean && npm run build",
     "test": "cross-env NODE_ENV=test jest --runInBand",
     "test:flow": "flow check",


### PR DESCRIPTION
For some reason, the good people at NPM decided that the 'prebublish' hook should also run on `npm install`, which I've always found to be unexpected. There is another hook though, `prepublishOnly` which _only_ runs on `npm publish` but not on `npm install`.

See [here](https://docs.npmjs.com/misc/scripts) for the relevant docs on npm scripts.