### PR TITLE
Docs: Add missing case 'change'

### DIFF
--- a/docs/api/ReduxForm.md
+++ b/docs/api/ReduxForm.md
@@ -241,9 +241,10 @@ at "design time" or passed in as props to your component at runtime.**
 
 > ##### `trigger : String` [required]
 
-> The reason to possibly run async validation. It will either be: `'blur'` or
-> `'submit'`, depending on whether an async blur field had triggered the async
-> validation or if submitting the form has triggered it, respectively.
+> The reason to possibly run async validation. It will be one of `'blur'`,
+> `'change'` and `'submit'`, depending on whether a field, either blurred or
+> changed, had triggered the async validation or if submitting the form has
+> triggered it, respectively.
 
 > ##### `blurredField : string` [optional]
 


### PR DESCRIPTION
# Changes
* Add the missing description for case 'change' of the param 'trigger' in shouldAsyncValidate().

# Preview
![0](https://user-images.githubusercontent.com/23452609/52862165-7d9bbc80-316f-11e9-8e5e-e3e2fac08804.PNG)
