### PR TITLE
Material-ui example with the 3.2.2 version

### DIFF
--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -7,9 +7,9 @@ design change.
 
 In `v5`, only the outer form component was connected to the Redux state, and the
 props for each field were passed in via the form component. The problem with
-this is that the _entire_ form component had to rerender _on every single
+this is that the _entire_ form component had to re-render _on every single
 keypress_ that changed a form value. This was fine for small login forms, but
-lead to extremely slow performance on larger forms with dozens or hundreds of
+lead to an extremely slow performance on larger forms with dozens or hundreds of
 fields.
 
 **In `v6`, every single field is connected to the Redux store.** The outer form

--- a/examples/material-ui/package.json
+++ b/examples/material-ui/package.json
@@ -9,6 +9,7 @@
     "prepublish": "npm run lint && npm run build"
   },
   "dependencies": {
+    "@material-ui/core": "^3.2.2",
     "babel-polyfill": "^6.16.0",
     "html-loader": "^0.5.1",
     "json-loader": "^0.5.7",
@@ -18,7 +19,6 @@
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-redux": "^5.0.3",
-    "react-tap-event-plugin": "^3.0.2",
     "redux": "^3.7.2",
     "redux-form": "^7.4.2",
     "redux-form-website-template": "0.0.123"

--- a/examples/material-ui/src/MaterialUiForm.js
+++ b/examples/material-ui/src/MaterialUiForm.js
@@ -1,36 +1,15 @@
 import React from 'react'
 import { Field, reduxForm } from 'redux-form'
 import TextField from '@material-ui/core/TextField'
-import { RadioButton, RadioButtonGroup } from 'material-ui/RadioButton'
 import Checkbox from '@material-ui/core/Checkbox'
 import FormControlLabel from '@material-ui/core/FormControlLabel'
-import SelectField from 'material-ui/SelectField'
 import FormControl from '@material-ui/core/FormControl'
-import asyncValidate from './asyncValidate'
 import Select from '@material-ui/core/Select'
 import InputLabel from '@material-ui/core/InputLabel'
 import FormHelperText from '@material-ui/core/FormHelperText'
-import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles'
-
-const theme = createMuiTheme({
-  overrides: {
-    MuiFormControl: {
-      root: {
-        '& p': {
-          fontSize: 12,
-          border: 0,
-          marginTop: 2,
-          padding: 0
-        }
-      }
-    },
-    MuiSelect: {
-      select: {
-        paddingBotton: 10
-      }
-    }
-  }
-})
+import Radio from '@material-ui/core/Radio'
+import RadioGroup from '@material-ui/core/RadioGroup'
+import asyncValidate from './asyncValidate'
 
 const validate = values => {
   const errors = {}
@@ -55,22 +34,20 @@ const validate = values => {
   return errors
 }
 
-const renderTextFieldMat2 = ({
+const renderTextField = ({
   label,
   input,
   meta: { touched, invalid, error },
-  custom
+  ...custom
 }) => (
-  <MuiThemeProvider theme={theme}>
-    <TextField
-      label={label}
-      placeholder={label}
-      error={touched && invalid}
-      helperText={touched && error}
-      {...input}
-      {...custom}
-    />
-  </MuiThemeProvider>
+  <TextField
+    label={label}
+    placeholder={label}
+    error={touched && invalid}
+    helperText={touched && error}
+    {...input}
+    {...custom}
+  />
 )
 
 const renderCheckbox = ({ input, label }) => (
@@ -87,13 +64,13 @@ const renderCheckbox = ({ input, label }) => (
   </div>
 )
 
-const renderRadioGroup = ({ input, ...rest }) => (
-  <RadioButtonGroup
-    {...input}
-    {...rest}
-    valueSelected={input.value}
-    onChange={(event, value) => input.onChange(value)}
-  />
+const radioButton = ({ input, ...rest }) => (
+  <FormControl>
+    <RadioGroup {...input} {...rest}>
+      <FormControlLabel value="female" control={<Radio />} label="Female" />
+      <FormControlLabel value="male" control={<Radio />} label="Male" />
+    </RadioGroup>
+  </FormControl>
 )
 
 const renderSelectField = ({
@@ -103,41 +80,21 @@ const renderSelectField = ({
   children,
   ...custom
 }) => (
-  <SelectField
-    error
-    floatingLabelText={label}
-    errorText={touched && error}
-    {...input}
-    onChange={(event, index, value) => input.onChange(value)}
-    children={children}
-    {...custom}
-  />
-)
-
-const renderSelectFieldMat2 = ({
-  input,
-  label,
-  meta: { touched, error },
-  children,
-  ...custom
-}) => (
-  <MuiThemeProvider theme={theme}>
-    <FormControl error={touched && error}>
-      <InputLabel htmlFor="age-native-simple">Age</InputLabel>
-      <Select
-        native
-        {...input}
-        {...custom}
-        inputProps={{
-          name: 'age',
-          id: 'age-native-simple'
-        }}
-      >
-        {children}
-      </Select>
-      {renderFromHelper({ touched, error })}
-    </FormControl>
-  </MuiThemeProvider>
+  <FormControl error={touched && error}>
+    <InputLabel htmlFor="age-native-simple">Age</InputLabel>
+    <Select
+      native
+      {...input}
+      {...custom}
+      inputProps={{
+        name: 'age',
+        id: 'age-native-simple'
+      }}
+    >
+      {children}
+    </Select>
+    {renderFromHelper({ touched, error })}
+  </FormControl>
 )
 
 const renderFromHelper = ({ touched, error }) => {
@@ -155,49 +112,47 @@ const MaterialUiForm = props => {
       <div>
         <Field
           name="firstName"
-          component={renderTextFieldMat2}
+          component={renderTextField}
           label="First Name"
         />
       </div>
       <div>
-        <Field
-          name="lastName"
-          component={renderTextFieldMat2}
-          label="Last Name"
-        />
+        <Field name="lastName" component={renderTextField} label="Last Name" />
       </div>
       <div>
-        <Field name="email" component={renderTextFieldMat2} label="Email" />
+        <Field name="email" component={renderTextField} label="Email" />
       </div>
       <div>
-        <Field name="sex" component={renderRadioGroup}>
-          <RadioButton value="male" label="male" />
-          <RadioButton value="female" label="female" />
+        <Field name="sex" component={radioButton}>
+          <Radio value="male" label="male" />
+          <Radio value="female" label="female" />
         </Field>
       </div>
       <div>
         <Field
           classes={classes}
           name="favoriteColor"
-          component={renderSelectFieldMat2}
+          component={renderSelectField}
           label="Favorite Color"
         >
           <option value="" />
-          <option value={10}>Ten</option>
-          <option value={20}>Twenty</option>
-          <option value={30}>Thirty</option>
+          <option value={'ff0000'}>Red</option>
+          <option value={'00ff00'}>Green</option>
+          <option value={'0000ff'}>Blue</option>
         </Field>
       </div>
       <div>
         <Field name="employed" component={renderCheckbox} label="Employed" />
       </div>
+      <div />
       <div>
         <Field
           name="notes"
-          component={renderTextFieldMat2}
+          component={renderTextField}
           label="Notes"
-          multiLine={true}
-          rows={2}
+          multiline
+          rowsMax="4"
+          margin="normal"
         />
       </div>
       <div>

--- a/examples/material-ui/src/MaterialUiForm.js
+++ b/examples/material-ui/src/MaterialUiForm.js
@@ -73,6 +73,14 @@ const radioButton = ({ input, ...rest }) => (
   </FormControl>
 )
 
+const renderFromHelper = ({ touched, error }) => {
+  if (!(touched && error)) {
+    return
+  } else {
+    return <FormHelperText>{touched && error}</FormHelperText>
+  }
+}
+
 const renderSelectField = ({
   input,
   label,
@@ -96,14 +104,6 @@ const renderSelectField = ({
     {renderFromHelper({ touched, error })}
   </FormControl>
 )
-
-const renderFromHelper = ({ touched, error }) => {
-  if (!(touched && error)) {
-    return
-  } else {
-    return <FormHelperText>{touched && error}</FormHelperText>
-  }
-}
 
 const MaterialUiForm = props => {
   const { handleSubmit, pristine, reset, submitting, classes } = props

--- a/examples/material-ui/src/MaterialUiForm.js
+++ b/examples/material-ui/src/MaterialUiForm.js
@@ -1,11 +1,36 @@
 import React from 'react'
 import { Field, reduxForm } from 'redux-form'
-import TextField from 'material-ui/TextField'
+import TextField from '@material-ui/core/TextField'
 import { RadioButton, RadioButtonGroup } from 'material-ui/RadioButton'
-import Checkbox from 'material-ui/Checkbox'
+import Checkbox from '@material-ui/core/Checkbox'
+import FormControlLabel from '@material-ui/core/FormControlLabel'
 import SelectField from 'material-ui/SelectField'
-import MenuItem from 'material-ui/MenuItem'
+import FormControl from '@material-ui/core/FormControl'
 import asyncValidate from './asyncValidate'
+import Select from '@material-ui/core/Select'
+import InputLabel from '@material-ui/core/InputLabel'
+import FormHelperText from '@material-ui/core/FormHelperText'
+import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles'
+
+const theme = createMuiTheme({
+  overrides: {
+    MuiFormControl: {
+      root: {
+        '& p': {
+          fontSize: 12,
+          border: 0,
+          marginTop: 2,
+          padding: 0
+        }
+      }
+    },
+    MuiSelect: {
+      select: {
+        paddingBotton: 10
+      }
+    }
+  }
+})
 
 const validate = values => {
   const errors = {}
@@ -30,27 +55,36 @@ const validate = values => {
   return errors
 }
 
-const renderTextField = ({
-  input,
+const renderTextFieldMat2 = ({
   label,
-  meta: { touched, error },
-  ...custom
+  input,
+  meta: { touched, invalid, error },
+  custom
 }) => (
-  <TextField
-    hintText={label}
-    floatingLabelText={label}
-    errorText={touched && error}
-    {...input}
-    {...custom}
-  />
+  <MuiThemeProvider theme={theme}>
+    <TextField
+      label={label}
+      placeholder={label}
+      error={touched && invalid}
+      helperText={touched && error}
+      {...input}
+      {...custom}
+    />
+  </MuiThemeProvider>
 )
 
 const renderCheckbox = ({ input, label }) => (
-  <Checkbox
-    label={label}
-    checked={input.value ? true : false}
-    onCheck={input.onChange}
-  />
+  <div>
+    <FormControlLabel
+      control={
+        <Checkbox
+          checked={input.value ? true : false}
+          onChange={input.onChange}
+        />
+      }
+      label={label}
+    />
+  </div>
 )
 
 const renderRadioGroup = ({ input, ...rest }) => (
@@ -70,6 +104,7 @@ const renderSelectField = ({
   ...custom
 }) => (
   <SelectField
+    error
     floatingLabelText={label}
     errorText={touched && error}
     {...input}
@@ -79,22 +114,60 @@ const renderSelectField = ({
   />
 )
 
+const renderSelectFieldMat2 = ({
+  input,
+  label,
+  meta: { touched, error },
+  children,
+  ...custom
+}) => (
+  <MuiThemeProvider theme={theme}>
+    <FormControl error={touched && error}>
+      <InputLabel htmlFor="age-native-simple">Age</InputLabel>
+      <Select
+        native
+        {...input}
+        {...custom}
+        inputProps={{
+          name: 'age',
+          id: 'age-native-simple'
+        }}
+      >
+        {children}
+      </Select>
+      {renderFromHelper({ touched, error })}
+    </FormControl>
+  </MuiThemeProvider>
+)
+
+const renderFromHelper = ({ touched, error }) => {
+  if (!(touched && error)) {
+    return
+  } else {
+    return <FormHelperText>{touched && error}</FormHelperText>
+  }
+}
+
 const MaterialUiForm = props => {
-  const { handleSubmit, pristine, reset, submitting } = props
+  const { handleSubmit, pristine, reset, submitting, classes } = props
   return (
     <form onSubmit={handleSubmit}>
       <div>
         <Field
           name="firstName"
-          component={renderTextField}
+          component={renderTextFieldMat2}
           label="First Name"
         />
       </div>
       <div>
-        <Field name="lastName" component={renderTextField} label="Last Name" />
+        <Field
+          name="lastName"
+          component={renderTextFieldMat2}
+          label="Last Name"
+        />
       </div>
       <div>
-        <Field name="email" component={renderTextField} label="Email" />
+        <Field name="email" component={renderTextFieldMat2} label="Email" />
       </div>
       <div>
         <Field name="sex" component={renderRadioGroup}>
@@ -104,13 +177,15 @@ const MaterialUiForm = props => {
       </div>
       <div>
         <Field
+          classes={classes}
           name="favoriteColor"
-          component={renderSelectField}
+          component={renderSelectFieldMat2}
           label="Favorite Color"
         >
-          <MenuItem value="ff0000" primaryText="Red" />
-          <MenuItem value="00ff00" primaryText="Green" />
-          <MenuItem value="0000ff" primaryText="Blue" />
+          <option value="" />
+          <option value={10}>Ten</option>
+          <option value={20}>Twenty</option>
+          <option value={30}>Thirty</option>
         </Field>
       </div>
       <div>
@@ -119,7 +194,7 @@ const MaterialUiForm = props => {
       <div>
         <Field
           name="notes"
-          component={renderTextField}
+          component={renderTextFieldMat2}
           label="Notes"
           multiLine={true}
           rows={2}

--- a/examples/material-ui/src/index.js
+++ b/examples/material-ui/src/index.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import injectTapEventPlugin from 'react-tap-event-plugin'
 import { Provider } from 'react-redux'
 import { createStore, combineReducers } from 'redux'
 import { reducer as reduxFormReducer } from 'redux-form'
@@ -13,7 +12,7 @@ import {
   Values,
   generateExampleBreadcrumbs
 } from 'redux-form-website-template'
-injectTapEventPlugin()
+
 const dest = document.getElementById('content')
 const reducer = combineReducers({
   form: reduxFormReducer // mounted under "form"
@@ -65,7 +64,7 @@ let render = () => {
             </a>
           </div>
 
-          <h2>Form</h2>
+          <h2>Form </h2>
 
           <MaterialUiForm onSubmit={showResults} />
 

--- a/examples/material-ui/src/index.js
+++ b/examples/material-ui/src/index.js
@@ -3,8 +3,7 @@ import ReactDOM from 'react-dom'
 import { Provider } from 'react-redux'
 import { createStore, combineReducers } from 'redux'
 import { reducer as reduxFormReducer } from 'redux-form'
-import getMuiTheme from 'material-ui/styles/getMuiTheme'
-import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
+import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles'
 import {
   App,
   Code,
@@ -17,6 +16,27 @@ const dest = document.getElementById('content')
 const reducer = combineReducers({
   form: reduxFormReducer // mounted under "form"
 })
+
+const theme = createMuiTheme({
+  overrides: {
+    MuiFormControl: {
+      root: {
+        '& p': {
+          fontSize: 12,
+          border: 0,
+          marginTop: 2,
+          padding: 0
+        }
+      }
+    },
+    MuiSelect: {
+      select: {
+        paddingBotton: 10
+      }
+    }
+  }
+})
+
 const store = (window.devToolsExtension
   ? window.devToolsExtension()(createStore)
   : createStore)(reducer)
@@ -37,7 +57,7 @@ let render = () => {
   const asyncValidateraw = require('!!raw-loader!./asyncValidate')
   ReactDOM.hydrate(
     <Provider store={store}>
-      <MuiThemeProvider muiTheme={getMuiTheme()}>
+      <MuiThemeProvider theme={theme}>
         <App
           /**
            * This <App/> component only provides the site wrapper.


### PR DESCRIPTION
This pull request resolve #3156

The material's documentation example uses an old version of material-ui.

I updated the version "material-ui" to the version 3.2.2