### PR TITLE
Fix type bug in field level validation example

### DIFF
--- a/examples/fieldLevelValidation/src/FieldLevelValidationForm.js
+++ b/examples/fieldLevelValidation/src/FieldLevelValidationForm.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Field, reduxForm } from 'redux-form'
 
-const required = value => (value ? undefined : 'Required')
+const required = value => (value || typeof value === 'number' ? undefined : 'Required')
 const maxLength = max => value =>
   value && value.length > max ? `Must be ${max} characters or less` : undefined
 const maxLength15 = maxLength(15)


### PR DESCRIPTION
0 evaluates to false here, so you need to check for a number type. ;)