### PR TITLE
Adding label as prop

### DIFF
--- a/src/createField.js
+++ b/src/createField.js
@@ -128,6 +128,7 @@ const createField = (structure: Structure<*, *>) => {
 
   Field.propTypes = {
     name: PropTypes.string.isRequired,
+    label: PropTypes.string,
     component: validateComponentProp,
     format: PropTypes.func,
     normalize: PropTypes.func,


### PR DESCRIPTION
Adding label as prop for Field.  This is shown as being available in [this documentation](https://redux-form.com/7.4.2/examples/syncvalidation/).