### PR TITLE
Fix misleading comment for _value

### DIFF
--- a/src/ConnectedField.js
+++ b/src/ConnectedField.js
@@ -331,7 +331,7 @@ const createConnectedField = (structure: Structure<*, *>) => {
         syncWarning,
         initial,
         value,
-        _value: ownProps.value // save value passed in (for checkboxes)
+        _value: ownProps.value // save value passed in (for radios)
       }
     },
     undefined,

--- a/src/ConnectedFields.js
+++ b/src/ConnectedFields.js
@@ -199,7 +199,7 @@ const createConnectedFields = (structure: Structure<*, *>) => {
             syncError,
             syncWarning,
             value,
-            _value: ownProps.value // save value passed in (for checkboxes)
+            _value: ownProps.value // save value passed in (for radios)
           }
           return accumulator
         }, {})


### PR DESCRIPTION
When I tried to pass component that that wrap `input['radio']` and add some styles I've got an issue with getting it checked(it doesn't work automatically until type `radio` is specified).

While digging into code I found [createFieldProps.js](https://github.com/erikras/redux-form/blob/e7ce5aec2bf0e24574e6f5f90bc04b9815c8e52e/src/createFieldProps.js) where `checked` prop calculates. Being curios where `_value` comes from I digged a bit more and found that line and it seems comments are misleading, since `_value` [is used](https://github.com/erikras/redux-form/blob/e7ce5aec2bf0e24574e6f5f90bc04b9815c8e52e/src/createFieldProps.js#L59) for `radio` not for `checkbox`