### PR TITLE
Made SubmissionError identification more flexible

### DIFF
--- a/src/handleSubmit.js
+++ b/src/handleSubmit.js
@@ -1,12 +1,13 @@
 // @flow
 import isPromise from 'is-promise'
-import SubmissionError from './SubmissionError'
 import type { Dispatch } from 'redux'
 import type { Props } from './createReduxForm'
 
 type SubmitFunction = {
   (values: any, dispatch: Dispatch<*>, props: Object): any
 }
+
+const isSubmissionError = error => error && error.name === 'SubmissionError'
 
 const handleSubmit = (
   submit: SubmitFunction,
@@ -38,10 +39,9 @@ const handleSubmit = (
       try {
         result = submit(values, dispatch, props)
       } catch (submitError) {
-        const error =
-          submitError instanceof SubmissionError
-            ? submitError.errors
-            : undefined
+        const error = isSubmissionError(submitError)
+          ? submitError.errors
+          : undefined
         stopSubmit(error)
         setSubmitFailed(...fields)
         if (onSubmitFail) {
@@ -66,10 +66,9 @@ const handleSubmit = (
             return submitResult
           },
           submitError => {
-            const error =
-              submitError instanceof SubmissionError
-                ? submitError.errors
-                : undefined
+            const error = isSubmissionError(submitError)
+              ? submitError.errors
+              : undefined
             stopSubmit(error)
             setSubmitFailed(...fields)
             if (onSubmitFail) {


### PR DESCRIPTION
I didn't add any further tests for this change, just made sure existing ones pass. I can if you think it's needed.

FYI, CHANGELOG.md says to run `npm run format` but there's no such script in the package.