### PR TITLE
Docs: Improve props list

### DIFF
--- a/docs/api/Field.md
+++ b/docs/api/Field.md
@@ -244,8 +244,6 @@ Otherwise, returns the `name` prop that you passed in.
 > Returns the instance of the rendered component. For this to work, you must provide a
 > `withRef` prop, and your component must not be a stateless function component.
 
-####
-
 ## Props
 
 These are props that `Field` will pass to your wrapped component. **The props provided by `redux-form`

--- a/docs/api/Fields.md
+++ b/docs/api/Fields.md
@@ -159,8 +159,6 @@ component.
 > provide a `withRef` prop, and your component must not be a stateless function
 > component.
 
-####
-
 ## Props
 
 The props that `Fields` will pass to your component are

--- a/docs/api/Props.md
+++ b/docs/api/Props.md
@@ -146,7 +146,7 @@ class SimpleForm extends Component {
 > The form name that you gave to the `reduxForm()` decorator or the prop you
 > passed in to your decorated form component.
 
-#### `handleSubmit(eventOrSubmit) : Function`
+### `handleSubmit(eventOrSubmit) : Function`
 
 > A function meant to be passed to `<form onSubmit={handleSubmit}>` or to
 > `<button onClick={handleSubmit}>`. It will run validation, both sync and
@@ -191,7 +191,7 @@ class SimpleForm extends Component {
 />
 ```
 
-#### `initialize(data:Object) : Function`
+### `initialize(data:Object) : Function`
 
 > Initializes the form data to the given values. All `dirty` and `pristine`
 > state will be determined by comparing the current data with these initialized
@@ -201,64 +201,64 @@ class SimpleForm extends Component {
 
 > `true` the form has been initialized with initial values, `false` otherwise.
 
-#### `initialValues : Object`
+### `initialValues : Object`
 
 > The same initialValues object passed to `reduxForm` to initialize the form
 > data.
 
-#### `invalid : boolean`
+### `invalid : boolean`
 
 > `true` if the form has validation errors. Opposite of `valid`.
 
-#### `pristine: boolean`
+### `pristine: boolean`
 
 > `true` if the form data is the same as its initialized values. Opposite of
 > `dirty`.
 
-#### `reset() : Function`
+### `reset() : Function`
 
 > Resets all the values in the form to the initialized state, making it pristine
 > again. This is a bound action creator, so it returns nothing.
 
-#### `resetSection(...sections:String) : Function`
+### `resetSection(...sections:String) : Function`
 
 > Resets all the values in the form sections to the initialized state, making it pristine
 > again. This is a bound action creator, so it returns nothing.
 
-#### `submitFailed : boolean`
+### `submitFailed : boolean`
 
 > Starts as `false`. If `onSubmit` is called, and fails to submit _for any
 > reason_, `submitFailed` will be set to `true`. A subsequent successful submit
 > will set it back to `false`.
 
-#### `submitSucceeded : boolean`
+### `submitSucceeded : boolean`
 
 > Starts as `false`. If `onSubmit` is called, and succeed to submit ,
 > `submitSucceeded` will be set to `true`. A subsequent unsuccessful submit will
 > set it back to `false`.
 
-#### `submitting : boolean`
+### `submitting : boolean`
 
 > Whether or not your form is currently submitting. This prop will only work if
 > you have passed an `onSubmit` function that returns a promise. It will be
 > `true` until the promise is resolved or rejected.
 
-#### `touch(...field:string) : Function`
+### `touch(...field:string) : Function`
 
 > Marks the given fields as "touched" to show errors. This is a bound action
 > creator, so it returns nothing.
 
-#### `untouch(...field:string) : Function`
+### `untouch(...field:string) : Function`
 
 > Clears the "touched" flag for the given fields This is a bound action creator,
 > so it returns nothing.
 
-#### `valid : boolean`
+### `valid : boolean`
 
 > `true` if the form passes validation (has no validation errors). Opposite of
 > `invalid`.
 
-#### `warning : any`
+### `warning : any`
 
 > A generic warning for the entire form given by the `_warning` key in the
 > result from the synchronous warning function.

--- a/docs/api/ReduxForm.md
+++ b/docs/api/ReduxForm.md
@@ -30,7 +30,7 @@ at "design time" or passed in as props to your component at runtime.**
 
 ### Optional
 
-#### -`asyncBlurFields : Array<String>` [optional]
+#### `asyncBlurFields : Array<String>` [optional]
 
 > field names for which `onBlur` should trigger a call to the `asyncValidate`
 > function. Defaults to triggering the async validation when any field is
@@ -42,7 +42,7 @@ at "design time" or passed in as props to your component at runtime.**
 > [Asynchronous Blur Validation Example](https://redux-form.com/7.4.2/examples/asyncValidation/)
 > for more details.
 
-#### -`asyncChangeFields : Array<String>` [optional]
+#### `asyncChangeFields : Array<String>` [optional]
 
 > field names for which `onChange` should trigger a call to the `asyncValidate`
 > function.


### PR DESCRIPTION
This updates `Props.md` to use level 3 heading for all prop names. They were a mix of level 3 and level 4.

This also removes some extra `####` on `Field.md` and `Fields.md` and some leading dashes on the first two props of `ReduxForm.md`.