### PR TITLE
Fields validation

### DIFF
--- a/docs/api/Fields.md
+++ b/docs/api/Fields.md
@@ -71,6 +71,32 @@ to be stored in the Redux store. Common use cases are to parse currencies into
 `parse` is called with the field `value` and `name` as arguments and should
 return the new parsed value to be stored in the Redux store.
 
+#### `validate : (value, allValues, props, name) => error` [optional]
+
+Allows you to to provide a field-level validation rule. The function is given
+the fields current value, all other form values, the props passed to the form,
+and the name of field currently being validated. If the field is valid it should
+return `undefined`. If the field is invalid it should return an error (usually,
+but not necessarily, a `String`). Note: if the validate prop changes the field
+will be re-registered.
+
+`validate` can be a function, an array of functions or an object. In the
+latest case, a property of the object is an element of `names` array. See the
+[Usage](#usage) section below for details.
+
+#### `warn : (value, allValues, props) => warning` [optional]
+
+Allows you to to provide a field-level warning rule. The function is given the
+fields current value, all other form values, and the props passed to the form.
+If the field does not need a warning it should return `undefined`. If the
+field needs a warning it should return the warning (usually, but not
+necessarily, a `String`). Note: if the warn prop changes the field will
+be re-registered.
+
+`warn` can be a function, an array of functions or an object. In the
+latest case, a property of the object is an element of `names` array. See the
+[Usage](#usage) section below for details.
+
 #### `forwardRef : boolean` [optional]
 
 If `true`, the rendered component will be available with the
@@ -103,7 +129,7 @@ different.** If you are defining your stateless function inside of `render()`,
 it will not only be slower, but your input will lose focus whenever the entire
 form component rerenders.
 
-```js
+```jsx
 // outside your render() method
 const renderFields = (fields) => (
   <div>
@@ -126,6 +152,23 @@ const renderFields = (fields) => (
 
 To learn what props will be passed to your stateless function, see the
 [Props](#props) section below.
+
+### Passing an object in `validate` and `warn` props
+
+The `validate` and `warn` props accepts an object: keys of the objects are elements of the `names` prop, entries of the object are validate and warn functions.
+
+```jsx
+<Fields
+  names={['foo', 'bar']}
+  component={input}
+  validate={{
+    foo: (value, allValues, props, name) => 'error'
+  }}
+  warn={{
+    foo: (value, allValues, props) => 'warning'
+  }}
+/>
+```
 
 ## Instance API
 

--- a/src/FieldsProps.types.js.flow
+++ b/src/FieldsProps.types.js.flow
@@ -7,5 +7,7 @@ export type Props = {
   format?: (value: any, name: string) => ?any,
   parse?: (value: any, name: string) => ?any,
   props?: Object,
-  forwardRef?: boolean
+  forwardRef?: boolean,
+  validate?: Object[],
+  warn?: Object[],
 }

--- a/src/FieldsProps.types.js.flow
+++ b/src/FieldsProps.types.js.flow
@@ -1,13 +1,17 @@
 // @flow
-import type {ComponentType} from 'react'
+import type { ComponentType } from 'react'
+import type { Validator } from './types'
+
+export type WarnAndValidateProp =
+  Validator | Validator[] | { [string]: (Validator | Validator[]) }
 
 export type Props = {
   names: string[],
   component: Function | ComponentType<*>,
-  format?: (value: any, name: string) => ?any,
-  parse?: (value: any, name: string) => ?any,
+  format?: (value: any, name: string) =>?any,
+  parse?: (value: any, name: string) =>?any,
   props?: Object,
   forwardRef?: boolean,
-  validate?: Object[],
-  warn?: Object[],
+  validate?: WarnAndValidateProp,
+  warn?: WarnAndValidateProp,
 }

--- a/src/__tests__/Fields.spec.js
+++ b/src/__tests__/Fields.spec.js
@@ -657,6 +657,177 @@ const describeFields = (name, structure, combineReducers, setup) => {
       )
     })
 
+    it('should provide Fields validation for each field', () => {
+      const store = makeStore({
+        testForm: {
+          values: {
+            author: {
+              firstName: 'Erik',
+              lastName: 'Rasmussen'
+            }
+          }
+        }
+      })
+      const input = jest.fn(props => <input {...props.input} />)
+      const validate = jest.fn(() => 'Error')
+      class Form extends Component {
+        render() {
+          return (
+            <div>
+              <Fields
+                names={['author']}
+                component={input}
+                validate={validate}
+              />
+            </div>
+          )
+        }
+      }
+      const TestForm = reduxForm({
+        form: 'testForm'
+      })(Form)
+      TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <TestForm />
+        </Provider>
+      )
+      expect(input).toHaveBeenCalled()
+      expect(input).toHaveBeenCalledTimes(2)
+      input.mock.calls[0][0].author.input.onChange('FIDO')
+      expect(input.mock.calls[2][0].author.meta.valid).toBe(false)
+      expect(input.mock.calls[2][0].author.meta.error).toBe('Error')
+    })
+
+    it('should provide Fields warning for each field', () => {
+      const store = makeStore({
+        testForm: {
+          values: {
+            foo: '',
+            bar: ''
+          }
+        }
+      })
+      const input = jest.fn(props => <input {...props.input} />)
+      const warn = jest.fn(() => 'warning')
+      class Form extends Component {
+        render() {
+          return (
+            <div>
+              <Fields names={['foo', 'bar']} component={input} warn={warn} />
+            </div>
+          )
+        }
+      }
+      const TestForm = reduxForm({
+        form: 'testForm'
+      })(Form)
+      TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <TestForm />
+        </Provider>
+      )
+      expect(input).toHaveBeenCalled()
+      expect(input).toHaveBeenCalledTimes(2)
+
+      input.mock.calls[0][0].foo.input.onChange('FIDO')
+      expect(input.mock.calls[2][0].foo.meta.warning).toBe('warning')
+      expect(input.mock.calls[2][0].bar.meta.warning).toBe('warning')
+    })
+
+    it('should provide Fields validation for one field', () => {
+      const store = makeStore({
+        testForm: {
+          values: {
+            author: {
+              firstName: 'Erik',
+              lastName: 'Rasmussen'
+            },
+            editor: {
+              firstName: 'John',
+              lastName: 'Jones'
+            }
+          }
+        }
+      })
+      const input = jest.fn(props => <input {...props.input} />)
+      const validate = jest.fn(() => 'Error')
+      class Form extends Component {
+        render() {
+          return (
+            <div>
+              <Fields
+                names={['author', 'editor']}
+                component={input}
+                validate={{
+                  author: validate
+                }}
+              />
+            </div>
+          )
+        }
+      }
+      const TestForm = reduxForm({
+        form: 'testForm'
+      })(Form)
+      TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <TestForm />
+        </Provider>
+      )
+      expect(input).toHaveBeenCalled()
+      expect(input).toHaveBeenCalledTimes(2)
+      input.mock.calls[0][0].author.input.onChange('FIDO')
+      expect(input.mock.calls[2][0].author.meta.valid).toBe(false)
+      expect(input.mock.calls[2][0].author.meta.error).toBe('Error')
+      expect(input.mock.calls[2][0].editor.meta.valid).toBe(true)
+    })
+
+    it('should provide Fields warning for a field', () => {
+      const store = makeStore({
+        testForm: {
+          values: {
+            foo: '',
+            bar: ''
+          },
+          fields: {
+            foo: {
+              touched: true
+            }
+          }
+        }
+      })
+      const input = jest.fn(props => <input {...props.input} />)
+      class Form extends Component {
+        render() {
+          return (
+            <div>
+              <Fields
+                names={['foo', 'bar']}
+                component={input}
+                warn={{
+                  foo: () => 'warning'
+                }}
+              />
+            </div>
+          )
+        }
+      }
+      const TestForm = reduxForm({
+        form: 'testForm'
+      })(Form)
+      TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <TestForm />
+        </Provider>
+      )
+      expect(input).toHaveBeenCalled()
+      expect(input).toHaveBeenCalledTimes(2)
+
+      input.mock.calls[0][0].foo.input.onChange('FIDO')
+      expect(input.mock.calls[2][0].foo.meta.warning).toBe('warning')
+      expect(input.mock.calls[2][0].bar.meta.warning).toBeUndefined()
+    })
+
     it('should provide access to rendered component', () => {
       const store = makeStore({
         testForm: {


### PR DESCRIPTION
This changes add `Fields` level validation and warning.

`validate` and `warn` props can get an object or a function or an array with functions.

Example:

```jsx
<Fields
    names={['facebook', 'twitter']}
    component={FormSocials}
    format={plainFormat}
    validate={url}
/>

<Fields
    names={['facebook', 'twitter']}
    component={FormSocials}
    format={plainFormat}
    validate={{
        facebook: url,
        twitter: [required, url],
    }}
/>
```