### PR TITLE
Add missing splice() to FieldArray's fields prop

### DIFF
--- a/src/createFieldArrayProps.js
+++ b/src/createFieldArrayProps.js
@@ -101,6 +101,7 @@ const createFieldArrayProps = (
         arrayShift()
         return getIn(value, '0')
       },
+      splice: arraySplice,
       swap: arraySwap,
       unshift: arrayUnshift
     },


### PR DESCRIPTION
The FieldArray's fields prop was missing the splice() function. This was once discussed in #2870.