### PR TITLE
createReduxForm: Don't put WrappedComponent in a withReduxForm

### DIFF
--- a/src/__tests__/reduxForm.spec.js
+++ b/src/__tests__/reduxForm.spec.js
@@ -144,7 +144,6 @@ const describeReduxForm = (name, structure, combineReducers, setup) => {
     it('should provide the correct props', () => {
       const props = propChecker({})
       expect(Object.keys(props).sort()).toEqual([
-        '_reduxForm',
         'anyTouched',
         'array',
         'asyncValidate',
@@ -229,9 +228,7 @@ const describeReduxForm = (name, structure, combineReducers, setup) => {
 
     it('should have declared all propTypes passed to decorated component', () => {
       const passedProps = Object.keys(propChecker({})).sort()
-      const declaredPropTypes = Object.keys(formPropTypes)
-        .concat('_reduxForm')
-        .sort()
+      const declaredPropTypes = Object.keys(formPropTypes).sort()
 
       expect(passedProps).toEqual(declaredPropTypes)
     })

--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -22,7 +22,7 @@ import createIsValid from './selectors/isValid'
 import plain from './structure/plain'
 import getDisplayName from './util/getDisplayName'
 import isHotReloading from './util/isHotReloading'
-import { withReduxForm, ReduxFormContext } from './ReduxFormContext'
+import { ReduxFormContext } from './ReduxFormContext'
 import type { ComponentType, Node, ElementRef } from 'react'
 import type { Dispatch } from 'redux'
 import type {
@@ -1167,10 +1167,7 @@ const createReduxForm = (structure: Structure<*, *>) => {
       }
 
       polyfill(ReduxForm)
-      const WithContext = hoistStatics(
-        withReduxForm(ReduxForm),
-        WrappedComponent
-      )
+      const WithContext = hoistStatics(ReduxForm, WrappedComponent)
       WithContext.defaultProps = config
       return WithContext
     }


### PR DESCRIPTION
withReduxForm is for internal redux-form components that need to
interact directly with the guts of the form state, not for access by
user components.

Fixes (at least in some cases?) #4299.