### PR TITLE
fix: re-bind actionCreators to changed props.form

### DIFF
--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -1093,7 +1093,7 @@ const createReduxForm = (structure: Structure<*, *>) => {
             unshift: bindActionCreators(boundArrayACs.arrayUnshift, dispatch)
           }
 
-          const computedActions = {
+          return {
             ...connectedFormACs,
             ...boundArrayACs,
             blur: boundBlur,
@@ -1102,8 +1102,6 @@ const createReduxForm = (structure: Structure<*, *>) => {
             focus: boundFocus,
             dispatch
           }
-
-          return () => computedActions
         },
         undefined,
         { forwardRef: true }


### PR DESCRIPTION
The `mapDispatchToProps` was only called once as it was returning a `() => computedActions` cached function. But in order to reflect a `form` property updates when one re-uses the decorated `reduxForm()(DetailComponent)` instance the bindings must be re-bound to the changed `form` prop value.