### PR TITLE
Move deep-equal to devDeps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2779,7 +2779,8 @@
       "version": "1.0.1",
       "resolved":
         "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
     },
     "deep-is": {
       "version": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
   },
   "homepage": "https://redux-form.com/",
   "dependencies": {
-    "deep-equal": "^1.0.1",
     "es6-error": "^4.1.1",
     "hoist-non-react-statics": "^2.5.0",
     "invariant": "^2.2.3",
@@ -97,6 +96,7 @@
     "babel-register": "^6.26.0",
     "codecov.io": "^0.1.6",
     "cross-env": "^5.1.3",
+    "deep-equal": "^1.0.1",
     "eslint": "^4.18.1",
     "eslint-config-react-app": "^2.1.0",
     "eslint-plugin-babel": "^4.1.2",


### PR DESCRIPTION
I have found the usage of `deep-equal` only in a test [here](https://github.com/krzysiek1507/redux-form/blob/03c37d7e19429e32e0d42810fe87ee69fe6cfab3/src/structure/immutable/__tests__/expectations.js#L2).