### PR TITLE
Run tests using same babel config as built product

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -9,8 +9,7 @@ module.exports = {
       '@babel/preset-env',
       {
         modules: isEs ? false : 'commonjs',
-        loose,
-        ...(test ? { targets: { node: '8' } } : {})
+        loose
       }
     ],
     '@babel/preset-react',


### PR DESCRIPTION
Run tests using same babel config as built product. This was created in response to https://github.com/erikras/redux-form/issues/4439#issuecomment-496594691. The goal here is prove that ImmutableJS is now broken as of v8.2.1 via a set of tests which fail after #4337 was reverted by https://github.com/erikras/redux-form/pull/4466.

During investigation, I was going to write an immutable test that fails but instead I found that the babel configuration was incorrectly running with `{ targets: { node: '8' } }`. The test suite should run using the same target as the built product to eliminate scenarios where babel either fixes or introduces new issues in the built product that do not fail during testing. One can see that this branch / PR is failing the test suite due to ImmutableJS errors.