### PR TITLE
feat(change): function supported for change-action

### DIFF
--- a/docs/api/Props.md
+++ b/docs/api/Props.md
@@ -118,6 +118,7 @@ class SimpleForm extends Component {
 
 > Changes the value of a field in the Redux store. This is a bound action
 > creator, so it returns nothing.
+> You could get current field-value & form-values while `value` is a function, For example: `change(field, (fieldValue, allValues) => {})`
 
 ### `clearAsyncError(field:String) : Function`
 

--- a/src/createReducer.js
+++ b/src/createReducer.js
@@ -39,6 +39,7 @@ import {
 import createDeleteInWithCleanUp from './deleteInWithCleanUp'
 import plain from './structure/plain'
 import type { Action, Structure } from './types.js.flow'
+import { isFunction } from 'lodash'
 
 const isReduxFormAction = action =>
   action &&
@@ -218,6 +219,9 @@ function createReducer<M, L>(structure: Structure<M, L>) {
       const initial = getIn(result, `initial.${field}`)
       if (initial === undefined && payload === '') {
         result = deleteInWithCleanUp(result, `values.${field}`)
+      } else if (isFunction(payload)) {
+        const fieldCurrentValue = getIn(state, `values.${field}`)
+        result = setIn(result, `values.${field}`, payload(fieldCurrentValue, state.values))
       } else if (payload !== undefined) {
         result = setIn(result, `values.${field}`, payload)
       }


### PR DESCRIPTION
function supported for `CHANGE`

e.g: `change(fieldName, (fieldValue, allValue) => {})`

```
this.props.change("data", preData => ({
  ...preData,
  name: "hello world"
}));
```

 @erikras PTAL