### PR TITLE
Fix export type for getFormError

### DIFF
--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -139,6 +139,7 @@ declare export function formValues(
 ): FormValuesInterface
 
 declare export function getFormError(
+  form: string,
   getFormState: ?GetFormState
 ): GetFormErrorInterface<*>
 


### PR DESCRIPTION
Add missing `state` argument