### PR TITLE
disable loose mode for @babel/plugin-transform-spread

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -34,6 +34,12 @@ module.exports = {
     '@babel/plugin-proposal-export-namespace-from',
     '@babel/plugin-proposal-numeric-separator',
     '@babel/plugin-proposal-throw-expressions',
+    [
+      '@babel/plugin-transform-spread',
+      {
+        loose: false
+      }
+    ],
     test && '@babel/plugin-transform-react-jsx-source',
     test && 'istanbul'
   ].filter(Boolean)

--- a/src/handleSubmit.js
+++ b/src/handleSubmit.js
@@ -36,7 +36,7 @@ const handleSubmit = (
     persistentSubmitErrors
   } = props
 
-  touch(...Array.from(fields)) // mark all fields as touched
+  touch(...fields) // mark all fields as touched
 
   if (valid || persistentSubmitErrors) {
     const doSubmit = () => {


### PR DESCRIPTION
This is a more general solution to #4313 because spread operators are used with immutable in several places in the project. Instead of fixing them all manually we can disable `loose` mode in `@babel/plugin-transform-spread`.

```
In loose mode, all iterables are assumed to be arrays.
```