### PR TITLE
fix hoc displayName issue

### DIFF
--- a/src/ReduxFormContext.js
+++ b/src/ReduxFormContext.js
@@ -16,7 +16,10 @@ export const withReduxForm = Component => {
       })
     }
   }
-  return React.forwardRef((props, ref) =>
+
+  const ref = React.forwardRef((props, ref) =>
     React.createElement(Hoc, { ...props, forwardedRef: ref })
   )
+  ref.displayName = Component.displayName || Component.name || 'Component'
+  return ref
 }


### PR DESCRIPTION
Our tests rely on component names and with special hoc additon that was broken. Nested components were named as Component. That fix restores original naming.