### PR TITLE
Add example for initializing type date

### DIFF
--- a/examples/initializeFromState/src/InitializeFromStateForm.js
+++ b/examples/initializeFromState/src/InitializeFromStateForm.js
@@ -7,6 +7,7 @@ const data = {
   firstName: 'Jane',
   lastName: 'Doe',
   age: '42',
+  anniversaryDate: '2018-08-22',
   sex: 'female',
   employed: true,
   favoriteColor: 'Blue',
@@ -49,6 +50,12 @@ let InitializeFromStateForm = props => {
         <label>Age</label>
         <div>
           <Field name="age" component="input" type="number" placeholder="Age" />
+        </div>
+      </div>
+      <div>
+        <label>Anniversary Date</label>
+        <div>
+          <Field name="anniversaryDate" component="input" type="date" />
         </div>
       </div>
       <div>


### PR DESCRIPTION
I was trying to help with this stackoverflow [question](https://stackoverflow.com/questions/51970636/how-to-display-initial-value-on-redux-form-date-input-field) where the user was struggling to initialize a `date` type Field and I thought adding it to the example might be helpful for others in the future. 

Here is it in action in a forked codesandbox: https://codesandbox.io/s/32n8221r21