### PR TITLE
Use lastSyncWarnings in updateSyncWarningsIfNeeded

### DIFF
--- a/src/__tests__/reduxForm.spec.js
+++ b/src/__tests__/reduxForm.spec.js
@@ -3874,6 +3874,38 @@ const describeReduxForm = (name, structure, combineReducers, setup) => {
       expect(propsAtNthRender(renderInput, 1).meta.warning).toEqual(warning)
     })
 
+    it.only('should not warn with initialValues', () => {
+      const store = makeStore({})
+      const formRender = jest.fn()
+      const renderInput = jest.fn(props => <input {...props.input} />)
+
+      class Form extends Component {
+        render() {
+          formRender(this.props)
+          return (
+            <form>
+              <Field name="foo" component={renderInput} type="text" />
+            </form>
+          )
+        }
+      }
+      const Decorated = reduxForm({
+        form: 'testForm',
+        initialValues: { foo: 'test' },
+        warn: values => (getIn(values, 'foo') ? {} : { foo: 'foo warning' })
+      })(Form)
+
+      TestUtils.renderIntoDocument(
+        <Provider store={store}>
+          <Decorated />
+        </Provider>
+      )
+
+      expect(propsAtLastRender(renderInput).meta.warning).not.toEqual(
+        'foo warning'
+      )
+    })
+
     it('should call async on blur of async blur field', () => {
       const store = makeStore({})
       const inputRender = jest.fn(props => <input {...props.input} />)

--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -444,17 +444,18 @@ const createReduxForm = (structure: Structure<*, *>) => {
         updateSyncWarningsIfNeeded(
           nextSyncWarnings: ?Object,
           nextWarning: any,
-          syncWarnings: ?Object
+          lastSyncWarnings: ?Object
         ) {
           const { warning, updateSyncWarnings } = this.props
           const noWarnings =
-            (!syncWarnings || !Object.keys(syncWarnings).length) && !warning
+            (!lastSyncWarnings || !Object.keys(lastSyncWarnings).length) &&
+            !warning
           const nextNoWarnings =
             (!nextSyncWarnings || !Object.keys(nextSyncWarnings).length) &&
             !nextWarning
           if (
             !(noWarnings && nextNoWarnings) &&
-            (!plain.deepEqual(syncWarnings, nextSyncWarnings) ||
+            (!plain.deepEqual(lastSyncWarnings, nextSyncWarnings) ||
               !plain.deepEqual(warning, nextWarning))
           ) {
             updateSyncWarnings(nextSyncWarnings, nextWarning)

--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -444,18 +444,17 @@ const createReduxForm = (structure: Structure<*, *>) => {
         updateSyncWarningsIfNeeded(
           nextSyncWarnings: ?Object,
           nextWarning: any,
-          lastSyncWarnings: ?Object
+          syncWarnings: ?Object
         ) {
           const { warning, updateSyncWarnings } = this.props
           const noWarnings =
-            (!lastSyncWarnings || !Object.keys(lastSyncWarnings).length) &&
-            !warning
+            (!syncWarnings || !Object.keys(syncWarnings).length) && !warning
           const nextNoWarnings =
             (!nextSyncWarnings || !Object.keys(nextSyncWarnings).length) &&
             !nextWarning
           if (
             !(noWarnings && nextNoWarnings) &&
-            (!plain.deepEqual(lastSyncWarnings, nextSyncWarnings) ||
+            (!plain.deepEqual(syncWarnings, nextSyncWarnings) ||
               !plain.deepEqual(warning, nextWarning))
           ) {
             updateSyncWarnings(nextSyncWarnings, nextWarning)

--- a/src/createReduxForm.js
+++ b/src/createReduxForm.js
@@ -446,9 +446,10 @@ const createReduxForm = (structure: Structure<*, *>) => {
           nextWarning: any,
           lastSyncWarnings: ?Object
         ) {
-          const { warning, syncWarnings, updateSyncWarnings } = this.props
+          const { warning, updateSyncWarnings } = this.props
           const noWarnings =
-            (!syncWarnings || !Object.keys(syncWarnings).length) && !warning
+            (!lastSyncWarnings || !Object.keys(lastSyncWarnings).length) &&
+            !warning
           const nextNoWarnings =
             (!nextSyncWarnings || !Object.keys(nextSyncWarnings).length) &&
             !nextWarning


### PR DESCRIPTION
`updateSyncWarningsIfNeeded` was using `syncWarnings` from `this.props`, but using it, in `componentWillReceiveProps` we won't have the value that we expected (since it's in `nextProps`), instead that, we use `lastSyncWarnings` that point for `nextProps`.

Closes #4488 