### PR TITLE
Rollback versions that were changed to 8.2.0 by publish script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10862,8 +10862,8 @@
           }
         },
         "yargs-parser": {
-          "version": "8.2.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.2.0.tgz",
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
           "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "immutable": "3.8.2",
     "insert-line": "^1.1.0",
     "jest": "^23.6.0",
-    "lint-staged": "^8.2.0",
+    "lint-staged": "^8.1.5",
     "lodash-webpack-plugin": "^0.11.5",
     "opencollective-postinstall": "^2.0.1",
     "prettier": "^1.15.3",


### PR DESCRIPTION
Whatever script you are using to update the version strings when publishing a new release is doing too much @erikras 😄 

See https://github.com/erikras/redux-form/commit/3df8a6b3af431a7e32e8d4dd7fc3769e68fb537b#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L120 for example.