### PR TITLE
Don't list and touch unregistered fields on submit

### DIFF
--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -639,7 +639,7 @@ const createReduxForm = (structure: Structure<*, *>) => {
             }
             if (options.excludeUnregistered) {
               keySeq = keySeq.filter(
-                name => getIn(registeredFields, `${name}.count`) !== 0
+                name => getIn(registeredFields, `['${name}'].count`) !== 0
               )
             }
           }

--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -630,11 +630,18 @@ const createReduxForm = (structure: Structure<*, *>) => {
             return list
           }
           let keySeq = keys(registeredFields)
-          if (options && options.excludeFieldArray) {
-            keySeq = keySeq.filter(
-              name =>
-                getIn(registeredFields, `['${name}'].type`) !== 'FieldArray'
-            )
+          if (options) {
+            if (options.excludeFieldArray) {
+              keySeq = keySeq.filter(
+                name =>
+                  getIn(registeredFields, `['${name}'].type`) !== 'FieldArray'
+              )
+            }
+            if (options.excludeUnregistered) {
+              keySeq = keySeq.filter(
+                name => getIn(registeredFields, `${name}.count`) !== 0
+              )
+            }
           }
           return fromJS(
             keySeq.reduce((acc, key) => {
@@ -788,7 +795,10 @@ const createReduxForm = (structure: Structure<*, *>) => {
                     },
                     this.props.validExceptSubmit,
                     this.asyncValidate,
-                    this.getFieldList({ excludeFieldArray: true })
+                    this.getFieldList({
+                      excludeFieldArray: true,
+                      excludeUnregistered: true
+                    })
                   )
                 )
               }
@@ -807,7 +817,10 @@ const createReduxForm = (structure: Structure<*, *>) => {
                     },
                     this.props.validExceptSubmit,
                     this.asyncValidate,
-                    this.getFieldList({ excludeFieldArray: true })
+                    this.getFieldList({
+                      excludeFieldArray: true,
+                      excludeUnregistered: true
+                    })
                   )
                 )
               )


### PR DESCRIPTION
I have added a new excludeUnregistered option to getFieldsList() method which enables / disables the excluding of fields registered with zero reference.

I have also added to use this option in the submit(...) call.