### PR TITLE
FieldProps.types: Relax component type, document problem with strictness

### DIFF
--- a/src/FieldProps.types.js.flow
+++ b/src/FieldProps.types.js.flow
@@ -12,7 +12,11 @@ type FieldTypeProps = {
 
 export type Props = {
   name: string,
-  component: ComponentType<FieldProps> | string,
+
+  // this is hard (impossible?) to type strictly - should be ComponentType<FieldProps & Passthrough>
+  // where Passthrough is `Props.props & ${any other props passed to the Field component}`
+  component: ComponentType<*> | string,
+
   format?: ?(value: any, name: string) => ?string,
   normalize?: (
     value: any,


### PR DESCRIPTION
Components are like functions - contravariant in their arguments! Which
means we'd need to have a generic Props<PassthroughProps>, and somehow
would need to deal with the two prop-passthrough styles (though the
`props` prop and passed straight to the Field).

And who knows how well that would even type-infer.

Should fix #4434 