### PR TITLE
Improve detection of whether mapToProps functions depends on props.

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,9 @@
+// A length of one signals that mapToProps does not depend on props from the parent component.
+// A length of zero is assumed to mean mapToProps is getting args via arguments or ...args and
+// therefore not reporting its length accurately..
+export function getDependsOnOwnProps(mapToProps) {
+  return mapToProps.dependsOnOwnProps !== null &&
+    mapToProps.dependsOnOwnProps !== undefined
+    ? Boolean(mapToProps.dependsOnOwnProps)
+    : mapToProps.length !== 1;
+}

--- a/src/wrapMapDispatchToProps.js
+++ b/src/wrapMapDispatchToProps.js
@@ -1,9 +1,10 @@
 import {bindActionCreators} from 'redux';
+import {getDependsOnOwnProps} from './helpers';
 
 const wrapMapDispatchToProps = (mapDispatchToProps, actionCreators) => {
   if (mapDispatchToProps) {
     if (typeof mapDispatchToProps === 'function') {
-      if (mapDispatchToProps.length > 1) {
+      if (getDependsOnOwnProps(mapDispatchToProps)) {
         return (dispatch, ownProps) => ({
           dispatch,
           ...mapDispatchToProps(dispatch, ownProps),

--- a/src/wrapMapStateToProps.js
+++ b/src/wrapMapStateToProps.js
@@ -1,9 +1,11 @@
+import {getDependsOnOwnProps} from './helpers';
+
 const wrapMapStateToProps = (mapStateToProps, getForm) => {
   if (mapStateToProps) {
     if (typeof mapStateToProps !== 'function') {
       throw new Error('mapStateToProps must be a function');
     }
-    if (mapStateToProps.length > 1) {
+    if (getDependsOnOwnProps(mapStateToProps)) {
       return (state, ownProps) => ({
         ...mapStateToProps(state, ownProps),
         form: getForm(state)


### PR DESCRIPTION
When using this version with the latest version of `reselect`, the props are not been passed to the  `mapStateToProps` selector generated by `createStructuredSelector` that the `form` HOC from redux-form takes for its second argument. The reason for that is that it does not accurately report its *arity*
as seen here
https://github.com/reduxjs/reselect/blob/master/src/index.js#L68.
This case is handled in the `react-redux` library  here
https://github.com/reduxjs/react-redux/blob/72ed6db1947913bdd4900b324243c43a490b4c5a/src/connect/wrapMapToProps.js#L22
I just copied it over and made sure we treat it the same way.


