### PR TITLE
Accept PropTypes.node for component props

### DIFF
--- a/src/ConnectedField.js
+++ b/src/ConnectedField.js
@@ -296,14 +296,20 @@ const createConnectedField = (structure: Structure<*, *>) => {
   }
 
   ConnectedField.propTypes = {
-    component: PropTypes.oneOfType([PropTypes.func, PropTypes.string])
-      .isRequired,
+    component: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.string,
+      PropTypes.node
+    ]).isRequired,
     props: PropTypes.object
   }
 
   const connector = connect(
     (state, ownProps) => {
-      const { name, _reduxForm: { initialValues, getFormState } } = ownProps
+      const {
+        name,
+        _reduxForm: { initialValues, getFormState }
+      } = ownProps
       const formState = getFormState(state)
       const initialState = getIn(formState, `initial.${name}`)
       const initial =

--- a/src/ConnectedFieldArray.js
+++ b/src/ConnectedFieldArray.js
@@ -122,8 +122,11 @@ const createConnectedFieldArray = (structure: Structure<*, *>) => {
   }
 
   ConnectedFieldArray.propTypes = {
-    component: PropTypes.oneOfType([PropTypes.func, PropTypes.string])
-      .isRequired,
+    component: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.string,
+      PropTypes.node
+    ]).isRequired,
     props: PropTypes.object,
     rerenderOnEveryChange: PropTypes.bool
   }
@@ -138,7 +141,10 @@ const createConnectedFieldArray = (structure: Structure<*, *>) => {
 
   const connector = connect(
     (state, ownProps) => {
-      const { name, _reduxForm: { initialValues, getFormState } } = ownProps
+      const {
+        name,
+        _reduxForm: { initialValues, getFormState }
+      } = ownProps
       const formState = getFormState(state)
       const initial =
         getIn(formState, `initial.${name}`) ||

--- a/src/ConnectedFields.js
+++ b/src/ConnectedFields.js
@@ -125,24 +125,25 @@ const createConnectedFields = (structure: Structure<*, *>) => {
     render() {
       const { component, withRef, _fields, _reduxForm, ...rest } = this.props
       const { sectionPrefix, form } = _reduxForm
-      const { custom, ...props } = Object.keys(
-        _fields
-      ).reduce((accumulator, name) => {
-        const connectedProps = _fields[name]
-        const { custom, ...fieldProps } = createFieldProps(structure, name, {
-          ...connectedProps,
-          ...rest,
-          form,
-          onBlur: this.onBlurFns[name],
-          onChange: this.onChangeFns[name],
-          onFocus: this.onFocusFns[name]
-        })
-        accumulator.custom = custom
-        const fieldName = sectionPrefix
-          ? name.replace(`${sectionPrefix}.`, '')
-          : name
-        return plain.setIn(accumulator, fieldName, fieldProps)
-      }, {})
+      const { custom, ...props } = Object.keys(_fields).reduce(
+        (accumulator, name) => {
+          const connectedProps = _fields[name]
+          const { custom, ...fieldProps } = createFieldProps(structure, name, {
+            ...connectedProps,
+            ...rest,
+            form,
+            onBlur: this.onBlurFns[name],
+            onChange: this.onChangeFns[name],
+            onFocus: this.onFocusFns[name]
+          })
+          accumulator.custom = custom
+          const fieldName = sectionPrefix
+            ? name.replace(`${sectionPrefix}.`, '')
+            : name
+          return plain.setIn(accumulator, fieldName, fieldProps)
+        },
+        {}
+      )
       if (withRef) {
         props.ref = 'renderedComponent'
       }
@@ -152,15 +153,21 @@ const createConnectedFields = (structure: Structure<*, *>) => {
   }
 
   ConnectedFields.propTypes = {
-    component: PropTypes.oneOfType([PropTypes.func, PropTypes.string])
-      .isRequired,
+    component: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.string,
+      PropTypes.node
+    ]).isRequired,
     _fields: PropTypes.object.isRequired,
     props: PropTypes.object
   }
 
   const connector = connect(
     (state, ownProps) => {
-      const { names, _reduxForm: { initialValues, getFormState } } = ownProps
+      const {
+        names,
+        _reduxForm: { initialValues, getFormState }
+      } = ownProps
       const formState = getFormState(state)
       return {
         _fields: names.reduce((accumulator, name) => {

--- a/src/createField.js
+++ b/src/createField.js
@@ -126,8 +126,11 @@ const createField = (structure: Structure<*, *>) => {
 
   Field.propTypes = {
     name: PropTypes.string.isRequired,
-    component: PropTypes.oneOfType([PropTypes.func, PropTypes.string])
-      .isRequired,
+    component: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.string,
+      PropTypes.node
+    ]).isRequired,
     format: PropTypes.func,
     normalize: PropTypes.func,
     onBlur: PropTypes.func,

--- a/src/createFieldArray.js
+++ b/src/createFieldArray.js
@@ -113,7 +113,11 @@ const createFieldArray = (structure: Structure<*, *>) => {
 
   FieldArray.propTypes = {
     name: PropTypes.string.isRequired,
-    component: PropTypes.func.isRequired,
+    component: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.string,
+      PropTypes.node
+    ]).isRequired,
     props: PropTypes.object,
     validate: PropTypes.oneOfType([
       PropTypes.func,

--- a/src/createFields.js
+++ b/src/createFields.js
@@ -43,7 +43,9 @@ const createFields = (structure: Structure<*, *>) => {
         throw error
       }
       const { context } = this
-      const { _reduxForm: { register } } = context
+      const {
+        _reduxForm: { register }
+      } = context
       this.names.forEach(name => register(name, 'Field'))
     }
 
@@ -108,8 +110,11 @@ const createFields = (structure: Structure<*, *>) => {
 
   Fields.propTypes = {
     names: (props, propName) => validateNameProp(props[propName]),
-    component: PropTypes.oneOfType([PropTypes.func, PropTypes.string])
-      .isRequired,
+    component: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.string,
+      PropTypes.node
+    ]).isRequired,
     format: PropTypes.func,
     parse: PropTypes.func,
     props: PropTypes.object,


### PR DESCRIPTION
## Purpose
I've created a higher-order component that makes it easy for custom form element components to consume `redux-form`'s `input` and `meta` props. I realized that for a couple of the form elements, I need to use [`React.forwardRef()`](https://reactjs.org/docs/forwarding-refs.html) in the HOC.

The ref-forwarding works as expected, but I get a couple prop type errors:
```
ERROR: 'Warning: Failed prop type: Invalid prop `component` supplied to `Field`.
ERROR: 'Warning: Failed prop type: Invalid prop `component` supplied to `ConnectedField`.
```

`React.forwardRef()` returns an object, not a function. `Field`'s `component` prop type is either `function` or `string`.

## Approach
I borrowed the approach from https://github.com/erikras/redux-form/pull/3995. Now the `component` prop can be a `node` in `ConnectedField`, `ConnectedFieldArray`, `ConnectedFields`, `createField`, `createFieldArray`, and `createFields`.

## Alternate options
- `PropTypes.element`?
- `React.isValidElementType()`?

## Extra info
Looks like `prettier` reformatted a few unrelated things.

### Related
- [`typeof React.forwardRef(...)` is not a 'function', breaking third-party libs](https://github.com/facebook/react/issues/12453)
- [Add ReactIs.isValidElementType()](https://github.com/facebook/react/pull/12483)
- [New PropType to check if a prop is a valid React Component](https://github.com/facebook/react/issues/9186)
