### PR TITLE
Tools: added redux-form-input-masks

### DIFF
--- a/tools.md
+++ b/tools.md
@@ -7,6 +7,7 @@ The following tools are either built on top of `redux-form` or are compatible wi
 * [`redux-form-schema`](https://github.com/inlight-media/redux-form-schema)
 * [`redux-validate`](https://github.com/ashtonwar/redux-validate)
 * [`revalidate`](https://github.com/jfairbank/revalidate)
+* [`redux-form-input-masks`](https://github.com/renato-bohler/redux-form-input-masks)
 
 ## Application structure
 * [Steve's Opinionated React Project](https://github.com/aikidoshi/Opinionated)  


### PR DESCRIPTION
This PR simply adds [`redux-form-input-masks`](https://github.com/renato-bohler/redux-form-input-masks) link to the `tools.md` file.

`redux-form-input-masks` is a library to easily create input masks for `redux-form`.