### PR TITLE
Remove * imports to avoid warning in React 15

### DIFF
--- a/src/ConnectedField.types.js.flow
+++ b/src/ConnectedField.types.js.flow
@@ -1,13 +1,13 @@
 // @flow
-import * as React from 'react'
+import type {Node, Component} from 'react'
 import type { Event, Context } from './types'
 
 export type InstanceApi = {
   name: string,
-  getRenderedComponent: { (): React.Component<*, *> },
+  getRenderedComponent: { (): Component<*, *> },
   isPristine: { (): boolean },
   getValue: { (): any }
-} & React.Component<*, *>
+} & Component<*, *>
 
 export type Props = {
   name: string,
@@ -15,7 +15,7 @@ export type Props = {
   withRef?: boolean,
   _reduxForm: Context,
   immutableProps?: Array<string>,
-  children?: React.Node,
+  children?: Node,
 
   // same as Props in createFieldProps.js:
   asyncError: any,

--- a/src/ConnectedFieldArray.js
+++ b/src/ConnectedFieldArray.js
@@ -1,5 +1,5 @@
 // @flow
-import * as React from 'react'
+import { Component, createElement } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
@@ -28,7 +28,7 @@ const createConnectedFieldArray = (structure: Structure<*, *>) => {
     return getIn(syncWarnings, `${name}._warning`)
   }
 
-  class ConnectedFieldArray extends React.Component<Props> {
+  class ConnectedFieldArray extends Component<Props> {
     static defaultProps: DefaultProps
     ref: ?HTMLElement
 
@@ -118,7 +118,7 @@ const createConnectedFieldArray = (structure: Structure<*, *>) => {
       if (withRef) {
         props.ref = this.saveRef
       }
-      return React.createElement(component, props)
+      return createElement(component, props)
     }
   }
 

--- a/src/ConnectedFieldArray.types.js.flow
+++ b/src/ConnectedFieldArray.types.js.flow
@@ -1,10 +1,10 @@
 // @flow
-import * as React from 'react'
+import type {Node, Component} from 'react'
 import type { Context } from './types'
 
 export type Props = {
   name: string,
-  children?: React.Node,
+  children?: Node,
   component: Function | string,
   withRef?: boolean,
   _reduxForm: Context,
@@ -43,9 +43,9 @@ export type DefaultProps = {
 
 type Api = {
   dirty: boolean,
-  getRenderedComponent: { (): React.Component<*, *> },
+  getRenderedComponent: { (): Component<*, *> },
   pristine: boolean,
   value: ?(any[])
 }
 
-export type InstanceApi = Api & React.Component<Props, void>
+export type InstanceApi = Api & Component<Props, void>

--- a/src/ConnectedFields.js
+++ b/src/ConnectedFields.js
@@ -1,5 +1,5 @@
 // @flow
-import * as React from 'react'
+import { Component, createElement } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import createFieldProps from './createFieldProps'
@@ -29,11 +29,11 @@ const createConnectedFields = (structure: Structure<*, *>) => {
     return warning && warning._warning ? warning._warning : warning
   }
 
-  class ConnectedFields extends React.Component<Props> {
+  class ConnectedFields extends Component<Props> {
     onChangeFns = {}
     onFocusFns = {}
     onBlurFns = {}
-    ref: ?React.Component<*>
+    ref: ?Component<*>
 
     constructor(props: Props) {
       super(props)
@@ -124,7 +124,7 @@ const createConnectedFields = (structure: Structure<*, *>) => {
       }
     }
 
-    saveRef = (ref: ?React.Component<*>) => {
+    saveRef = (ref: ?Component<*>) => {
       this.ref = ref
     }
 
@@ -154,7 +154,7 @@ const createConnectedFields = (structure: Structure<*, *>) => {
         props.ref = this.saveRef
       }
 
-      return React.createElement(component, { ...props, ...custom })
+      return createElement(component, { ...props, ...custom })
     }
   }
 

--- a/src/ConnectedFields.types.js.flow
+++ b/src/ConnectedFields.types.js.flow
@@ -1,11 +1,11 @@
 // @flow
-import * as React from 'react'
+import type { Node } from 'react'
 import type { Structure, Event, Context } from './types'
 
 export type Props = {
   names: string[],
   component: Function | string,
-  children?: React.Node,
+  children?: Node,
   withRef?: boolean,
   dispatch: Function,
   _reduxForm: Context,

--- a/src/FieldArrayProps.types.js.flow
+++ b/src/FieldArrayProps.types.js.flow
@@ -1,9 +1,9 @@
 // @flow
-import * as React from 'react'
+import type {ElementType, ComponentType} from 'react'
 
 export type Props = {
   name: string,
-  component: React.ComponentType<*> | React.ElementType,
+  component: ComponentType<*> | tType,
   props?: Object,
   rerenderOnEveryChange?: boolean,
   validate?: (value: any, allValues: Object, props: Object) => ?any,

--- a/src/FieldArrayProps.types.js.flow
+++ b/src/FieldArrayProps.types.js.flow
@@ -3,7 +3,7 @@ import type {ElementType, ComponentType} from 'react'
 
 export type Props = {
   name: string,
-  component: ComponentType<*> | tType,
+  component: ComponentType<*> | ElementType,
   props?: Object,
   rerenderOnEveryChange?: boolean,
   validate?: (value: any, allValues: Object, props: Object) => ?any,

--- a/src/FieldProps.types.js.flow
+++ b/src/FieldProps.types.js.flow
@@ -1,11 +1,11 @@
 // @flow
 import type { Dispatch } from 'redux'
 import type { Event, Validator } from './types'
-import * as React from 'react'
+import type {ComponentType, ElementRef} from 'react'
 
 export type Props = {
   name: string,
-  component: React.ComponentType<*> | Function | string,
+  component: ComponentType<*> | Function | string,
   format?: ?(value: any, name: string) => ?string,
   normalize?: (
     value: any,
@@ -58,6 +58,6 @@ export type FieldProps = {
     warning?: any
   },
   custom: {
-    ref?: (ref: React.ElementRef<*>) => React.ElementRef<*>
+    ref?: (ref: ElementRef<*>) => ElementRef<*>
   }
 }

--- a/src/FieldsProps.types.js.flow
+++ b/src/FieldsProps.types.js.flow
@@ -1,9 +1,9 @@
 // @flow
-import * as React from 'react'
+import type {ComponentType} from 'react'
 
 export type Props = {
   names: string[],
-  component: Function | React.ComponentType<*>,
+  component: Function | ComponentType<*>,
   format?: (value: any, name: string) => ?any,
   parse?: (value: any, name: string) => ?any,
   props?: Object,

--- a/src/FormName.js
+++ b/src/FormName.js
@@ -1,22 +1,23 @@
 // @flow
 
-import * as React from 'react'
 import PropTypes from 'prop-types'
-import type {ReactContext} from './types'
+import type { Node } from 'react'
+import type { ReactContext } from './types'
 
 export type Props = {
-  +children: (props: {form: string, sectionPrefix: ?string}) => React.Node,
+  +children: (props: { form: string, sectionPrefix: ?string }) => Node
 }
 
-const FormName = ({children}: Props, {_reduxForm}: ReactContext): React.Node => children({
-  form: _reduxForm && _reduxForm.form,
-  sectionPrefix: _reduxForm && _reduxForm.sectionPrefix,
-})
+const FormName = ({ children }: Props, { _reduxForm }: ReactContext): Node =>
+  children({
+    form: _reduxForm && _reduxForm.form,
+    sectionPrefix: _reduxForm && _reduxForm.sectionPrefix
+  })
 FormName.contextTypes = {
   _reduxForm: PropTypes.shape({
     form: PropTypes.string.isRequired,
-    sectionPrefix: PropTypes.string,
-  }).isRequired,
+    sectionPrefix: PropTypes.string
+  }).isRequired
 }
 
 export default FormName

--- a/src/FormNameProps.types.js.flow
+++ b/src/FormNameProps.types.js.flow
@@ -1,7 +1,7 @@
 // @flow
 
-import * as React from 'react'
+import type {Node} from 'react'
 
 export type Props = {
-  +children: (props: {form: string}) => React.Node,
+  +children: (props: {form: string}) => Node,
 }

--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -1,5 +1,4 @@
 // @flow
-import React from 'react'
 import { polyfill } from 'react-lifecycles-compat'
 import hoistStatics from 'hoist-non-react-statics'
 import invariant from 'invariant'

--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -1,5 +1,5 @@
 // @flow
-import * as React from 'react'
+import React from 'react'
 import { polyfill } from 'react-lifecycles-compat'
 import hoistStatics from 'hoist-non-react-statics'
 import invariant from 'invariant'
@@ -23,7 +23,7 @@ import createIsValid from './selectors/isValid'
 import plain from './structure/plain'
 import getDisplayName from './util/getDisplayName'
 import isHotReloading from './util/isHotReloading'
-import type { ComponentType } from 'react'
+import type { ComponentType, Node } from 'react'
 import type { Dispatch } from 'redux'
 import type {
   ConnectedComponent,
@@ -215,7 +215,7 @@ export type Props = {
   asyncValidating: boolean,
   blur: BlurAction,
   change: ChangeAction,
-  children?: React.Node,
+  children?: Node,
   clearSubmit: ClearSubmitAction,
   destroy: DestroyAction,
   destroyOnUnmount: boolean,
@@ -308,7 +308,7 @@ const createReduxForm = (structure: Structure<*, *>) => {
         static WrappedComponent: ComponentType<*>
 
         context: ReactContext
-        wrapped: ?React.Component<*, *>
+        wrapped: ?Component<*, *>
 
         destroyed = false
         fieldCounts = {}
@@ -834,7 +834,7 @@ const createReduxForm = (structure: Structure<*, *>) => {
 
         reset = (): void => this.props.reset()
 
-        saveRef = (ref: ?React.Component<*, *>) => {
+        saveRef = (ref: ?Component<*, *>) => {
           this.wrapped = ref
         }
 

--- a/src/immutable.js.flow
+++ b/src/immutable.js.flow
@@ -1,5 +1,5 @@
 // @flow
-import * as React from 'react'
+import type { ComponentType } from 'react'
 import type { Action, GetFormState } from './types'
 import type { Params as DefaultShouldAsyncValidateParams } from './defaultShouldAsyncValidate'
 import type { Params as DefaultShouldValidateParams } from './defaultShouldValidate'
@@ -117,17 +117,17 @@ declare export var fieldArrayPropTypes: Object
 
 declare export var formPropTypes: Object
 
-declare export var FormName: React.ComponentType<FormNameProps>
+declare export var FormName: ComponentType<FormNameProps>
 
-declare export var Field: React.ComponentType<FieldInputProps>
+declare export var Field: ComponentType<FieldInputProps>
 
-declare export var Fields: React.ComponentType<FieldsInputProps>
+declare export var Fields: ComponentType<FieldsInputProps>
 
-declare export var FieldArray: React.ComponentType<FieldArrayInputProps>
+declare export var FieldArray: ComponentType<FieldArrayInputProps>
 
-declare export var Form: React.ComponentType<FormProps>
+declare export var Form: ComponentType<FormProps>
 
-declare export var FormSection: React.ComponentType<FormSectionProps>
+declare export var FormSection: ComponentType<FormSectionProps>
 
 declare export function formValueSelector(
   form: string,
@@ -219,7 +219,7 @@ declare export function isSubmitting(
 
 declare export function reduxForm(
   config: ReduxFormConfig
-): { (WrappedComponent: React.ComponentType<*>): React.ComponentType<*> }
+): { (WrappedComponent: ComponentType<*>): ComponentType<*> }
 
 declare export function reducer(state: any, action: Action): any
 
@@ -229,7 +229,7 @@ declare export class SubmissionError {
 
 declare export function values(
   config: ValuesConfig
-): { (React.ComponentType<*>): React.ComponentType<*> }
+): { (ComponentType<*>): ComponentType<*> }
 
 // Action creators
 declare export var arrayInsert: ArrayInsertAction

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1,5 +1,5 @@
 // @flow
-import * as React from 'react'
+import type { ComponentType } from 'react'
 import type { Action, GetFormState } from './types'
 import type { Params as DefaultShouldAsyncValidateParams } from './defaultShouldAsyncValidate'
 import type { Params as DefaultShouldValidateParams } from './defaultShouldValidate'
@@ -116,17 +116,17 @@ declare export var fieldArrayPropTypes: Object
 
 declare export var formPropTypes: Object
 
-declare export var FormName: React.ComponentType<FormNameProps>
+declare export var FormName: ComponentType<FormNameProps>
 
-declare export var Field: React.ComponentType<FieldInputProps>
+declare export var Field: ComponentType<FieldInputProps>
 
-declare export var Fields: React.ComponentType<FieldsInputProps>
+declare export var Fields: ComponentType<FieldsInputProps>
 
-declare export var FieldArray: React.ComponentType<FieldArrayInputProps>
+declare export var FieldArray: ComponentType<FieldArrayInputProps>
 
-declare export var Form: React.ComponentType<FormProps>
+declare export var Form: ComponentType<FormProps>
 
-declare export var FormSection: React.ComponentType<FormSectionProps>
+declare export var FormSection: ComponentType<FormSectionProps>
 
 declare export function formValueSelector(
   form: string,
@@ -218,7 +218,7 @@ declare export function isSubmitting(
 
 declare export function reduxForm(
   config: ReduxFormConfig
-): { (WrappedComponent: React.ComponentType<*>): React.ComponentType<*> }
+): { (WrappedComponent: ComponentType<*>): ComponentType<*> }
 
 declare export function reducer(state: any, action: Action): any
 
@@ -228,7 +228,7 @@ declare export class SubmissionError {
 
 declare export function values(
   config: ValuesConfig
-): { (React.ComponentType<*>): React.ComponentType<*> }
+): { (ComponentType<*>): ComponentType<*> }
 
 // Action creators
 declare export var arrayInsert: ArrayInsert

--- a/src/util/FormNameProps.types.js.flow.js
+++ b/src/util/FormNameProps.types.js.flow.js
@@ -1,6 +1,6 @@
 // @flow
-import * as React from 'react'
+import type { Node } from 'react'
 
 export type Props = {
-  children: (form: {name: string}) => React.Node,
+  children: (form: { name: string }) => Node
 }


### PR DESCRIPTION
This PR removes all `*` react imports, since React 15 is supported, when we import everything from React, we enter in a deprecated warning.

Fix #4083 