### PR TITLE
feat: export ReduxFormContext

### DIFF
--- a/src/immutable.js
+++ b/src/immutable.js
@@ -1,7 +1,7 @@
 // @flow
 import actions from './actions'
 import * as _actionTypes from './actionTypes'
-export { ReduxFormContext, withReduxForm } from './ReduxFormContext'
+export { ReduxFormContext } from './ReduxFormContext'
 export {
   default as defaultShouldAsyncValidate
 } from './defaultShouldAsyncValidate'

--- a/src/immutable.js
+++ b/src/immutable.js
@@ -1,6 +1,7 @@
 // @flow
 import actions from './actions'
 import * as _actionTypes from './actionTypes'
+export { ReduxFormContext, withReduxForm } from './ReduxFormContext'
 export {
   default as defaultShouldAsyncValidate
 } from './defaultShouldAsyncValidate'

--- a/src/immutable.js.flow
+++ b/src/immutable.js.flow
@@ -1,6 +1,7 @@
 // @flow
+import * as React from 'react'
 import type { ComponentType } from 'react'
-import type { Action, GetFormState } from './types'
+import type { Action, GetFormState, Context, ReactContext } from './types'
 import type { Params as DefaultShouldAsyncValidateParams } from './defaultShouldAsyncValidate'
 import type { Params as DefaultShouldValidateParams } from './defaultShouldValidate'
 import type { Params as DefaultShouldErrorParams } from './defaultShouldError'
@@ -76,6 +77,10 @@ import type {
 import type { Actions } from './actions.types'
 
 type StructureMap = Object
+
+declare export var ReduxFormContext: React.Context<Context>
+declare export var withReduxForm: <P>(React.ComponentType<P>) =>
+  React.ComponentType<P & ReactContext>
 
 export type FormProps = _FormProps
 export type FormNameProps = _FormNameProps

--- a/src/immutable.js.flow
+++ b/src/immutable.js.flow
@@ -79,8 +79,6 @@ import type { Actions } from './actions.types'
 type StructureMap = Object
 
 declare export var ReduxFormContext: React.Context<Context>
-declare export var withReduxForm: <P>(React.ComponentType<P>) =>
-  React.ComponentType<P & ReactContext>
 
 export type FormProps = _FormProps
 export type FormNameProps = _FormNameProps

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 // @flow
 import actions from './actions'
 import * as _actionTypes from './actionTypes'
-export { ReduxFormContext, withReduxForm } from './ReduxFormContext'
+export { ReduxFormContext } from './ReduxFormContext'
 export {
   default as defaultShouldAsyncValidate
 } from './defaultShouldAsyncValidate'

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 // @flow
 import actions from './actions'
 import * as _actionTypes from './actionTypes'
+export { ReduxFormContext, withReduxForm } from './ReduxFormContext'
 export {
   default as defaultShouldAsyncValidate
 } from './defaultShouldAsyncValidate'

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -13,13 +13,9 @@ import type {
   DefaultProps as FormSectionDefaultProps,
   Props as FormSectionProps
 } from './FormSection'
-import type {
-  Props as FieldInputProps,
-} from './FieldProps.types'
+import type { Props as FieldInputProps } from './FieldProps.types'
 import type { Props as FieldsInputProps } from './FieldsProps.types'
-import type {
-  Props as FieldArrayInputProps,
-} from './FieldArrayProps.types'
+import type { Props as FieldArrayInputProps } from './FieldArrayProps.types'
 import type { FormValueSelectorInterface } from './formValueSelector.types'
 import type { FormValuesInterface } from './formValues.types'
 import type { GetFormErrorInterface } from './selectors/getFormError.types'
@@ -77,8 +73,6 @@ import type {
 export type { Event, FormProps } from './types'
 
 declare export var ReduxFormContext: React.Context<Context>
-declare export var withReduxForm: <P>(React.ComponentType<P>) =>
-  React.ComponentType<P & ReactContext>
 
 type StructureMap = Object
 

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1,6 +1,7 @@
 // @flow
+import * as React from 'react'
 import type { ComponentType } from 'react'
-import type { Action, GetFormState } from './types'
+import type { Action, GetFormState, Context, ReactContext } from './types'
 import type { Params as DefaultShouldAsyncValidateParams } from './defaultShouldAsyncValidate'
 import type { Params as DefaultShouldValidateParams } from './defaultShouldValidate'
 import type { Params as DefaultShouldErrorParams } from './defaultShouldError'
@@ -74,6 +75,10 @@ import type {
 } from './actions.types'
 
 export type { Event, FormProps } from './types'
+
+declare export var ReduxFormContext: React.Context<Context>
+declare export var withReduxForm: <P>(React.ComponentType<P>) =>
+  React.ComponentType<P & ReactContext>
 
 type StructureMap = Object
 


### PR DESCRIPTION
Pretty please 🍒 

fix #3852

`react-router` allows components to access the ancestor `<Route>` props from context by using `withRouter`;  Likewise `redux-form` should allow components to access the ancestor form props from context.

I have a component that needs to know know its enclosing `sectionPrefix` and dispatch `change` multiple fields under that `sectionPrefix`, and the public API (`formValueSelector`, custom `Field` components, action creators and selectors, etc) just doesn't cut it for this use case.