### PR TITLE
Use react-lifecycles-compat polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9705,6 +9705,11 @@
         "prop-types": "^15.6.0"
       }
     },
+    "react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
     "react-redux": {
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "is-promise": "^2.1.0",
     "lodash": "^4.17.10",
     "lodash-es": "^4.17.10",
-    "prop-types": "^15.6.1"
+    "prop-types": "^15.6.1",
+    "react-lifecycles-compat": "^3.0.4"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/Form.js
+++ b/src/Form.js
@@ -1,5 +1,6 @@
 // @flow
 import React, { Component } from 'react'
+import { polyfill } from 'react-lifecycles-compat'
 import PropTypes from 'prop-types'
 import type { ReactContext } from './types'
 
@@ -35,4 +36,5 @@ Form.contextTypes = {
   _reduxForm: PropTypes.object
 }
 
+polyfill(Form)
 export default Form

--- a/src/createField.js
+++ b/src/createField.js
@@ -1,5 +1,6 @@
 // @flow
 import React, { Component, createElement } from 'react'
+import { polyfill } from 'react-lifecycles-compat'
 import PropTypes from 'prop-types'
 import invariant from 'invariant'
 import createConnectedField from './ConnectedField'
@@ -155,6 +156,7 @@ const createField = (structure: Structure<*, *>) => {
     _reduxForm: PropTypes.object
   }
 
+  polyfill(Field)
   return Field
 }
 

--- a/src/createFieldArray.js
+++ b/src/createFieldArray.js
@@ -1,5 +1,6 @@
 // @flow
 import React, { Component, createElement } from 'react'
+import { polyfill } from 'react-lifecycles-compat'
 import PropTypes from 'prop-types'
 import invariant from 'invariant'
 import createConnectedFieldArray from './ConnectedFieldArray'
@@ -133,6 +134,7 @@ const createFieldArray = (structure: Structure<*, *>) => {
     _reduxForm: PropTypes.object
   }
 
+  polyfill(FieldArray)
   return FieldArray
 }
 

--- a/src/createFields.js
+++ b/src/createFields.js
@@ -1,5 +1,6 @@
 // @flow
 import { Component, createElement } from 'react'
+import { polyfill } from 'react-lifecycles-compat'
 import PropTypes from 'prop-types'
 import invariant from 'invariant'
 import createConnectedFields from './ConnectedFields'
@@ -124,6 +125,7 @@ const createFields = (structure: Structure<*, *>) => {
     _reduxForm: PropTypes.object
   }
 
+  polyfill(Fields)
   return Fields
 }
 

--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react'
+import { polyfill } from 'react-lifecycles-compat'
 import hoistStatics from 'hoist-non-react-statics'
 import invariant from 'invariant'
 import isPromise from 'is-promise'
@@ -1157,6 +1158,7 @@ const createReduxForm = (structure: Structure<*, *>) => {
         }
       }
 
+      polyfill(ReduxForm)
       return hoistStatics(ReduxForm, WrappedComponent)
     }
   }


### PR DESCRIPTION
Deepest apologies for the reckless release of `v7.4.0` without the [React 16.3 polyfill](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#open-source-project-maintainers).

Closes #4078 
Fixes #4069 
Fixes #4070 
Fixes #4072