### PR TITLE
Fix getFormError Flow typedef.

### DIFF
--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -139,8 +139,9 @@ declare export function formValues(
 ): FormValuesInterface
 
 declare export function getFormError(
+  form: string,
   getFormState: ?GetFormState
-): GetFormErrorInterface<*>
+): GetFormErrorInterface
 
 declare export function getFormNames(
   getFormState: ?GetFormState


### PR DESCRIPTION
The getFormError selector takes in a form name but it was not accounted for in the Flow typedefs.

Also, the GetFormErrorInterface is not a polymorphic type.

See docs for this selector here:
https://redux-form.com/7.4.2/docs/api/selectors.md/