### PR TITLE
fix(chore): upgrade flow-bin to maximum supported version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-form",
-  "version": "8.2.5",
+  "version": "8.2.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5162,9 +5162,9 @@
       "dev": true
     },
     "flow-bin": {
-      "version": "0.72.0",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.72.0.tgz",
-      "integrity": "sha1-EgURgPstt8y3KP7+Z8d+lV6SpE0=",
+      "version": "0.79.1",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.79.1.tgz",
+      "integrity": "sha512-GGetgxz6q9BNqqCQ8wgAGRtyYWXltn++39C6W8HKbS1QC59USfwm3YP3X+eITp7wbkwa+LGlhGfggqeQxOY1vw==",
       "dev": true
     },
     "flush-write-stream": {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "eslint-plugin-import": "^2.17.3",
     "eslint-plugin-jsx-a11y": "^6.1.2",
     "eslint-plugin-react": "^7.11.1",
-    "flow-bin": "^0.72.0",
+    "flow-bin": "^0.79.1",
     "flux-standard-action": "^2.0.3",
     "glow": "^1.2.2",
     "husky": "^1.2.1",


### PR DESCRIPTION
fixes vscode flow error
```
Flow version 0.72.0 doesn't support 'flow lsp'. Please upgrade flow to version >=0.75.
```

Closes #4336