### PR TITLE
Make it easier for Flow

### DIFF
--- a/src/FieldArrayProps.types.js.flow
+++ b/src/FieldArrayProps.types.js.flow
@@ -3,7 +3,7 @@ import * as React from 'react'
 
 export type Props = {
   name: string,
-  component: React.ComponentType<*> | Function,
+  component: React.ComponentType<*> | React.ElementType,
   props?: Object,
   rerenderOnEveryChange?: boolean,
   validate?: (value: any, allValues: Object, props: Object) => ?any,


### PR DESCRIPTION
With a stateless functional component passed as `component`, Flow cannot decide which type in the union to use. If we use a more specific type like `ElementType`, Flow can now figure out which case we mean.