### PR TITLE
docs: Add note that `formMeta` is populated lazily

### DIFF
--- a/docs/api/Selectors.md
+++ b/docs/api/Selectors.md
@@ -77,6 +77,8 @@ MyComponent = connect(state => ({
 
 > Returns the form's fields meta data, namely `touched` and `visited`.
 
+> NOTE: redux-form creates the `formMeta` object lazily as each individual form field gets visited/touched/etc. Empty/missing properties imply that the corresponding field (or set of fields) has neither been visited nor touched.
+
 ### `getFormAsyncErrors(formName:String)` returns `(state) => formAsyncErrors:Object`
 
 > Returns the form asynchronous validation errors.


### PR DESCRIPTION
Will save developers headache and wasted time on figuring this out via trial and error.

See: https://github.com/erikras/redux-form/issues/3768