### PR TITLE
Added proptype Proptypes.node to FormSection's component propTypes

### DIFF
--- a/src/FormSection.js
+++ b/src/FormSection.js
@@ -58,7 +58,11 @@ class FormSection extends Component<Props> {
 
 FormSection.propTypes = {
   name: PropTypes.string.isRequired,
-  component: PropTypes.oneOfType([PropTypes.func, PropTypes.string])
+  component: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.string,
+    PropTypes.node
+  ])
 }
 
 FormSection.defaultProps = {


### PR DESCRIPTION
I have changed the propTypes of components props in FormSection so that the following bug can be resolved.
>FormSection propType doesn't allow React 16 Fragment #3859 

I want to contribute further. Looking forward to your comments and feedback. Do tell me if I have missed anything or code of conduct I needed to follow. Thank you.