### PR TITLE
Revert "Run tests using same babel config as built product"

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -9,7 +9,8 @@ module.exports = {
       '@babel/preset-env',
       {
         modules: isEs ? false : 'commonjs',
-        loose
+        loose,
+        ...(test ? { targets: { node: '8' } } : {})
       }
     ],
     '@babel/preset-react',


### PR DESCRIPTION
Reverts erikras/redux-form#4470. This broke v8.2.2 and needs more examination.