### PR TITLE
A way to cancel dispatching events for RN.

### DIFF
--- a/src/ConnectedField.js
+++ b/src/ConnectedField.js
@@ -126,7 +126,7 @@ const createConnectedField = (structure: Structure<*, *>) => {
             name
           )
         } else {
-          onChange(event, newValue, previousValue, name)
+          defaultPrevented = onChange(event, newValue, previousValue, name)
         }
       }
       if (!defaultPrevented) {
@@ -157,7 +157,7 @@ const createConnectedField = (structure: Structure<*, *>) => {
             name
           )
         } else {
-          onFocus(event, name)
+          defaultPrevented = onFocus(event, name)
         }
       }
 
@@ -201,7 +201,7 @@ const createConnectedField = (structure: Structure<*, *>) => {
             name
           )
         } else {
-          onBlur(event, newValue, previousValue, name)
+          defaultPrevented = onBlur(event, newValue, previousValue, name)
         }
       }
 


### PR DESCRIPTION
Right now there's no way to cancel dispatching an event for React-Native.
Assign defaultPrevented to a returned value of the onChange callback for React-Native to prevent dispatching onChange/onFocus/onBlur for some cases.