### PR TITLE
Hotfix: Revert all UNSAFE_ lifecycle methods

### DIFF
--- a/src/Form.js
+++ b/src/Form.js
@@ -19,7 +19,7 @@ class Form extends Component<Props> {
     }
   }
 
-  UNSAFE_componentWillMount() {
+  componentWillMount() {
     this.context._reduxForm.registerInnerOnSubmit(this.props.onSubmit)
   }
 

--- a/src/createField.js
+++ b/src/createField.js
@@ -37,7 +37,7 @@ const createField = (structure: Structure<*, *>) => {
       return shallowCompare(this, nextProps, nextState)
     }
 
-    UNSAFE_componentWillMount() {
+    componentWillMount() {
       this.context._reduxForm.register(
         this.name,
         'Field',
@@ -46,7 +46,7 @@ const createField = (structure: Structure<*, *>) => {
       )
     }
 
-    UNSAFE_componentWillReceiveProps(nextProps: Props, nextContext: any) {
+    componentWillReceiveProps(nextProps: Props, nextContext: any) {
       const oldName = prefixName(this.context, this.props.name)
       const newName = prefixName(nextContext, nextProps.name)
 

--- a/src/createFieldArray.js
+++ b/src/createFieldArray.js
@@ -45,7 +45,7 @@ const createFieldArray = (structure: Structure<*, *>) => {
       }
     }
 
-    UNSAFE_componentWillMount() {
+    componentWillMount() {
       this.context._reduxForm.register(
         this.name,
         'FieldArray',
@@ -54,7 +54,7 @@ const createFieldArray = (structure: Structure<*, *>) => {
       )
     }
 
-    UNSAFE_componentWillReceiveProps(nextProps: Props, nextContext: any) {
+    componentWillReceiveProps(nextProps: Props, nextContext: any) {
       const oldName = prefixName(this.context, this.props.name)
       const newName = prefixName(nextContext, nextProps.name)
 

--- a/src/createFields.js
+++ b/src/createFields.js
@@ -37,7 +37,7 @@ const createFields = (structure: Structure<*, *>) => {
       return shallowCompare(this, nextProps)
     }
 
-    UNSAFE_componentWillMount() {
+    componentWillMount() {
       const error = validateNameProp(this.props.names)
       if (error) {
         throw error
@@ -49,7 +49,7 @@ const createFields = (structure: Structure<*, *>) => {
       this.names.forEach(name => register(name, 'Field'))
     }
 
-    UNSAFE_componentWillReceiveProps(nextProps: Props) {
+    componentWillReceiveProps(nextProps: Props) {
       if (!plain.deepEqual(this.props.names, nextProps.names)) {
         const { context } = this
         const { register, unregister } = context._reduxForm

--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -521,7 +521,7 @@ const createReduxForm = (structure: Structure<*, *>) => {
           }
         }
 
-        UNSAFE_componentWillMount() {
+        componentWillMount() {
           if (!isHotReloading()) {
             this.initIfNeeded()
             this.validateIfNeeded()


### PR DESCRIPTION
The addition of the `UNSAFE_` lifecycle methods broke React 15 compatibility. Those methods are not intended for libraries still supporting React 15. 

The only way to remove the React 16.4+ `StrictMode` warnings about `cWM`, `cWRP`, and `cWU` in a React 15 compatible way is to migrate these methods to the new lifecycle methods and use `react-lifecycles-compat` for backwards compatibility. The `UNSAFE_` methods were to support application authors with a known target version of React (16.3+) from having to migrate every component before upgrading. Unfortunately we can't do that trick. 

#### Additional Testing
Since the automated tests are all run against React 16, I've confirmed this locally by building my fork, and copying the `lib` folder to `node_modules/redux-form` of a download of [this sandbox](https://codesandbox.io/s/r0o9q33lmp) which is against 15.6, and confirming that the initialValues (as per #4069) are now showing. That's the only test I've run.  

#### Should fix
#4069, #4070, #4072